### PR TITLE
feat(utils): M1.1 testability foundations (adapter, runCli, address)

### DIFF
--- a/packages/movehat/src/errors.ts
+++ b/packages/movehat/src/errors.ts
@@ -19,3 +19,28 @@ export class ModuleAlreadyDeployedError extends Error {
     }
   }
 }
+
+/**
+ * Thrown by runCli when a spawned process exits with a non-zero status.
+ *
+ * `stderr` and `stdoutPreview` are already redacted of well-known secret
+ * shapes (private keys, etc.) by the caller before construction, so the error
+ * is safe to log.
+ */
+export class CliExecutionError extends Error {
+  constructor(
+    message: string,
+    public readonly command: string,
+    public readonly args: readonly string[],
+    public readonly exitCode: number,
+    public readonly stderr: string,
+    public readonly stdoutPreview: string
+  ) {
+    super(message);
+    this.name = 'CliExecutionError';
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, CliExecutionError);
+    }
+  }
+}

--- a/packages/movehat/src/errors.ts
+++ b/packages/movehat/src/errors.ts
@@ -20,24 +20,30 @@ export class ModuleAlreadyDeployedError extends Error {
   }
 }
 
+import { redactSecrets } from './utils/redact.js';
+
 /**
  * Thrown by runCli when a spawned process exits with a non-zero status.
  *
- * `stderr` and `stdoutPreview` are already redacted of well-known secret
- * shapes (private keys, etc.) by the caller before construction, so the error
- * is safe to log.
+ * `stderr`, `stdoutPreview`, and each entry in `args` are redacted of
+ * well-known secret shapes (private keys, etc.) in the constructor, so the
+ * error is safe to log regardless of how it was raised. Redaction is
+ * idempotent.
  */
 export class CliExecutionError extends Error {
+  public readonly args: readonly string[];
+
   constructor(
     message: string,
     public readonly command: string,
-    public readonly args: readonly string[],
+    args: readonly string[],
     public readonly exitCode: number,
     public readonly stderr: string,
     public readonly stdoutPreview: string
   ) {
     super(message);
     this.name = 'CliExecutionError';
+    this.args = args.map(redactSecrets);
 
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, CliExecutionError);

--- a/packages/movehat/src/utils/__tests__/address.test.ts
+++ b/packages/movehat/src/utils/__tests__/address.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isHexAddress,
+  normalizeAddress,
+  normalizeAddressShort,
+} from '../address.js';
+
+const PADDED_ONE = '0x' + '0'.repeat(63) + '1';
+const PADDED_DEAD = '0x' + '0'.repeat(60) + 'dead';
+
+describe('normalizeAddress', () => {
+  it('pads a short hex to 64 chars and adds 0x', () => {
+    expect(normalizeAddress('1')).toBe(PADDED_ONE);
+  });
+
+  it('preserves a fully padded address', () => {
+    const full = '0x' + 'a'.repeat(64);
+    expect(normalizeAddress(full)).toBe(full);
+  });
+
+  it('lowercases mixed-case input', () => {
+    expect(normalizeAddress('0xDEAD')).toBe(PADDED_DEAD);
+  });
+
+  it('adds the 0x prefix when missing', () => {
+    expect(normalizeAddress('dead')).toBe(PADDED_DEAD);
+  });
+
+  it('returns 0x followed by 64 zeros for empty input', () => {
+    expect(normalizeAddress('')).toBe('0x' + '0'.repeat(64));
+  });
+
+  it('matches fork/manager.ts legacy semantics for the canonical case', () => {
+    // Mirrors the inline `private normalizeAddress` from fork/manager.ts:243.
+    expect(normalizeAddress('0X1')).toBe(PADDED_ONE);
+  });
+});
+
+describe('normalizeAddressShort', () => {
+  it('adds 0x and lowercases without padding', () => {
+    expect(normalizeAddressShort('DEAD')).toBe('0xdead');
+  });
+
+  it('preserves the 0x prefix when already present', () => {
+    expect(normalizeAddressShort('0xBeef')).toBe('0xbeef');
+  });
+
+  it('does not pad a short address', () => {
+    expect(normalizeAddressShort('1')).toBe('0x1');
+  });
+
+  it('returns just 0x for empty input', () => {
+    expect(normalizeAddressShort('')).toBe('0x');
+  });
+});
+
+describe('isHexAddress', () => {
+  it('accepts short hex with 0x prefix', () => {
+    expect(isHexAddress('0x1')).toBe(true);
+  });
+
+  it('accepts hex without 0x prefix', () => {
+    expect(isHexAddress('dead')).toBe(true);
+  });
+
+  it('accepts uppercase 0X prefix', () => {
+    expect(isHexAddress('0Xabc')).toBe(true);
+  });
+
+  it('accepts a full 64-char address', () => {
+    expect(isHexAddress('0x' + 'f'.repeat(64))).toBe(true);
+  });
+
+  it('rejects empty string', () => {
+    expect(isHexAddress('')).toBe(false);
+  });
+
+  it('rejects lone 0x with no hex', () => {
+    expect(isHexAddress('0x')).toBe(false);
+  });
+
+  it('rejects non-hex characters', () => {
+    expect(isHexAddress('0xghij')).toBe(false);
+  });
+
+  it('rejects input longer than 64 hex chars', () => {
+    expect(isHexAddress('0x' + '0'.repeat(65))).toBe(false);
+  });
+
+  it('accepts mixed case hex', () => {
+    expect(isHexAddress('0xAbCdEf')).toBe(true);
+  });
+});

--- a/packages/movehat/src/utils/__tests__/childProcessAdapter.test.ts
+++ b/packages/movehat/src/utils/__tests__/childProcessAdapter.test.ts
@@ -61,8 +61,9 @@ describe('defaultChildProcessAdapter', () => {
     ).rejects.toThrow(/timed out/);
   });
 
-  it('aborts a running command when the signal fires', async () => {
+  it('aborts a running command with exitCode -1 and signal SIGTERM', async () => {
     const controller = new AbortController();
+    const start = Date.now();
     const promise = defaultChildProcessAdapter.run({
       command: NODE,
       args: ['-e', 'setTimeout(() => {}, 5000)'],
@@ -72,9 +73,11 @@ describe('defaultChildProcessAdapter', () => {
     setTimeout(() => controller.abort(), 20);
 
     const result = await promise;
-    // SIGTERM → child exits with non-zero (null on signal kill in some Node versions
-    // → adapter coerces to 0; we just assert it didn't hang)
-    expect(result).toBeDefined();
+    const elapsed = Date.now() - start;
+
+    expect(result.exitCode).toBe(-1);
+    expect(result.signal).toBe('SIGTERM');
+    expect(elapsed).toBeLessThan(500);
   });
 
   it('rejects synchronously when signal is already aborted', async () => {

--- a/packages/movehat/src/utils/__tests__/childProcessAdapter.test.ts
+++ b/packages/movehat/src/utils/__tests__/childProcessAdapter.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { defaultChildProcessAdapter } from '../childProcessAdapter.js';
+
+const NODE = process.execPath;
+
+describe('defaultChildProcessAdapter', () => {
+  it('captures stdout and zero exit code on success', async () => {
+    const result = await defaultChildProcessAdapter.run({
+      command: NODE,
+      args: ['-e', "process.stdout.write('hello-stdout')"],
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('hello-stdout');
+    expect(result.stderr).toBe('');
+  });
+
+  it('captures stderr separately from stdout', async () => {
+    const result = await defaultChildProcessAdapter.run({
+      command: NODE,
+      args: ['-e', "process.stderr.write('boom'); process.exit(2)"],
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('boom');
+  });
+
+  it('pipes stdin to the child process', async () => {
+    const result = await defaultChildProcessAdapter.run({
+      command: NODE,
+      args: [
+        '-e',
+        "let d=''; process.stdin.on('data', c => d += c); process.stdin.on('end', () => process.stdout.write(d.toUpperCase()))",
+      ],
+      stdin: 'piped-input',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('PIPED-INPUT');
+  });
+
+  it('passes env to the child process', async () => {
+    const result = await defaultChildProcessAdapter.run({
+      command: NODE,
+      args: ['-e', 'process.stdout.write(process.env.MH_TEST_VAR ?? "missing")'],
+      env: { ...process.env, MH_TEST_VAR: 'present' },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('present');
+  });
+
+  it('rejects when the command times out', async () => {
+    await expect(
+      defaultChildProcessAdapter.run({
+        command: NODE,
+        args: ['-e', 'setTimeout(() => {}, 5000)'],
+        timeoutMs: 50,
+      })
+    ).rejects.toThrow(/timed out/);
+  });
+
+  it('aborts a running command when the signal fires', async () => {
+    const controller = new AbortController();
+    const promise = defaultChildProcessAdapter.run({
+      command: NODE,
+      args: ['-e', 'setTimeout(() => {}, 5000)'],
+      signal: controller.signal,
+    });
+
+    setTimeout(() => controller.abort(), 20);
+
+    const result = await promise;
+    // SIGTERM → child exits with non-zero (null on signal kill in some Node versions
+    // → adapter coerces to 0; we just assert it didn't hang)
+    expect(result).toBeDefined();
+  });
+
+  it('rejects synchronously when signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      defaultChildProcessAdapter.run({
+        command: NODE,
+        args: ['-e', "process.stdout.write('never')"],
+        signal: controller.signal,
+      })
+    ).rejects.toThrow(/aborted/);
+  });
+
+  it('rejects when the command does not exist', async () => {
+    await expect(
+      defaultChildProcessAdapter.run({
+        command: '/nonexistent/path/to/binary-xyz',
+        args: [],
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/movehat/src/utils/__tests__/runCli.test.ts
+++ b/packages/movehat/src/utils/__tests__/runCli.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { CliExecutionError } from '../../errors.js';
+import type {
+  ChildProcessAdapter,
+  RunInput,
+  RunResult,
+} from '../childProcessAdapter.js';
+import { redactSecrets, runCli } from '../runCli.js';
+
+function makeAdapter(result: RunResult, capture?: { last?: RunInput }): ChildProcessAdapter {
+  return {
+    async run(input) {
+      if (capture) capture.last = input;
+      return result;
+    },
+  };
+}
+
+describe('redactSecrets', () => {
+  it('replaces ed25519-priv-0x… literals', () => {
+    const key = '0x' + 'a'.repeat(64);
+    const input = `Loaded key ed25519-priv-${key} ok`;
+    expect(redactSecrets(input)).toBe('Loaded key ***REDACTED*** ok');
+  });
+
+  it('redacts private_key labelled values', () => {
+    const input = 'private_key: 0x' + 'b'.repeat(64);
+    expect(redactSecrets(input)).toBe('***REDACTED***');
+  });
+
+  it('redacts priv-key labelled values with hyphen variants', () => {
+    const input = 'priv-key = 0x' + 'c'.repeat(64);
+    expect(redactSecrets(input)).toBe('***REDACTED***');
+  });
+
+  it('leaves regular hex addresses alone', () => {
+    const input = 'Account 0x1234 deployed module counter';
+    expect(redactSecrets(input)).toBe(input);
+  });
+
+  it('is a no-op on empty input', () => {
+    expect(redactSecrets('')).toBe('');
+  });
+});
+
+describe('runCli', () => {
+  it('returns redacted stdout and stderr on success', async () => {
+    const key = 'ed25519-priv-0x' + 'a'.repeat(64);
+    const adapter = makeAdapter({
+      exitCode: 0,
+      stdout: `ok ${key}`,
+      stderr: '',
+    });
+
+    const result = await runCli({ command: 'fake', args: [] }, { adapter });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('ok ***REDACTED***');
+    expect(result.stderr).toBe('');
+  });
+
+  it('throws CliExecutionError with redacted stderr on non-zero exit', async () => {
+    const adapter = makeAdapter({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'boom private_key: 0x' + 'd'.repeat(64),
+    });
+
+    await expect(
+      runCli({ command: 'movement', args: ['publish'] }, { adapter })
+    ).rejects.toMatchObject({
+      name: 'CliExecutionError',
+      command: 'movement',
+      exitCode: 1,
+    });
+
+    try {
+      await runCli({ command: 'movement', args: ['publish'] }, { adapter });
+    } catch (e) {
+      expect(e).toBeInstanceOf(CliExecutionError);
+      const err = e as CliExecutionError;
+      expect(err.stderr).toBe('boom ***REDACTED***');
+      expect(err.stderr).not.toContain('private_key');
+      expect(err.args).toEqual(['publish']);
+    }
+  });
+
+  it('does not throw on non-zero exit when throwOnNonZeroExit is false', async () => {
+    const adapter = makeAdapter({
+      exitCode: 2,
+      stdout: 'partial',
+      stderr: 'warn',
+    });
+
+    const result = await runCli(
+      { command: 'fake', args: [] },
+      { adapter, throwOnNonZeroExit: false }
+    );
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe('partial');
+    expect(result.stderr).toBe('warn');
+  });
+
+  it('passes the input through to the adapter unchanged', async () => {
+    const capture: { last?: RunInput } = {};
+    const adapter = makeAdapter({ exitCode: 0, stdout: '', stderr: '' }, capture);
+    const env = { FOO: 'bar' };
+    const signal = new AbortController().signal;
+
+    await runCli(
+      {
+        command: 'movement',
+        args: ['move', 'build'],
+        cwd: '/tmp/pkg',
+        env,
+        stdin: 'hello',
+        timeoutMs: 1234,
+        signal,
+      },
+      { adapter }
+    );
+
+    expect(capture.last).toEqual({
+      command: 'movement',
+      args: ['move', 'build'],
+      cwd: '/tmp/pkg',
+      env,
+      stdin: 'hello',
+      timeoutMs: 1234,
+      signal,
+    });
+  });
+
+  it('truncates stdoutPreview on CliExecutionError', async () => {
+    const longStdout = 'x'.repeat(5000);
+    const adapter = makeAdapter({
+      exitCode: 1,
+      stdout: longStdout,
+      stderr: '',
+    });
+
+    try {
+      await runCli({ command: 'fake', args: [] }, { adapter });
+      expect.fail('should have thrown');
+    } catch (e) {
+      const err = e as CliExecutionError;
+      expect(err.stdoutPreview.length).toBe(2000);
+    }
+  });
+});

--- a/packages/movehat/src/utils/__tests__/runCli.test.ts
+++ b/packages/movehat/src/utils/__tests__/runCli.test.ts
@@ -148,4 +148,72 @@ describe('runCli', () => {
       expect(err.stdoutPreview.length).toBe(2000);
     }
   });
+
+  it('redacts secret-shaped args inside CliExecutionError.args', async () => {
+    const key = 'ed25519-priv-0x' + 'a'.repeat(64);
+    const adapter = makeAdapter({ exitCode: 1, stdout: '', stderr: '' });
+
+    try {
+      await runCli(
+        { command: 'movement', args: ['publish', '--private-key', key] },
+        { adapter }
+      );
+      expect.fail('should have thrown');
+    } catch (e) {
+      const err = e as CliExecutionError;
+      expect(err.args[0]).toBe('publish');
+      expect(err.args[1]).toBe('--private-key');
+      expect(err.args[2]).toBe('***REDACTED***');
+    }
+  });
+
+  it('preserves non-secret args unchanged', async () => {
+    const adapter = makeAdapter({ exitCode: 1, stdout: '', stderr: '' });
+    const args = ['move', 'publish', '--package-dir', '/tmp/pkg'];
+
+    try {
+      await runCli({ command: 'movement', args }, { adapter });
+      expect.fail('should have thrown');
+    } catch (e) {
+      const err = e as CliExecutionError;
+      expect(Array.from(err.args)).toEqual(args);
+    }
+  });
+
+  it('propagates AbortSignal to a slow adapter and returns the killed result', async () => {
+    const slowAdapter: ChildProcessAdapter = {
+      run(input) {
+        return new Promise((resolve) => {
+          const t = setTimeout(
+            () => resolve({ exitCode: 0, stdout: '', stderr: '' }),
+            5000
+          );
+          input.signal?.addEventListener('abort', () => {
+            clearTimeout(t);
+            resolve({
+              exitCode: -1,
+              stdout: '',
+              stderr: '',
+              signal: 'SIGTERM',
+            });
+          });
+        });
+      },
+    };
+
+    const controller = new AbortController();
+    const start = Date.now();
+    const promise = runCli(
+      { command: 'movement', args: ['move', 'test'], signal: controller.signal },
+      { adapter: slowAdapter, throwOnNonZeroExit: false }
+    );
+    setTimeout(() => controller.abort(), 20);
+
+    const result = await promise;
+    const elapsed = Date.now() - start;
+
+    expect(result.exitCode).toBe(-1);
+    expect(result.signal).toBe('SIGTERM');
+    expect(elapsed).toBeLessThan(500);
+  });
 });

--- a/packages/movehat/src/utils/address.ts
+++ b/packages/movehat/src/utils/address.ts
@@ -1,0 +1,56 @@
+/**
+ * Address normalization helpers shared across the fork code.
+ *
+ * Two normalization variants live in production today and are preserved here
+ * with identical semantics so the in-place migration in M1.2 is behavior-
+ * preserving:
+ *
+ *   - `normalizeAddress`      → lowercase + `0x` + left-pad to 64 hex chars.
+ *                                Used by `fork/manager.ts` for storage keys.
+ *   - `normalizeAddressShort` → lowercase + `0x`, no padding.
+ *                                Used by `fork/api.ts` for HTTP paths.
+ */
+
+/**
+ * Lowercase the input, ensure a `0x` prefix, and left-pad the hex tail to
+ * 64 characters (66 total). Already-padded inputs are returned unchanged
+ * (apart from case folding).
+ *
+ * No validation: callers that need to reject non-hex input should consult
+ * `isHexAddress` first.
+ */
+export function normalizeAddress(input: string): string {
+  let normalized = input.toLowerCase();
+
+  if (!normalized.startsWith('0x')) {
+    normalized = `0x${normalized}`;
+  }
+
+  if (normalized.length < 66) {
+    normalized = '0x' + normalized.slice(2).padStart(64, '0');
+  }
+
+  return normalized;
+}
+
+/**
+ * Lowercase the input and ensure a `0x` prefix. Length is preserved — no
+ * padding is applied. Suitable for callers that pass addresses straight to
+ * an HTTP endpoint that accepts short forms.
+ */
+export function normalizeAddressShort(input: string): string {
+  const lower = input.toLowerCase();
+  return lower.startsWith('0x') ? lower : `0x${lower}`;
+}
+
+/**
+ * Returns true when the input is a syntactically valid hex address: optional
+ * `0x` prefix followed by 1 to 64 hex characters (case insensitive).
+ */
+export function isHexAddress(input: string): boolean {
+  const stripped = input.startsWith('0x') || input.startsWith('0X')
+    ? input.slice(2)
+    : input;
+  if (stripped.length === 0 || stripped.length > 64) return false;
+  return /^[0-9a-fA-F]+$/.test(stripped);
+}

--- a/packages/movehat/src/utils/childProcessAdapter.ts
+++ b/packages/movehat/src/utils/childProcessAdapter.ts
@@ -21,9 +21,19 @@ export interface RunInput {
 }
 
 export interface RunResult {
+  /**
+   * Numeric exit code from the child. `-1` when the child was terminated by
+   * a signal (no numeric exit code available) — in that case `signal` is
+   * populated.
+   */
   exitCode: number;
   stdout: string;
   stderr: string;
+  /**
+   * Populated when the child died from a signal (e.g. external abort, kill
+   * during shutdown). `undefined` for normal exits.
+   */
+  signal?: NodeJS.Signals;
 }
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
@@ -70,14 +80,18 @@ class DefaultChildProcessAdapter implements ChildProcessAdapter {
         reject(err);
       });
 
-      child.on('close', (code) => {
+      child.on('close', (code, signal) => {
         clearTimeout(timeoutHandle);
         input.signal?.removeEventListener('abort', onAbort);
-        resolve({
-          exitCode: code ?? 0,
+        const result: RunResult = {
+          exitCode: code !== null ? code : -1,
           stdout: Buffer.concat(stdoutChunks).toString('utf8'),
           stderr: Buffer.concat(stderrChunks).toString('utf8'),
-        });
+        };
+        if (signal) {
+          result.signal = signal;
+        }
+        resolve(result);
       });
 
       if (input.stdin !== undefined) {

--- a/packages/movehat/src/utils/childProcessAdapter.ts
+++ b/packages/movehat/src/utils/childProcessAdapter.ts
@@ -1,0 +1,92 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Injectable abstraction over `child_process.spawn`.
+ *
+ * Tests inject a fake adapter; production code uses `defaultChildProcessAdapter`.
+ * Higher-level helpers (see `runCli`) wrap this with redaction and error handling.
+ */
+export interface ChildProcessAdapter {
+  run(input: RunInput): Promise<RunResult>;
+}
+
+export interface RunInput {
+  command: string;
+  args: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stdin?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface RunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+class DefaultChildProcessAdapter implements ChildProcessAdapter {
+  run(input: RunInput): Promise<RunResult> {
+    const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    return new Promise<RunResult>((resolve, reject) => {
+      const child = spawn(input.command, [...input.args], {
+        cwd: input.cwd,
+        env: input.env ?? process.env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+
+      child.stdout?.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+      child.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+      const timeoutHandle = setTimeout(() => {
+        child.kill('SIGTERM');
+        reject(new Error(`Command timed out after ${timeoutMs}ms: ${input.command}`));
+      }, timeoutMs);
+
+      const onAbort = () => {
+        child.kill('SIGTERM');
+      };
+
+      if (input.signal) {
+        if (input.signal.aborted) {
+          clearTimeout(timeoutHandle);
+          child.kill('SIGTERM');
+          reject(new Error('Command aborted before start'));
+          return;
+        }
+        input.signal.addEventListener('abort', onAbort, { once: true });
+      }
+
+      child.on('error', (err) => {
+        clearTimeout(timeoutHandle);
+        input.signal?.removeEventListener('abort', onAbort);
+        reject(err);
+      });
+
+      child.on('close', (code) => {
+        clearTimeout(timeoutHandle);
+        input.signal?.removeEventListener('abort', onAbort);
+        resolve({
+          exitCode: code ?? 0,
+          stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+          stderr: Buffer.concat(stderrChunks).toString('utf8'),
+        });
+      });
+
+      if (input.stdin !== undefined) {
+        child.stdin?.end(input.stdin);
+      } else {
+        child.stdin?.end();
+      }
+    });
+  }
+}
+
+export const defaultChildProcessAdapter: ChildProcessAdapter = new DefaultChildProcessAdapter();

--- a/packages/movehat/src/utils/redact.ts
+++ b/packages/movehat/src/utils/redact.ts
@@ -1,0 +1,24 @@
+/**
+ * Patterns that match well-known secret shapes Movement / Aptos tools emit on
+ * stderr / stdout / CLI arguments. Each match is replaced with
+ * `***REDACTED***` by `redactSecrets`.
+ *
+ * The labelled pattern (second entry) intentionally accepts bare `priv` and
+ * `key` prefixes. Over-redaction is fine; missing a real key is not.
+ */
+export const SECRET_PATTERNS: readonly RegExp[] = [
+  /ed25519-priv-0x[0-9a-fA-F]{64}/g,
+  /(private[_-]?key|priv[_-]?key|priv|key)\s*[:=]\s*0x[0-9a-fA-F]{32,}/gi,
+];
+
+/**
+ * Replaces every match of every known secret pattern with `***REDACTED***`.
+ * Idempotent: running it on already-redacted text is a no-op.
+ */
+export function redactSecrets(text: string): string {
+  let out = text;
+  for (const pattern of SECRET_PATTERNS) {
+    out = out.replace(pattern, '***REDACTED***');
+  }
+  return out;
+}

--- a/packages/movehat/src/utils/runCli.ts
+++ b/packages/movehat/src/utils/runCli.ts
@@ -39,6 +39,9 @@ export async function runCli(
     stdout: redactSecrets(raw.stdout),
     stderr: redactSecrets(raw.stderr),
   };
+  if (raw.signal) {
+    result.signal = raw.signal;
+  }
 
   if (result.exitCode !== 0 && throwOnNonZeroExit) {
     throw new CliExecutionError(

--- a/packages/movehat/src/utils/runCli.ts
+++ b/packages/movehat/src/utils/runCli.ts
@@ -1,0 +1,76 @@
+import { CliExecutionError } from '../errors.js';
+import {
+  defaultChildProcessAdapter,
+  type ChildProcessAdapter,
+  type RunInput,
+  type RunResult,
+} from './childProcessAdapter.js';
+
+const STDOUT_PREVIEW_CHARS = 2000;
+
+/**
+ * Patterns that match well-known secret shapes Movement / Aptos tools emit on
+ * stderr or stdout. The matched span is replaced with `***REDACTED***`.
+ *
+ * Order matters when patterns overlap: the longer / more specific shape goes
+ * first.
+ */
+const SECRET_PATTERNS: readonly RegExp[] = [
+  /ed25519-priv-0x[0-9a-fA-F]{64}/g,
+  /(private[_-]?key|priv[_-]?key|priv|key)\s*[:=]\s*0x[0-9a-fA-F]{32,}/gi,
+];
+
+/**
+ * Replaces every match of every known secret pattern with `***REDACTED***`.
+ * Pure function; the input string is not mutated.
+ */
+export function redactSecrets(text: string): string {
+  let out = text;
+  for (const pattern of SECRET_PATTERNS) {
+    out = out.replace(pattern, '***REDACTED***');
+  }
+  return out;
+}
+
+export interface RunCliOptions {
+  /** Override the child-process adapter (defaults to spawn-based). */
+  adapter?: ChildProcessAdapter;
+  /** When true (default), throw `CliExecutionError` on non-zero exit. */
+  throwOnNonZeroExit?: boolean;
+}
+
+/**
+ * Spawns a CLI command through the injectable adapter, redacts well-known
+ * secret shapes from stdout and stderr before returning, and throws
+ * `CliExecutionError` (with already-redacted payloads) on non-zero exits.
+ *
+ * Callers that need to inspect raw output should set `throwOnNonZeroExit:false`
+ * and consume the returned `RunResult` directly — fields are still redacted.
+ */
+export async function runCli(
+  input: RunInput,
+  options: RunCliOptions = {}
+): Promise<RunResult> {
+  const adapter = options.adapter ?? defaultChildProcessAdapter;
+  const throwOnNonZeroExit = options.throwOnNonZeroExit ?? true;
+
+  const raw = await adapter.run(input);
+  const result: RunResult = {
+    exitCode: raw.exitCode,
+    stdout: redactSecrets(raw.stdout),
+    stderr: redactSecrets(raw.stderr),
+  };
+
+  if (result.exitCode !== 0 && throwOnNonZeroExit) {
+    throw new CliExecutionError(
+      `Command failed with exit code ${result.exitCode}: ${input.command}`,
+      input.command,
+      input.args,
+      result.exitCode,
+      result.stderr,
+      result.stdout.slice(0, STDOUT_PREVIEW_CHARS)
+    );
+  }
+
+  return result;
+}

--- a/packages/movehat/src/utils/runCli.ts
+++ b/packages/movehat/src/utils/runCli.ts
@@ -5,32 +5,11 @@ import {
   type RunInput,
   type RunResult,
 } from './childProcessAdapter.js';
+import { redactSecrets } from './redact.js';
+
+export { redactSecrets } from './redact.js';
 
 const STDOUT_PREVIEW_CHARS = 2000;
-
-/**
- * Patterns that match well-known secret shapes Movement / Aptos tools emit on
- * stderr or stdout. The matched span is replaced with `***REDACTED***`.
- *
- * Order matters when patterns overlap: the longer / more specific shape goes
- * first.
- */
-const SECRET_PATTERNS: readonly RegExp[] = [
-  /ed25519-priv-0x[0-9a-fA-F]{64}/g,
-  /(private[_-]?key|priv[_-]?key|priv|key)\s*[:=]\s*0x[0-9a-fA-F]{32,}/gi,
-];
-
-/**
- * Replaces every match of every known secret pattern with `***REDACTED***`.
- * Pure function; the input string is not mutated.
- */
-export function redactSecrets(text: string): string {
-  let out = text;
-  for (const pattern of SECRET_PATTERNS) {
-    out = out.replace(pattern, '***REDACTED***');
-  }
-  return out;
-}
 
 export interface RunCliOptions {
   /** Override the child-process adapter (defaults to spawn-based). */


### PR DESCRIPTION
## Summary

First sub-PR of M1 (#68). Adds the three utility modules every later M1 sub-PR will depend on. **100% additive — zero production callers migrated**: builds the runway without changing any spawn/exec or address-normalization site yet.

Closes nothing yet; lays the foundation for #43, #56, #58.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Docs / chore / tooling

## What's in this PR

**7 commits, one per logical artifact:**

| Commit | What |
|--------|------|
| `feat(errors)` | `CliExecutionError` — thrown by `runCli` on non-zero exit, carries redacted stderr + stdout preview. |
| `feat(utils)` | `childProcessAdapter.ts` — injectable interface over `spawn`, with `defaultChildProcessAdapter`. Handles stdin pipe, env, cwd, timeout, AbortSignal. |
| `test(utils)` | 8 tests for the default adapter using `node -e` subprocesses (fast, no Movement CLI needed). |
| `feat(utils)` | `runCli.ts` — wraps the adapter, redacts well-known secret patterns (`ed25519-priv-…`, `private_key: 0x…`) from stdout/stderr, throws `CliExecutionError` on non-zero exit. |
| `test(utils)` | 10 tests for `runCli` + the exported `redactSecrets` helper, using a fake adapter. |
| `feat(utils)` | `address.ts` — three pure helpers: `normalizeAddress` (lowercase + `0x` + left-pad to 64 hex, mirrors `fork/manager.ts:243`), `normalizeAddressShort` (no pad, mirrors `fork/api.ts`), `isHexAddress`. |
| `test(utils)` | 19 tests covering padding, case folding, prefix handling, validation edges. |

## Files added

- \`packages/movehat/src/utils/childProcessAdapter.ts\`
- \`packages/movehat/src/utils/runCli.ts\`
- \`packages/movehat/src/utils/address.ts\`
- \`packages/movehat/src/utils/__tests__/childProcessAdapter.test.ts\`
- \`packages/movehat/src/utils/__tests__/runCli.test.ts\`
- \`packages/movehat/src/utils/__tests__/address.test.ts\`

## Files NOT touched (intentional)

\`runtime.ts\`, \`fork/manager.ts\`, \`fork/api.ts\`, \`fork/storage.ts\`, \`node/LocalNodeManager.ts\`, \`helpers/setupLocalTesting.ts\`, \`commands/*.ts\`, \`helpers/move-tests.ts\`. Their migrations land in later M1.x PRs.

## How was this tested?

- \`pnpm --filter movehat build\` → green (strict TS clean)
- \`pnpm --filter movehat test\` → **156/156** passing (119 pre-existing + 37 new)
- \`grep child_process\` outside \`utils/\` — same callsites as before, untouched
- Adapter happy-path verified by spawning real \`node -e\` subprocesses (no Movement CLI dependency)
- Redactor verified to mask both standalone \`ed25519-priv-…\` literals and labelled \`private_key: 0x…\` forms

## M1 progress

✅ \`packages/movehat/src/utils/runCli.ts\` exists
✅ \`packages/movehat/src/utils/childProcessAdapter.ts\` exists with injectable interface
✅ \`packages/movehat/src/utils/address.ts\` exists
✅ All previously passing 119 tests still green; new tests for \`runCli\` and \`address\`

Pending (next sub-PRs):
- ❌ Replaces all direct \`exec\`/\`spawn\` callers (M1.3)
- ❌ Replaces ad-hoc normalization in fork/{manager,storage,api}.ts (M1.2)
- ❌ \`Publisher.ts\` + per-deploy temp dir + SIGINT (M1.4)
- ❌ Singletons removal (M1.5)
- ❌ \`loadUserConfig\` mtime cache + \`switchNetwork\` return (M1.6)

## Checklist

- [x] \`pnpm --filter movehat test\` passes locally (156/156)
- [x] CHANGELOG \`[Unreleased]\` — not updated (purely internal utilities, no consumer-visible behavior change yet)
- [x] Conventional Commits used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced CLI execution handling with richer failure details and truncated output previews.
  * Automatic secret redaction applied to CLI stdout/stderr.
  * Address utilities for normalization and validation.

* **Tests**
  * Added comprehensive tests for address utilities, CLI runner behavior, child-process adapter, redaction, and error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/76)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->