### PR TITLE
feat: add project name replacement in Move.toml and update copyDir fu…

### DIFF
--- a/packages/movehat/src/templates/move/Move.toml
+++ b/packages/movehat/src/templates/move/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "{{PROJECT_NAME}}"
+name = "{{projectName}}"
 version = "1.0.0"
 authors = []
 


### PR DESCRIPTION
This pull request enhances the Move project initialization process in `movehat` by introducing template variable replacement when copying files from the template directory. This allows the project name to be dynamically inserted into files like `Move.toml` during project setup.

**Template variable replacement improvements:**

* The `copyDir` function now accepts a `replacements` parameter and applies replacements to `.toml` and `.move` files, enabling dynamic content insertion during project creation. [[1]](diffhunk://#diff-4880ec0bf36a27f1e0c277f03712fec61ff1f085f17da1db199171335b627ffeL131-R132) [[2]](diffhunk://#diff-4880ec0bf36a27f1e0c277f03712fec61ff1f085f17da1db199171335b627ffeL145-R156)
* The `initCommand` function passes the `projectName` as a replacement variable when copying the `move` template directory, ensuring the new project uses the correct name in its configuration files.

**Template update:**

* The `Move.toml` template was updated to use the `{{projectName}}` variable, so it will be replaced with the actual project name during initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project name substitution during Move project initialization. The initialization process now properly applies template variables to all configuration files, ensuring generated Move projects contain the correct project identifiers and metadata. This resolves issues with incorrect project naming in auto-generated configuration and manifest files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->