### PR TITLE
updating lock file

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
-      tsx:
-        specifier: ^4.7.0
-        version: 4.21.0
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9


### PR DESCRIPTION
This pull request removes the `tsx` package from the `importers` section in `pnpm-lock.yaml`, indicating that it is no longer required as a dependency.