### PR TITLE
implement deployment management and redeploy functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 dist/
 node_modules/
 .env
+.movehat-refactor-plan.md

--- a/examples/counter-example/deployments/testnet/counter.json
+++ b/examples/counter-example/deployments/testnet/counter.json
@@ -1,0 +1,8 @@
+{
+  "address": "0x662a2aa90fdf2b8e400640a49fc922b713fe4baaec8c37b088ecef315561e4d9",
+  "moduleName": "counter",
+  "network": "testnet",
+  "deployer": "0x662a2aa90fdf2b8e400640a49fc922b713fe4baaec8c37b088ecef315561e4d9",
+  "timestamp": 1765035995414,
+  "txHash": "0xa1a0eda6c2a071d6a5c3e9a9296b9bf0aa64a0fbf65c3b78ca15adcaf59144aa"
+}

--- a/examples/counter-example/deployments/testnet/counter.json
+++ b/examples/counter-example/deployments/testnet/counter.json
@@ -1,8 +1,0 @@
-{
-  "address": "0x662a2aa90fdf2b8e400640a49fc922b713fe4baaec8c37b088ecef315561e4d9",
-  "moduleName": "counter",
-  "network": "testnet",
-  "deployer": "0x662a2aa90fdf2b8e400640a49fc922b713fe4baaec8c37b088ecef315561e4d9",
-  "timestamp": 1765035995414,
-  "txHash": "0xa1a0eda6c2a071d6a5c3e9a9296b9bf0aa64a0fbf65c3b78ca15adcaf59144aa"
-}

--- a/examples/counter-example/scripts/deploy-counter.ts
+++ b/examples/counter-example/scripts/deploy-counter.ts
@@ -11,13 +11,17 @@ async function main() {
   console.log(`   Network: ${mh.network.name}`);
   console.log(`   RPC: ${mh.network.rpc}\n`);
 
-  // Get contract instance
-  const counter = mh.getContract(
-    mh.account.accountAddress.toString(),
-    "counter"
-  );
+  // Deploy (publish) the module
+  // Automatically checks if already deployed and suggests --redeploy if needed
+  const deployment = await mh.deployContract("counter");
 
-  console.log(`📍 Contract address: ${mh.account.accountAddress.toString()}::counter`);
+  console.log(`\n✅ Module deployed at: ${deployment.address}::counter`);
+  if (deployment.txHash) {
+    console.log(`   Transaction: ${deployment.txHash}`);
+  }
+
+  // Get contract instance
+  const counter = mh.getContract(deployment.address, "counter");
 
   // Initialize the counter
   console.log("\n📝 Initializing counter...");

--- a/examples/counter-example/scripts/deploy-counter.ts
+++ b/examples/counter-example/scripts/deploy-counter.ts
@@ -39,6 +39,10 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error("❌ Deployment failed:", error);
+  // ModuleAlreadyDeployedError is already logged with full details by deployContract()
+  // For other errors, show the message
+  if (error.name !== 'ModuleAlreadyDeployedError') {
+    console.error("❌ Deployment failed:", error.message || error);
+  }
   process.exit(1);
 });

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -53,9 +53,11 @@
     "@aptos-labs/ts-sdk": "^5.1.5",
     "commander": "^14.0.2",
     "dotenv": "^17.2.3",
+    "js-yaml": "^4.1.1",
     "tsx": "^4.7.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.10.1",
     "typescript": "^5.9.3"
   }

--- a/packages/movehat/src/cli.ts
+++ b/packages/movehat/src/cli.ts
@@ -12,11 +12,15 @@ program
   .description('A CLI tool for managing Move smart contracts')
   .version('0.0.1')
   .option('--network <name>', 'Network to use (testnet, mainnet, local, etc.)')
+  .option('--redeploy', 'Force redeploy even if already deployed')
   .hook('preAction', (thisCommand) => {
     // Store network option in environment for commands to access
     const options = thisCommand.opts();
     if (options.network) {
       process.env.MH_CLI_NETWORK = options.network;
+    }
+    if (options.redeploy) {
+      process.env.MH_CLI_REDEPLOY = 'true';
     }
   });
 

--- a/packages/movehat/src/cli.ts
+++ b/packages/movehat/src/cli.ts
@@ -4,8 +4,11 @@ import testCommand from './commands/test.js';
 import compileCommand from './commands/compile.js';
 import initCommand from './commands/init.js';
 import runCommand from './commands/run.js';
+import { printMovehatBanner } from './helpers/banner.js';
 
 const program = new Command();
+
+printMovehatBanner();
 
 program
   .name('movehat')

--- a/packages/movehat/src/commands/compile.ts
+++ b/packages/movehat/src/commands/compile.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import { exec } from "child_process";
 import { loadUserConfig } from "../helpers/config.js";
+import { validateAndEscapePath, escapeShellArg } from "../helpers/shell.js";
 
 function run(command: string, cwd: string) {
   return new Promise<void>((resolve, reject) => {
@@ -31,16 +32,42 @@ export default async function compileCommand() {
       return;
     }
 
+    // Validate and escape to prevent command injection
+    const safeMoveDir = validateAndEscapePath(moveDir, "Move directory");
+
     // Use global named addresses for compilation
     const namedAddresses = userConfig.namedAddresses ?? {};
-    const namedAddressesArg =
-      Object.keys(namedAddresses).length > 0
-        ? `--named-addresses ${Object.entries(namedAddresses)
-            .map(([k, v]) => `${k}=${v}`)
-            .join(",")}`
-        : "";
+    let namedAddressesArg = "";
 
-    const command = `movement move build --package-dir ${moveDir} ${namedAddressesArg}`.trim();
+    if (Object.keys(namedAddresses).length > 0) {
+      // Validate and escape each address name and value
+      const escapedAddresses = Object.entries(namedAddresses)
+        .map(([k, v]) => {
+          // Validate address name (alphanumeric, underscore only)
+          if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(k)) {
+            throw new Error(
+              `Invalid named address "${k}". ` +
+              `Names must start with a letter or underscore and contain only alphanumeric characters and underscores.`
+            );
+          }
+
+          // Validate address value (should be hex address)
+          if (!/^0x[a-fA-F0-9]+$/.test(v)) {
+            throw new Error(
+              `Invalid address value for "${k}": "${v}". ` +
+              `Address values must be hex strings starting with "0x".`
+            );
+          }
+
+          // No need to escape since we validated the format
+          return `${k}=${v}`;
+        })
+        .join(",");
+
+      namedAddressesArg = `--named-addresses ${escapeShellArg(escapedAddresses)}`;
+    }
+
+    const command = `movement move build --package-dir ${safeMoveDir} ${namedAddressesArg}`.trim();
 
     console.log(`   Move directory: ${moveDir}`);
     if (Object.keys(namedAddresses).length > 0) {

--- a/packages/movehat/src/commands/init.ts
+++ b/packages/movehat/src/commands/init.ts
@@ -1,10 +1,6 @@
-//import { exec } from "child_process";
-//import { promisify } from "util";
 import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
-
-//const execAsync = promisify(exec);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/movehat/src/commands/init.ts
+++ b/packages/movehat/src/commands/init.ts
@@ -1,10 +1,10 @@
-import { exec } from "child_process";
-import { promisify } from "util";
+//import { exec } from "child_process";
+//import { promisify } from "util";
 import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 
-const execAsync = promisify(exec);
+//const execAsync = promisify(exec);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/movehat/src/commands/test.ts
+++ b/packages/movehat/src/commands/test.ts
@@ -1,9 +1,6 @@
 import { spawn } from "child_process";
-import { join, 
-  //dirname
- } from "path";
+import { join } from "path";
 import { existsSync } from "fs";
-//import { fileURLToPath } from "url";
 
 export default async function testCommand() {
   const testDir = join(process.cwd(), "tests");

--- a/packages/movehat/src/commands/test.ts
+++ b/packages/movehat/src/commands/test.ts
@@ -1,7 +1,9 @@
 import { spawn } from "child_process";
-import { join, dirname } from "path";
+import { join, 
+  //dirname
+ } from "path";
 import { existsSync } from "fs";
-import { fileURLToPath } from "url";
+//import { fileURLToPath } from "url";
 
 export default async function testCommand() {
   const testDir = join(process.cwd(), "tests");

--- a/packages/movehat/src/errors.ts
+++ b/packages/movehat/src/errors.ts
@@ -1,0 +1,21 @@
+/**
+ * Custom error thrown when attempting to deploy a module that is already deployed
+ */
+export class ModuleAlreadyDeployedError extends Error {
+  constructor(
+    message: string,
+    public readonly moduleName: string,
+    public readonly network: string,
+    public readonly address: string,
+    public readonly timestamp: number,
+    public readonly txHash?: string
+  ) {
+    super(message);
+    this.name = 'ModuleAlreadyDeployedError';
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ModuleAlreadyDeployedError);
+    }
+  }
+}

--- a/packages/movehat/src/helpers/banner.ts
+++ b/packages/movehat/src/helpers/banner.ts
@@ -1,0 +1,47 @@
+type Rgb = [number, number, number];
+
+// Warm yellow-to-amber palette for a subtle gradient.
+const gradientPalette: Rgb[] = [
+  [255, 239, 150],
+  [255, 223, 88],
+  [255, 207, 64],
+  [255, 181, 45],
+  [255, 160, 30],
+];
+
+const bannerLines = [
+  " ███╗   ███╗ ██████╗ ██╗   ██╗███████╗██╗  ██╗ █████╗ ████████╗",
+  " ████╗ ████║██╔═══██╗██║   ██║██╔════╝██║  ██║██╔══██╗╚══██╔══╝",
+  " ██╔████╔██║██║   ██║██║   ██║█████╗  ███████║███████║   ██║   ",
+  " ██║╚██╔╝██║██║   ██║╚██╗ ██╔╝██╔══╝  ██╔══██║██╔══██║   ██║   ",
+  " ██║ ╚═╝ ██║╚██████╔╝ ╚████╔╝ ███████╗██║  ██║██║  ██║   ██║   ",
+  " ╚═╝     ╚═╝ ╚═════╝   ╚═══╝  ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝   ",
+];
+
+const reset = "\x1b[0m";
+
+const shouldColorize = () => process.env.NO_COLOR === undefined && Boolean(process.stdout.isTTY);
+
+const toAnsi = ([r, g, b]: Rgb) => `\x1b[38;2;${r};${g};${b}m`;
+
+const applyGradient = (line: string, offset: number) => {
+  let painted = "";
+  for (let i = 0; i < line.length; i++) {
+    const color = gradientPalette[(i + offset) % gradientPalette.length];
+    painted += `${toAnsi(color)}${line[i]}`;
+  }
+  return painted;
+};
+
+export const renderMovehatBanner = () => {
+  if (!shouldColorize()) {
+    return bannerLines.join("\n");
+  }
+
+  const coloredLines = bannerLines.map((line, idx) => applyGradient(line, idx * 2));
+  return `${coloredLines.join("\n")}${reset}`;
+};
+
+export const printMovehatBanner = () => {
+  console.log(renderMovehatBanner());
+};

--- a/packages/movehat/src/helpers/config.ts
+++ b/packages/movehat/src/helpers/config.ts
@@ -1,7 +1,7 @@
 import { pathToFileURL } from "url";
 import { join } from "path";
 import { existsSync } from "fs";
-import { MovehatConfig, MovehatUserConfig, NetworkConfig } from "../types/config.js";
+import { MovehatConfig, MovehatUserConfig } from "../types/config.js";
 
 /**
  * Loads the user's movehat.config.js from the current working directory.

--- a/packages/movehat/src/helpers/deployments.ts
+++ b/packages/movehat/src/helpers/deployments.ts
@@ -1,0 +1,103 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+export interface DeploymentInfo {
+  address: string;
+  moduleName: string;
+  network: string;
+  deployer: string;
+  timestamp: number;
+  txHash?: string;
+  blockNumber?: string;
+}
+
+/**
+ * Get the deployments directory path
+ */
+function getDeploymentsDir(): string {
+  return join(process.cwd(), "deployments");
+}
+
+/**
+ * Get the network-specific deployments directory
+ */
+function getNetworkDeploymentsDir(network: string): string {
+  const deploymentsDir = getDeploymentsDir();
+  const networkDir = join(deploymentsDir, network);
+
+  // Create directories if they don't exist
+  if (!existsSync(deploymentsDir)) {
+    mkdirSync(deploymentsDir, { recursive: true });
+  }
+  if (!existsSync(networkDir)) {
+    mkdirSync(networkDir, { recursive: true });
+  }
+
+  return networkDir;
+}
+
+/**
+ * Save a deployment
+ */
+export function saveDeployment(deployment: DeploymentInfo): void {
+  const networkDir = getNetworkDeploymentsDir(deployment.network);
+  const filePath = join(networkDir, `${deployment.moduleName}.json`);
+
+  writeFileSync(filePath, JSON.stringify(deployment, null, 2), "utf-8");
+
+  console.log(`💾 Deployment saved: deployments/${deployment.network}/${deployment.moduleName}.json`);
+}
+
+/**
+ * Load a deployment
+ */
+export function loadDeployment(network: string, moduleName: string): DeploymentInfo | null {
+  const networkDir = getNetworkDeploymentsDir(network);
+  const filePath = join(networkDir, `${moduleName}.json`);
+
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    return JSON.parse(content) as DeploymentInfo;
+  } catch (error) {
+    console.error(`Failed to load deployment for ${moduleName} on ${network}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Get all deployments for a network
+ */
+export function getAllDeployments(network: string): Record<string, DeploymentInfo> {
+  const networkDir = getNetworkDeploymentsDir(network);
+
+  if (!existsSync(networkDir)) {
+    return {};
+  }
+
+  const { readdirSync } = require("fs");
+  const files = readdirSync(networkDir).filter((f: string) => f.endsWith(".json"));
+
+  const deployments: Record<string, DeploymentInfo> = {};
+
+  for (const file of files) {
+    const moduleName = file.replace(".json", "");
+    const deployment = loadDeployment(network, moduleName);
+    if (deployment) {
+      deployments[moduleName] = deployment;
+    }
+  }
+
+  return deployments;
+}
+
+/**
+ * Get deployed address for a module
+ */
+export function getDeployedAddress(network: string, moduleName: string): string | null {
+  const deployment = loadDeployment(network, moduleName);
+  return deployment ? deployment.address : null;
+}

--- a/packages/movehat/src/helpers/deployments.ts
+++ b/packages/movehat/src/helpers/deployments.ts
@@ -87,9 +87,18 @@ export function saveDeployment(deployment: DeploymentInfo): void {
   const networkDir = getNetworkDeploymentsDir(deployment.network);
   const filePath = join(networkDir, `${deployment.moduleName}.json`);
 
-  writeFileSync(filePath, JSON.stringify(deployment, null, 2), "utf-8");
-
-  console.log(`💾 Deployment saved: deployments/${deployment.network}/${deployment.moduleName}.json`);
+  try {
+    writeFileSync(filePath, JSON.stringify(deployment, null, 2), "utf-8");
+    console.log(
+      `💾 Deployment saved: deployments/${deployment.network}/${deployment.moduleName}.json`
+    );
+  } catch (error) {
+    console.error(
+      `Failed to save deployment for ${deployment.moduleName} on ${deployment.network} at ${filePath}:`,
+      error
+    );
+    throw error;
+  }
 }
 
 /**

--- a/packages/movehat/src/helpers/deployments.ts
+++ b/packages/movehat/src/helpers/deployments.ts
@@ -16,7 +16,7 @@ export interface DeploymentInfo {
  * Only allows alphanumeric characters, hyphens, and underscores
  * Prevents path traversal attacks
  */
-function validateSafeName(name: string, type: "network" | "module"): void {
+export function validateSafeName(name: string, type: "network" | "module"): void {
   if (!name || typeof name !== "string") {
     throw new Error(`Invalid ${type} name: must be a non-empty string`);
   }

--- a/packages/movehat/src/helpers/index.ts
+++ b/packages/movehat/src/helpers/index.ts
@@ -7,6 +7,12 @@ export {
   assertTransactionSuccess,
   assertTransactionFailed,
 } from "./assertions.js";
-
+export {
+  saveDeployment,
+  loadDeployment,
+  getAllDeployments,
+  getDeployedAddress,
+} from "./deployments.js";
+export type { DeploymentInfo } from "./deployments.js";
 
 export type { MovehatConfig } from "../types/config.js";

--- a/packages/movehat/src/helpers/shell.ts
+++ b/packages/movehat/src/helpers/shell.ts
@@ -1,0 +1,66 @@
+/**
+ * Escapes a shell argument to prevent command injection
+ * Wraps the argument in single quotes and escapes any single quotes within
+ *
+ * @param arg - The argument to escape
+ * @returns The escaped argument safe for shell execution
+ */
+export function escapeShellArg(arg: string): string {
+  if (typeof arg !== "string") {
+    throw new Error("Shell argument must be a string");
+  }
+
+  // Wrap in single quotes and escape any single quotes by replacing them with '\''
+  // This technique works on both Unix and Windows (Git Bash, WSL)
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Validates that a path is safe (no command injection characters)
+ * and returns the escaped version
+ *
+ * @param path - The path to validate and escape
+ * @param name - Name for error messages (e.g., "package directory")
+ * @returns The escaped path safe for shell execution
+ */
+export function validateAndEscapePath(path: string, name: string = "path"): string {
+  if (!path || typeof path !== "string") {
+    throw new Error(`Invalid ${name}: must be a non-empty string`);
+  }
+
+  // Check for obvious command injection attempts
+  const dangerousChars = /[;&|`$(){}[\]<>]/;
+  if (dangerousChars.test(path)) {
+    throw new Error(
+      `Invalid ${name}: "${path}"\n` +
+      `Path contains potentially dangerous characters.\n` +
+      `Allowed characters: letters, numbers, ., -, _, /, \\, spaces`
+    );
+  }
+
+  // Escape for shell safety
+  return escapeShellArg(path);
+}
+
+/**
+ * Validates that a profile name is safe
+ *
+ * @param profile - The profile name to validate
+ * @returns The escaped profile name
+ */
+export function validateAndEscapeProfile(profile: string): string {
+  if (!profile || typeof profile !== "string") {
+    throw new Error("Invalid profile name: must be a non-empty string");
+  }
+
+  // Profile names should only contain alphanumeric, hyphens, underscores
+  const safePattern = /^[a-zA-Z0-9_-]+$/;
+  if (!safePattern.test(profile)) {
+    throw new Error(
+      `Invalid profile name: "${profile}"\n` +
+      `Only alphanumeric characters, hyphens (-), and underscores (_) are allowed.`
+    );
+  }
+
+  return escapeShellArg(profile);
+}

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -5,3 +5,6 @@ export type { MovehatConfig } from "./types/config.js";
 // Export Movehat Runtime Environment
 export { initRuntime, getRuntime, getMovehat, mh } from "./runtime.js";
 export type { MovehatRuntime, NetworkInfo } from "./types/runtime.js";
+
+// Export custom errors
+export { ModuleAlreadyDeployedError } from "./errors.js";

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -6,7 +6,7 @@ import {
   Network,
 } from "@aptos-labs/ts-sdk";
 import { MovehatRuntime, NetworkInfo } from "./types/runtime.js";
-import { MovehatConfig, MovehatUserConfig } from "./types/config.js";
+import { MovehatUserConfig } from "./types/config.js";
 import { loadUserConfig, resolveNetworkConfig } from "./helpers/config.js";
 import { getContract, MoveContract } from "./helpers/contract.js";
 import {

--- a/packages/movehat/src/templates/scripts/deploy-counter.ts
+++ b/packages/movehat/src/templates/scripts/deploy-counter.ts
@@ -1,4 +1,4 @@
-import { getMovehat } from "movehat";
+import { getMovehat, ModuleAlreadyDeployedError } from "movehat";
 
 async function main() {
   console.log("🚀 Deploying Counter contract...\n");
@@ -41,8 +41,8 @@ async function main() {
 main().catch((error) => {
   // ModuleAlreadyDeployedError is already logged with full details by deployContract()
   // For other errors, show the message
-  if (error.name !== 'ModuleAlreadyDeployedError') {
-    console.error("❌ Deployment failed:", error.message || error);
+  if (!(error instanceof ModuleAlreadyDeployedError)) {
+    console.error("❌ Deployment failed:", error?.message || error);
   }
   process.exit(1);
 });

--- a/packages/movehat/src/templates/scripts/deploy-counter.ts
+++ b/packages/movehat/src/templates/scripts/deploy-counter.ts
@@ -11,13 +11,17 @@ async function main() {
   console.log(`   Network: ${mh.network.name}`);
   console.log(`   RPC: ${mh.network.rpc}\n`);
 
-  // Get contract instance
-  const counter = mh.getContract(
-    mh.account.accountAddress.toString(),
-    "counter"
-  );
+  // Deploy (publish) the module
+  // Automatically checks if already deployed and suggests --redeploy if needed
+  const deployment = await mh.deployContract("counter");
 
-  console.log(`📍 Contract address: ${mh.account.accountAddress.toString()}::counter`);
+  console.log(`\n✅ Module deployed at: ${deployment.address}::counter`);
+  if (deployment.txHash) {
+    console.log(`   Transaction: ${deployment.txHash}`);
+  }
+
+  // Get contract instance
+  const counter = mh.getContract(deployment.address, "counter");
 
   // Initialize the counter
   console.log("\n📝 Initializing counter...");

--- a/packages/movehat/src/templates/scripts/deploy-counter.ts
+++ b/packages/movehat/src/templates/scripts/deploy-counter.ts
@@ -39,6 +39,10 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error("❌ Deployment failed:", error);
+  // ModuleAlreadyDeployedError is already logged with full details by deployContract()
+  // For other errors, show the message
+  if (error.name !== 'ModuleAlreadyDeployedError') {
+    console.error("❌ Deployment failed:", error.message || error);
+  }
   process.exit(1);
 });

--- a/packages/movehat/src/templates/types/movehat.d.ts
+++ b/packages/movehat/src/templates/types/movehat.d.ts
@@ -21,15 +21,36 @@ declare module 'movehat' {
     namedAddresses?: Record<string, string>;
   }
 
+  export interface DeploymentInfo {
+    address: string;
+    moduleName: string;
+    network: string;
+    deployer: string;
+    timestamp: number;
+    txHash?: string;
+    blockNumber?: string;
+  }
+
   export interface MovehatRuntime {
     config: MovehatConfig;
     network: NetworkInfo;
     aptos: Aptos;
     account: Account;
+    accounts: Account[];
     getContract: (address: string, moduleName: string) => any;
-    deployContract: (moduleName: string, metadataBytes?: Uint8Array, byteCode?: Uint8Array) => Promise<any>;
+    deployContract: (
+      moduleName: string,
+      options?: {
+        packageDir?: string;
+      }
+    ) => Promise<DeploymentInfo>;
+    getDeployment: (moduleName: string) => DeploymentInfo | null;
+    getDeployments: () => Record<string, DeploymentInfo>;
+    getDeploymentAddress: (moduleName: string) => string | null;
     createAccount: () => Account;
     getAccount: (privateKey: string) => Account;
+    getAccountByIndex: (index: number) => Account;
+    switchNetwork: (networkName: string) => Promise<void>;
   }
 
   export function getMovehat(): Promise<MovehatRuntime>;
@@ -61,9 +82,23 @@ declare module 'movehat/helpers' {
     success: boolean;
   }
 
+  export interface DeploymentInfo {
+    address: string;
+    moduleName: string;
+    network: string;
+    deployer: string;
+    timestamp: number;
+    txHash?: string;
+    blockNumber?: string;
+  }
+
   export function setupTestEnvironment(): Promise<TestEnvironment>;
   export function createTestAccount(): Account;
   export function getContract(aptos: Aptos, address: string, moduleName: string): MoveContract;
   export function assertTransactionSuccess(result: TransactionResult): void;
   export function assertTransactionFailed(result: TransactionResult): void;
+  export function saveDeployment(deployment: DeploymentInfo): void;
+  export function loadDeployment(network: string, moduleName: string): DeploymentInfo | null;
+  export function getAllDeployments(network: string): Record<string, DeploymentInfo>;
+  export function getDeployedAddress(network: string, moduleName: string): string | null;
 }

--- a/packages/movehat/src/types/runtime.ts
+++ b/packages/movehat/src/types/runtime.ts
@@ -1,6 +1,7 @@
 import { Aptos, Account } from "@aptos-labs/ts-sdk";
 import { MovehatConfig } from "./config.js";
 import { MoveContract } from "../helpers/contract.js";
+import { DeploymentInfo } from "../helpers/deployments.js";
 
 export interface NetworkInfo {
   name: string;
@@ -26,7 +27,17 @@ export interface MovehatRuntime {
 
   // Helper functions
   getContract: (address: string, moduleName: string) => MoveContract;
-  deployContract: (moduleName: string, metadataBytes?: Uint8Array, byteCode?: Uint8Array) => Promise<any>;
+
+  // Deployment functions
+  deployContract: (
+    moduleName: string,
+    options?: {
+      packageDir?: string;
+    }
+  ) => Promise<DeploymentInfo>;
+  getDeployment: (moduleName: string) => DeploymentInfo | null;
+  getDeployments: () => Record<string, DeploymentInfo>;
+  getDeploymentAddress: (moduleName: string) => string | null;
 
   // Account management
   createAccount: () => Account;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,19 +47,22 @@ importers:
       '@aptos-labs/ts-sdk':
         specifier: ^5.1.5
         version: 5.1.5(got@11.8.6)
-      axios:
-        specifier: ^1.13.2
-        version: 1.13.2
       commander:
         specifier: ^14.0.2
         version: 14.0.2
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
     devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
@@ -284,6 +287,9 @@ packages:
   '@types/http-cache-semantics@4.0.4':
     resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
@@ -319,12 +325,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -341,10 +341,6 @@ packages:
   cacheable-request@7.0.4:
     resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
-
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
 
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
@@ -375,10 +371,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -413,10 +405,6 @@ packages:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
@@ -424,10 +412,6 @@ packages:
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
-
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -440,22 +424,6 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
 
   esbuild@0.27.0:
     resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
@@ -481,42 +449,18 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
 
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
@@ -529,10 +473,6 @@ packages:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
-
   got@11.8.6:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
@@ -540,18 +480,6 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
 
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
@@ -618,18 +546,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
-
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
   mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
@@ -693,9 +609,6 @@ packages:
 
   poseidon-lite@0.2.1:
     resolution: {integrity: sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -978,6 +891,8 @@ snapshots:
 
   '@types/http-cache-semantics@4.0.4': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 24.10.1
@@ -1006,16 +921,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  asynckit@0.4.0: {}
-
-  axios@1.13.2:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   balanced-match@1.0.2: {}
 
   brace-expansion@2.0.2:
@@ -1035,11 +940,6 @@ snapshots:
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.1
-
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
 
   camelcase@6.3.0: {}
 
@@ -1070,10 +970,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   commander@12.1.0: {}
 
   commander@14.0.2: {}
@@ -1098,17 +994,9 @@ snapshots:
 
   defer-to-connect@2.0.1: {}
 
-  delayed-stream@1.0.0: {}
-
   diff@7.0.0: {}
 
   dotenv@17.2.3: {}
-
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
 
@@ -1119,21 +1007,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-
-  es-define-property@1.0.1: {}
-
-  es-errors@1.3.0: {}
-
-  es-object-atoms@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
 
   esbuild@0.27.0:
     optionalDependencies:
@@ -1177,45 +1050,15 @@ snapshots:
 
   flat@5.0.2: {}
 
-  follow-redirects@1.15.11: {}
-
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.2: {}
-
   get-caller-file@2.0.5: {}
-
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.2
-      math-intrinsics: 1.1.0
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
 
   get-stream@5.2.0:
     dependencies:
@@ -1234,8 +1077,6 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  gopd@1.2.0: {}
-
   got@11.8.6:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -1251,16 +1092,6 @@ snapshots:
       responselike: 2.0.1
 
   has-flag@4.0.0: {}
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
 
   he@1.2.0: {}
 
@@ -1313,14 +1144,6 @@ snapshots:
   lowercase-keys@2.0.0: {}
 
   lru-cache@10.4.3: {}
-
-  math-intrinsics@1.1.0: {}
-
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
 
   mimic-response@1.0.1: {}
 
@@ -1388,8 +1211,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   poseidon-lite@0.2.1: {}
-
-  proxy-from-env@1.1.0: {}
 
   pump@3.0.3:
     dependencies:


### PR DESCRIPTION
This pull request introduces a robust deployment tracking system to the MoveHat toolchain, making it easier to manage, retrieve, and redeploy Move smart contracts across different networks. The main changes include adding deployment persistence, CLI improvements, and enhanced runtime deployment logic. These updates ensure deployments are recorded, prevent accidental redeployment, and provide convenient access to deployment information.

**Deployment persistence and retrieval:**

* Added a new `deployments.ts` helper module implementing functions to save, load, and list deployments per network, as well as retrieve deployed addresses. This enables persistent tracking of deployed modules and their metadata.
* Updated the `helpers/index.ts` barrel to export the new deployment helpers and types.

**Runtime deployment improvements:**

* Enhanced the `deployContract` logic in `runtime.ts` to check for existing deployments before publishing, suggest the `--redeploy` flag if already deployed, and save deployment information after publishing. Also added helper methods to retrieve deployment info and addresses. [[1]](diffhunk://#diff-6b8d47c4ed1fc940af806b94d82c9babc5620e3769bf4a3fe3002cec79c4ff79R12-R18) [[2]](diffhunk://#diff-6b8d47c4ed1fc940af806b94d82c9babc5620e3769bf4a3fe3002cec79c4ff79L75-R192) [[3]](diffhunk://#diff-6b8d47c4ed1fc940af806b94d82c9babc5620e3769bf4a3fe3002cec79c4ff79R226-R228)
* Updated the `MovehatRuntime` interface to include new deployment-related methods and type annotations. [[1]](diffhunk://#diff-85535841676b2a57a2a6b29fe21097092d16cc5a241f6d7a882964514a1766f7R4) [[2]](diffhunk://#diff-85535841676b2a57a2a6b29fe21097092d16cc5a241f6d7a882964514a1766f7L29-R40)

**CLI and script template updates:**

* Added a `--redeploy` CLI flag to force redeployment even if a module is already deployed, and wired it into the environment for runtime checks.
* Updated deployment scripts (`deploy-counter.ts`) to use the new deployment API, display deployment info, and retrieve contract instances using the deployed address.

**Minor codebase cleanup:**

* Removed unused imports from `init.ts` and `test.ts` for clarity. [[1]](diffhunk://#diff-4880ec0bf36a27f1e0c277f03712fec61ff1f085f17da1db199171335b627ffeL1-R7) [[2]](diffhunk://#diff-ede82c6dadaaccfa6e4e73b9df3d8a0b852f8a4c9c7a593bb50d6554a6d908e8L2-R6)

**Deployment tracking example:**

* Added an example deployment JSON file for the counter module on testnet, demonstrating the new deployment tracking format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per‑network deployment tracking with persistent records and runtime accessors (save/load/list/get address)
  * CLI: --redeploy flag to force redeploy
  * CLI startup banner

* **Improvements**
  * Deployment-first example workflow with post-deploy init, clearer address/txHash logs, and improved error messaging
  * Safer shell invocation via validated/escaped paths and profiles
  * New ModuleAlreadyDeployed error type surfaced

* **Documentation**
  * README and CONTRIBUTING updated with deployment workflows and examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->