### PR TITLE
Fix: security errors with 

### DIFF
--- a/packages/movehat/src/cli.ts
+++ b/packages/movehat/src/cli.ts
@@ -36,7 +36,7 @@ function parsePort(value: string): number {
 // Check for updates at startup (skip if running update command or help)
 const args = process.argv.slice(2);
 const isUpdateCommand = args.includes('update');
-const isHelpOnly = args.length === 0 || args.every(arg => arg === '-h' || arg === '--help');
+const isHelpOnly = args.length === 0 || args.includes('-h') || args.includes('--help');
 
 if (!isUpdateCommand && !isHelpOnly) {
   checkForUpdates(version, packageName);

--- a/packages/movehat/src/helpers/npm-registry.ts
+++ b/packages/movehat/src/helpers/npm-registry.ts
@@ -42,6 +42,22 @@ export async function fetchLatestVersion(
     }
 
     const data = (await response.json()) as NpmRegistryResponse;
+
+    // Defensive validation of registry response structure
+    if (
+      !data ||
+      typeof data !== "object" ||
+      !data["dist-tags"] ||
+      typeof data["dist-tags"] !== "object" ||
+      typeof data["dist-tags"].latest !== "string"
+    ) {
+      const error = new Error(
+        `Invalid npm registry response: missing or malformed "dist-tags.latest" field`
+      );
+      if (throwOnError) throw error;
+      return null;
+    }
+
     return data["dist-tags"].latest;
   } catch (error) {
     if (throwOnError) {

--- a/packages/movehat/src/helpers/npm-registry.ts
+++ b/packages/movehat/src/helpers/npm-registry.ts
@@ -1,0 +1,55 @@
+export interface NpmRegistryResponse {
+  "dist-tags": {
+    latest: string;
+    [tag: string]: string;
+  };
+  versions: Record<string, unknown>;
+}
+
+export interface FetchOptions {
+  timeout?: number; // Timeout in milliseconds
+  throwOnError?: boolean; // If true, throw errors; if false, return null on error
+}
+
+/**
+ * Fetch latest version from npm registry
+ * @param packageName - The npm package name
+ * @param options - Fetch options (timeout, error handling)
+ * @returns Latest version string, or null if failed and throwOnError is false
+ */
+export async function fetchLatestVersion(
+  packageName: string,
+  options: FetchOptions = {}
+): Promise<string | null> {
+  const { timeout = 0, throwOnError = false } = options;
+
+  try {
+    const controller = timeout > 0 ? new AbortController() : undefined;
+    const timeoutId = timeout > 0 && controller
+      ? setTimeout(() => controller.abort(), timeout)
+      : undefined;
+
+    const response = await fetch(`https://registry.npmjs.org/${packageName}`, {
+      signal: controller?.signal,
+    });
+
+    if (timeoutId) clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const error = new Error(`Failed to fetch package info: ${response.statusText}`);
+      if (throwOnError) throw error;
+      return null;
+    }
+
+    const data = (await response.json()) as NpmRegistryResponse;
+    return data["dist-tags"].latest;
+  } catch (error) {
+    if (throwOnError) {
+      throw new Error(
+        `Failed to check for updates: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+    // Silently fail - don't interrupt user's workflow
+    return null;
+  }
+}

--- a/packages/movehat/src/helpers/semver-utils.ts
+++ b/packages/movehat/src/helpers/semver-utils.ts
@@ -1,0 +1,53 @@
+/**
+ * Compare two semver versions
+ * Returns true if newVersion > currentVersion
+ * Handles variable-length versions (1.2, 1.2.3, 1.2.3.4, etc.)
+ */
+export function isNewerVersion(currentVersion: string, newVersion: string): boolean {
+  // Remove any pre-release tags (e.g., -alpha.0, -beta.1)
+  const cleanCurrent = currentVersion.split("-")[0];
+  const cleanNew = newVersion.split("-")[0];
+
+  // Split and validate numeric parts
+  const currentParts = cleanCurrent.split(".").map((part) => {
+    const num = Number(part);
+    if (isNaN(num) || !part.trim()) {
+      throw new Error(`Invalid version format: ${currentVersion}`);
+    }
+    return num;
+  });
+
+  const newerParts = cleanNew.split(".").map((part) => {
+    const num = Number(part);
+    if (isNaN(num) || !part.trim()) {
+      throw new Error(`Invalid version format: ${newVersion}`);
+    }
+    return num;
+  });
+
+  // Compare up to the maximum length, treating missing parts as 0
+  const maxLength = Math.max(currentParts.length, newerParts.length);
+
+  for (let i = 0; i < maxLength; i++) {
+    const currentPart = currentParts[i] || 0;
+    const newerPart = newerParts[i] || 0;
+
+    if (newerPart > currentPart) return true;
+    if (newerPart < currentPart) return false;
+  }
+
+  // If base versions are equal, check pre-release tags
+  // A version with no pre-release tag is considered newer than one with a tag
+  const currentHasPrerelease = currentVersion.includes("-");
+  const newHasPrerelease = newVersion.includes("-");
+
+  if (!currentHasPrerelease && newHasPrerelease) {
+    return false; // Current stable is newer than new pre-release
+  }
+
+  if (currentHasPrerelease && !newHasPrerelease) {
+    return true; // New stable is newer than current pre-release
+  }
+
+  return false;
+}

--- a/packages/movehat/src/helpers/version-check.ts
+++ b/packages/movehat/src/helpers/version-check.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import { isNewerVersion } from "./semver-utils.js";
 
 interface VersionCache {
   lastChecked: number;
@@ -16,38 +17,6 @@ interface NpmRegistryResponse {
 const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
 const CACHE_DIR = join(homedir(), ".movehat");
 const CACHE_FILE = join(CACHE_DIR, "version-cache.json");
-
-/**
- * Compare two semver versions
- * Returns true if newVersion > currentVersion
- */
-function isNewerVersion(currentVersion: string, newVersion: string): boolean {
-  // Remove any pre-release tags (e.g., -alpha.0, -beta.1)
-  const cleanCurrent = currentVersion.split("-")[0];
-  const cleanNew = newVersion.split("-")[0];
-
-  const current = cleanCurrent.split(".").map(Number);
-  const newer = cleanNew.split(".").map(Number);
-
-  for (let i = 0; i < 3; i++) {
-    if (newer[i] > current[i]) return true;
-    if (newer[i] < current[i]) return false;
-  }
-
-  // If base versions are equal, check pre-release tags
-  const currentHasPrerelease = currentVersion.includes("-");
-  const newHasPrerelease = newVersion.includes("-");
-
-  if (!currentHasPrerelease && newHasPrerelease) {
-    return false; // Current stable is newer than new pre-release
-  }
-
-  if (currentHasPrerelease && !newHasPrerelease) {
-    return true; // New stable is newer than current pre-release
-  }
-
-  return false;
-}
 
 /**
  * Fetch latest version from npm registry


### PR DESCRIPTION
This pull request refactors and improves the update-checking logic in the Movehat CLI, making version comparison and npm registry queries more robust and modular. The main changes include extracting semver comparison and npm registry fetching into helper modules, improving error handling and timeouts, and enhancing package manager detection. These updates make the codebase easier to maintain and more reliable for users.

### Refactoring and modularization

* Extracted the semver version comparison logic into a new helper module `semver-utils.ts`, with improved handling for variable-length versions and better validation. (`[packages/movehat/src/helpers/semver-utils.tsR1-R53](diffhunk://#diff-ae6876dcee3ff220b47793cf4a57e2522cd78d3f1c76b2c05a49043a52881373R1-R53)`)
* Moved the npm registry fetch logic to a new helper module `npm-registry.ts`, adding support for timeouts and configurable error handling. (`[packages/movehat/src/helpers/npm-registry.tsR1-R55](diffhunk://#diff-a4308222bfd457cd1be5660850a23e3489279bd05d0922333c700a60766bf788R1-R55)`)

### Improved update command reliability

* Enhanced error handling in the update command to ensure the process exits cleanly if the latest version cannot be fetched, and uses the home directory for updates to avoid local conflicts. (`[[1]](diffhunk://#diff-1f6695c433e6e61d9511ce86f785caf0ca536e58777aed469bd7cfe20558ed2dL101-R90)`, `[[2]](diffhunk://#diff-1f6695c433e6e61d9511ce86f785caf0ca536e58777aed469bd7cfe20558ed2dL135-R124)`)
* Improved package manager detection by searching for lockfiles up the directory tree and checking environment variables, with a sensible fallback. (`[packages/movehat/src/commands/update.tsL14-R60](diffhunk://#diff-1f6695c433e6e61d9511ce86f785caf0ca536e58777aed469bd7cfe20558ed2dL14-R60)`)

### Version check enhancements

* Updated the version check logic to use the new helpers, adding a 2-second timeout and non-blocking error handling to avoid interrupting the user's workflow. (`[[1]](diffhunk://#diff-480b0c183ef4c49de0f11d26c474ba3e33210de634f881497b3091b39ef362caR4-L77)`, `[[2]](diffhunk://#diff-480b0c183ef4c49de0f11d26c474ba3e33210de634f881497b3091b39ef362caL144-R85)`)

### CLI usability improvement

* Fixed the CLI help detection logic to correctly identify help commands using `-h` or `--help` flags. (`[packages/movehat/src/cli.tsL39-R39](diffhunk://#diff-214a02dcef3e78fd9fd3dc187cae419edb1d0518798f7848aed8c475bf07c965L39-R39)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changed help-flag handling: any presence of -h/--help is now treated as a help-only startup (affects whether update checks run).

* **Improvements**
  * Automatic detection of npm/yarn/pnpm for updates.
  * More reliable update checks with registry fetches (timeout/error handling) and improved version comparison.
  * Clearer user messages and guidance for update failures and manual update commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->