### PR TITLE
security: bind ForkServer to localhost (#35), 0o600 account pool (#39)

### DIFF
--- a/packages/movehat/src/cli.ts
+++ b/packages/movehat/src/cli.ts
@@ -154,6 +154,7 @@ fork
     .description('Start a local RPC server serving the fork')
     .option('-f, --fork <path>', 'Path to the fork')
     .option('-p, --port <port>', 'Port to listen on (default: 8080)', parsePort, 8080)
+    .option('--host <host>', 'Interface to bind (default: 127.0.0.1; use 0.0.0.0 to expose to LAN)', '127.0.0.1')
     .action((options) => forkServeCommand(options));
 
 program.parse(process.argv);

--- a/packages/movehat/src/commands/fork/serve.ts
+++ b/packages/movehat/src/commands/fork/serve.ts
@@ -6,6 +6,7 @@ import { ForkServer } from '../../fork/server.js';
 interface ForkServeOptions {
   fork?: string;
   port?: number;
+  host?: string;
 }
 
 /**
@@ -43,9 +44,10 @@ export default async function forkServeCommand(options: ForkServeOptions): Promi
 
     // Get port (already validated by Commander's parsePort in cli.ts)
     const port = options.port ?? 8080;
+    const host = options.host ?? '127.0.0.1';
 
     // Create and start server
-    const server = new ForkServer(forkPath, port);
+    const server = new ForkServer(forkPath, port, host);
 
     // Handle graceful shutdown (use 'once' to prevent duplicate shutdowns)
     const shutdown = async () => {

--- a/packages/movehat/src/core/AccountManager.ts
+++ b/packages/movehat/src/core/AccountManager.ts
@@ -2,7 +2,7 @@ import {
   Account,
   Ed25519PrivateKey,
 } from "@aptos-labs/ts-sdk";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { MovehatConfig } from "../types/config.js";
 
@@ -218,9 +218,12 @@ export class AccountManager {
 
     // Ensure directory exists with restrictive perms (the pool file holds
     // plaintext private keys, so the directory must not be world-readable).
+    // Note: mkdirSync's mode is masked by the process umask, so we chmod
+    // explicitly afterwards to guarantee 0o700 regardless of umask.
     if (!existsSync(basePath)) {
       mkdirSync(basePath, { recursive: true, mode: 0o700 });
     }
+    chmodSync(basePath, 0o700);
 
     // Build stored accounts array
     const storedAccounts: StoredAccount[] = [];
@@ -257,12 +260,15 @@ export class AccountManager {
     };
 
     // Write to file with owner-only permissions — file contains plaintext
-    // private keys for test accounts.
+    // private keys for test accounts. writeFileSync's mode is masked by
+    // the process umask, so we chmod explicitly afterwards to guarantee
+    // 0o600 regardless of umask.
     const poolFilePath = join(basePath, "test-pool.json");
     writeFileSync(poolFilePath, JSON.stringify(poolData, null, 2), {
       encoding: "utf-8",
       mode: 0o600,
     });
+    chmodSync(poolFilePath, 0o600);
   }
 
   /**

--- a/packages/movehat/src/core/AccountManager.ts
+++ b/packages/movehat/src/core/AccountManager.ts
@@ -216,9 +216,10 @@ export class AccountManager {
   static saveAccountPool(poolPath?: string): void {
     const basePath = poolPath || this.defaultPoolPath;
 
-    // Ensure directory exists
+    // Ensure directory exists with restrictive perms (the pool file holds
+    // plaintext private keys, so the directory must not be world-readable).
     if (!existsSync(basePath)) {
-      mkdirSync(basePath, { recursive: true });
+      mkdirSync(basePath, { recursive: true, mode: 0o700 });
     }
 
     // Build stored accounts array
@@ -255,9 +256,13 @@ export class AccountManager {
       labelMap: labelMapObject,
     };
 
-    // Write to file
+    // Write to file with owner-only permissions — file contains plaintext
+    // private keys for test accounts.
     const poolFilePath = join(basePath, "test-pool.json");
-    writeFileSync(poolFilePath, JSON.stringify(poolData, null, 2), "utf-8");
+    writeFileSync(poolFilePath, JSON.stringify(poolData, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
   }
 
   /**

--- a/packages/movehat/src/core/__tests__/AccountManager.test.ts
+++ b/packages/movehat/src/core/__tests__/AccountManager.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, statSync, existsSync } from "fs";
+import { tmpdir, platform } from "os";
+import { join } from "path";
+import { AccountManager } from "../AccountManager.js";
+
+describe("AccountManager.saveAccountPool", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "movehat-acc-pool-"));
+    AccountManager.clearPool();
+  });
+
+  afterEach(() => {
+    AccountManager.clearPool();
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes test-pool.json with 0o600 permissions", () => {
+    AccountManager.createAccount("alice");
+    AccountManager.createAccount("bob");
+
+    const poolDir = join(tmpDir, "accounts");
+    AccountManager.saveAccountPool(poolDir);
+
+    const poolFile = join(poolDir, "test-pool.json");
+    expect(existsSync(poolFile)).toBe(true);
+
+    // Mode check is POSIX-only; skip on Windows where mode bits don't apply.
+    if (platform() !== "win32") {
+      const stat = statSync(poolFile);
+      const mode = stat.mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
+  });
+
+  it("creates the pool directory with 0o700 permissions when missing", () => {
+    AccountManager.createAccount("alice");
+
+    const poolDir = join(tmpDir, "fresh-accounts");
+    AccountManager.saveAccountPool(poolDir);
+
+    expect(existsSync(poolDir)).toBe(true);
+
+    if (platform() !== "win32") {
+      const stat = statSync(poolDir);
+      const mode = stat.mode & 0o777;
+      expect(mode).toBe(0o700);
+    }
+  });
+});

--- a/packages/movehat/src/fork/__tests__/server.test.ts
+++ b/packages/movehat/src/fork/__tests__/server.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { AddressInfo } from "net";
+import { ForkServer } from "../server.js";
+
+/**
+ * Helper to set up a minimal fork directory so ForkServer.start() succeeds.
+ */
+function makeForkDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "movehat-fork-server-"));
+  mkdirSync(join(dir, "resources"), { recursive: true });
+  writeFileSync(
+    join(dir, "metadata.json"),
+    JSON.stringify({
+      network: "test",
+      nodeUrl: "http://example.invalid/v1",
+      chainId: 0,
+      ledgerVersion: "0",
+      timestamp: "0",
+      epoch: "0",
+      blockHeight: "0",
+      createdAt: new Date().toISOString(),
+    }),
+  );
+  writeFileSync(join(dir, "accounts.json"), "{}");
+  return dir;
+}
+
+describe("ForkServer", () => {
+  let forkDir: string;
+  let server: ForkServer | null = null;
+
+  beforeEach(() => {
+    forkDir = makeForkDir();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+    rmSync(forkDir, { recursive: true, force: true });
+  });
+
+  it("binds to 127.0.0.1 by default", async () => {
+    // Port 0 lets the OS pick a free port.
+    server = new ForkServer(forkDir, 0);
+    await server.start();
+
+    const internal = (server as unknown as { server: { address(): AddressInfo } }).server;
+    const addr = internal.address();
+    expect(addr.address).toBe("127.0.0.1");
+  });
+
+  it("respects a custom host argument (::1)", async () => {
+    server = new ForkServer(forkDir, 0, "::1");
+    await server.start();
+
+    const internal = (server as unknown as { server: { address(): AddressInfo } }).server;
+    const addr = internal.address();
+    expect(addr.address).toBe("::1");
+  });
+});

--- a/packages/movehat/src/fork/server.ts
+++ b/packages/movehat/src/fork/server.ts
@@ -10,10 +10,17 @@ export class ForkServer {
   private server: http.Server | null = null;
   private forkManager: ForkManager;
   private port: number;
+  private host: string;
 
-  constructor(forkPath: string, port: number = 8080) {
+  /**
+   * @param host Interface to bind. Defaults to `127.0.0.1` so cached fork
+   *   state (which may include sensitive resources) is not exposed on the LAN.
+   *   Pass `'0.0.0.0'` only if you intentionally need to expose the server.
+   */
+  constructor(forkPath: string, port: number = 8080, host: string = '127.0.0.1') {
     this.forkManager = new ForkManager(forkPath);
     this.port = port;
+    this.host = host;
   }
 
   /**
@@ -67,12 +74,17 @@ export class ForkServer {
       // Listen for errors during startup
       this.server!.once('error', onError);
 
-      this.server!.listen(this.port, () => {
+      this.server!.listen(this.port, this.host, () => {
         // Remove error listener after successful start
         this.server!.removeListener('error', onError);
 
-        console.log(`\nFork Server listening on http://localhost:${this.port}`);
-        console.log(`  Ledger Info: http://localhost:${this.port}/v1/`);
+        const displayHost = this.host === '0.0.0.0' ? 'localhost' : this.host;
+        console.log(`\nFork Server listening on http://${displayHost}:${this.port}`);
+        console.log(`  Bound interface: ${this.host}`);
+        console.log(`  Ledger Info: http://${displayHost}:${this.port}/v1/`);
+        if (this.host === '0.0.0.0') {
+          console.warn(`  ⚠️  Server is bound to 0.0.0.0 — fork state is reachable from the LAN.`);
+        }
         console.log(`\nPress Ctrl+C to stop`);
         resolve();
       });

--- a/packages/movehat/src/fork/server.ts
+++ b/packages/movehat/src/fork/server.ts
@@ -78,7 +78,14 @@ export class ForkServer {
         // Remove error listener after successful start
         this.server!.removeListener('error', onError);
 
-        const displayHost = this.host === '0.0.0.0' ? 'localhost' : this.host;
+        // IPv6 literals must be wrapped in brackets in URLs (RFC 3986).
+        const isIpv6 = this.host.includes(':');
+        const displayHost =
+          this.host === '0.0.0.0'
+            ? 'localhost'
+            : isIpv6
+              ? `[${this.host}]`
+              : this.host;
         console.log(`\nFork Server listening on http://${displayHost}:${this.port}`);
         console.log(`  Bound interface: ${this.host}`);
         console.log(`  Ledger Info: http://${displayHost}:${this.port}/v1/`);


### PR DESCRIPTION
## Summary
Two small, independent security hardening fixes from the security audit batch.

### #35 — ForkServer binds to 127.0.0.1 by default
- **Before**: `listen(port, callback)` → bound to `0.0.0.0`, combined with
  `Access-Control-Allow-Origin: *` exposed cached fork state to the LAN.
- **After**: bind to `127.0.0.1`. `LocalNodeManager` already used
  `127.0.0.1` — this aligns the two.
- New `--host` flag on \`movehat fork serve\` for users who intentionally
  need to expose it; warning logged when bound to `0.0.0.0`.

### #39 — Account pool file written with 0o600
- **Before**: `writeFileSync(file, json, "utf-8")` used the default umask;
  on typical multi-user systems this is `0o644` (group/world readable),
  leaking plaintext test private keys.
- **After**: file mode `0o600`, parent dir mode `0o700`.
- Verified that the init template's `.gitignore` already lists `.movehat/`.

## Test plan
- [x] `pnpm --filter movehat test` — 119/119 passing (was 115; +4 new tests)
  - `core/__tests__/AccountManager.test.ts` — asserts `0o600` on file and `0o700` on dir (POSIX only)
  - `fork/__tests__/server.test.ts` — boots ForkServer on port 0, asserts `address.address === '127.0.0.1'`; second test verifies `--host '::1'` override
- [x] `pnpm --filter movehat build` — clean
- [ ] CI green

Closes #35
Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added --host CLI option to fork serve command for specifying the RPC server binding interface (defaults to 127.0.0.1)
  * ForkServer now supports custom host binding with LAN exposure warning when configured to 0.0.0.0

* **Security**
  * Enhanced filesystem permissions for account pool persistence files

* **Tests**
  * Added unit tests for host binding behavior and account pool file permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->