### PR TITLE
fix: suppress experimental JSON module warnings and skip update check…

### DIFF
--- a/packages/movehat/bin/movehat.js
+++ b/packages/movehat/bin/movehat.js
@@ -1,5 +1,15 @@
 #!/usr/bin/env node
 
+// Suppress experimental JSON module warning
+process.removeAllListeners('warning');
+process.on('warning', (warning) => {
+  if (warning.name === 'ExperimentalWarning' &&
+      warning.message.includes('Importing JSON modules')) {
+    return;
+  }
+  console.warn(warning);
+});
+
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 

--- a/packages/movehat/src/helpers/version-check.ts
+++ b/packages/movehat/src/helpers/version-check.ts
@@ -67,6 +67,11 @@ function writeCache(latestVersion: string): void {
  */
 export function checkForUpdates(currentVersion: string, packageName: string): void {
   try {
+    // Skip update check for development versions (0.0.0)
+    if (currentVersion === '0.0.0') {
+      return;
+    }
+
     const cache = readCache();
     let shouldNotify = false;
 


### PR DESCRIPTION
This pull request makes a small but important change to the update-checking logic in `version-check.ts`. Now, the update check is skipped entirely for development versions (when `currentVersion` is `'0.0.0'`), preventing unnecessary checks during development.

* Skips the update check in `checkForUpdates` if the current version is `'0.0.0'`, ensuring that development builds do not trigger update notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary console warnings during CLI startup.

* **Chores**
  * Optimized update checking behavior for development builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->