### PR TITLE
fixiing error with imports

### DIFF
--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -54,7 +54,8 @@
     "commander": "^14.0.2",
     "dotenv": "^17.2.3",
     "js-yaml": "^4.1.1",
-    "prompts": "^2.4.2"
+    "prompts": "^2.4.2",
+    "tsx": "^4.7.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9


### PR DESCRIPTION
This pull request adds the `tsx` package as a dependency to the `movehat` package. This will allow the project to use `tsx` for running or building TypeScript files, which can improve the developer experience.

Dependency updates:

* Added `tsx` version `^4.7.0` to the `dependencies` section in `packages/movehat/package.json`
* Updated `pnpm-lock.yaml` to include `tsx` version `4.21.0` under the `importers` section for proper dependency locking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies for the Movehat package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->