### PR TITLE
docs: track CLAUDE.md, link M1 sub-issues, add examples gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,7 @@
 ## Checklist
 
 - [ ] `pnpm test` passes locally
+- [ ] `pnpm test:example` passes — or this PR doesn't touch `packages/movehat/src/**`, `bin/**`, or published templates (mark N/A in "How was this tested?")
 - [ ] CHANGELOG `[Unreleased]` updated if user-visible
 - [ ] Docs updated if public API or CLI surface changed
 - [ ] Conventional Commits used in commit messages

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ pnpm-debug.log*
 !BENCHMARKS.md
 !MOVEMENT_CLI_COMPAT.md
 !NOTICE.md
+!CLAUDE.md
 !.github/**/*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,165 @@
+# CLAUDE.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. Split Big Work Into Sub-Issues
+
+**Any milestone or feature that needs more than one PR must be broken into GitHub sub-issues, with each sub-issue detailed in `ROADMAP.md`.**
+
+The rule:
+
+- If the work cannot land in a single, reviewable PR, open a sub-issue for each PR you intend to ship. Use titles like `[M1.3] Migrate child_process callers to runCli`.
+- Each sub-issue carries its own Definition of Done — the same level of mechanical precision the meta-issue uses (exact file paths, exact greps, exact test commands).
+- The meta-issue (`[Roadmap] M1: …`) tracks the sub-issues. The meta-issue closes only when all sub-issues close.
+- `ROADMAP.md` lists every sub-issue under its milestone, with links and a one-line summary of what each PR delivers.
+- Each PR references its sub-issue with `Closes #<n>` and `Tracks #<meta>`.
+
+When in doubt about granularity: prefer one sub-issue per logical refactor (e.g. "migrate the address helpers" is one sub-issue, "migrate the child_process callers" is another). A sub-PR that takes more than a day of focused work is a sign it should be split further.
+
+## 6. Verify the Example Project
+
+**The `examples/counter-example/` is the canonical install-experience test. Any PR that touches `packages/movehat/src/**`, `packages/movehat/bin/**`, `packages/movehat/package.json` exports, or the published templates must verify the example still works before being declared ready.**
+
+Practical checklist:
+
+- Run `pnpm test:example` (mocha suite under `examples/counter-example/tests/`) and report the result in the PR description.
+- For changes that affect the CLI surface, also run `pnpm test:smoke` (packs movehat, installs globally, exercises `movehat init` etc.).
+- For changes that affect deploy / runtime / fork paths, run `pnpm test:e2e:quick`.
+- If any of those scripts is broken by infrastructure (Movement CLI not installed, missing keys), say so explicitly in the PR rather than silently skipping.
+
+CI enforcement of this rule is itself M4 work — until then, the gate is manual but mandatory.
+
+---
+
+## Project-Specific Context
+
+**What is Movehat?** A Hardhat-like development framework for Movement L1 and Aptos Move smart contracts. Provides local blockchain testing, compilation, deployment, and testing utilities.
+
+### Package Structure
+```
+movehat-workspace/
+├── packages/
+│   ├── movehat/           # Main CLI package (src/cli.ts, src/runtime.ts, src/helpers/)
+│   └── docs/              # Fumadocs + Next.js 15 static site (out/)
+├── examples/
+│   └── counter-example/   # Example project demonstrating usage — the install-experience gate
+├── scripts/               # E2E, smoke-test, pre-publish scripts
+└── .github/workflows/     # CI: unit tests, E2E, security audit
+```
+
+### Key Commands
+```bash
+pnpm build              # Build all packages
+pnpm dev                # Dev mode for movehat CLI
+pnpm test               # Unit tests (movehat package)
+pnpm test:e2e           # E2E tests (requires Movement CLI tarball)
+pnpm test:watch         # Watch mode for tests
+pnpm test:coverage      # Coverage report (target 80%)
+pnpm test:example       # Run examples/counter-example mocha suite
+pnpm test:smoke         # Pack + global install + CLI smoke checks
+pnpm build:docs         # Build static docs site → out/
+pnpm dev:docs           # Dev server for docs
+```
+
+### Important Conventions
+
+**Dual Testing Modes:**
+- `local-node` — Full local blockchain (auto-starts node, funds accounts, deploys contracts)
+- `fork` — Read-only snapshot of remote network state
+
+**Test Fixture Pattern:**
+```typescript
+const fixture = await setupTestFixture(['counter'] as const, ['alice', 'bob']);
+fixture.contracts.counter.call(deployer, "increment", []);
+fixture.contracts.counter.view<string>("get", [deployer.accountAddress.toString()]);
+```
+
+**Named Addresses:** Auto-detected from Move source; use directly without manual address resolution.
+
+**Coverage Target:** 80% (currently ~15%)
+
+### Docs Site
+- **Framework:** Fumadocs v15 + Next.js 15 with `output: 'export'` (static)
+- **Important:** Do NOT use fumadocs-core/ui v16+ with Next.js 15 — requires `useEffectEvent` which only works with Next.js 16
+- **Import workaround:** Use `import { docs } from '../.source/server'` instead of `fumadocs-mdx:collections/server`
+- **Content:** `packages/docs/content/docs/`
+
+### CI Workflow
+- **Unit tests:** On all PRs, Node 20/22, coverage threshold 15%
+- **E2E tests:** PRs to main only, downloads Movement CLI tarball
+- **Security audit:** Runs on PRs
+
+### Key Files (for reference)
+| File | Purpose |
+|------|---------|
+| `src/cli.ts` | Commander CLI entry point |
+| `src/runtime.ts` | Runtime (`getMovehat()`, `mh`) |
+| `src/helpers/index.ts` | `setupTestFixture`, `setupLocalTesting` |
+| `src/core/contract.ts` | `MoveContract` class |
+| `src/core/AccountManager.ts` | Account generation/funding |
+| `src/core/deployments.ts` | Deployment tracking |
+| `src/utils/childProcessAdapter.ts` | Injectable spawn abstraction (M1.1) |
+| `src/utils/runCli.ts` | CLI wrapper with stderr redaction (M1.1) |
+| `src/utils/address.ts` | Address normalization helpers (M1.1) |
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 
 **Goal**: Refactor core modules so they can be unit-tested without spawning real processes or relying on global state.
 
-**Sub-issues** (each is a separate PR, executed in order; M1.4 may parallelize with M1.5/M1.6 once M1.3 lands):
+**Sub-issues** (each is a separate PR. Execution order: M1.2 → M1.3 → M1.4 → M1.5 in serial — M1.4 and M1.5 both rewrite `runtime.ts` and would collide if run in parallel. M1.6 may parallelize with M1.4 or M1.5 because it touches `core/config.ts` and an isolated return signature. M1.7 may run at any time.):
 
 | Sub-PR | Issue | Focus | Closes |
 |--------|-------|-------|--------|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,6 +24,8 @@ This roadmap organizes the next phase of Movehat development. Each milestone has
 2. **Hardhat-style API.** Method names align with the broader Move/Aptos testing ecosystem (`createLocal`, `createFork`, `createLive`, `deployCodeObject`, `upgradeCodeObject`, `runViewFunction`, `runMoveScript`). All code implemented from scratch under MIT.
 3. **TypeDoc complements Fumadocs.** TypeDoc emits MDX into `packages/docs/content/docs/api/`; Fumadocs renders.
 4. **Unit ≠ integration tests.** Unit tests may mock `child_process` via an injectable adapter. The integration suite runs the real Movement CLI without mocks.
+5. **Big work is split into sub-issues.** Any milestone that needs more than one PR is broken into GitHub sub-issues, each with its own Definition of Done. The meta-issue closes only when every sub-issue closes. The sub-issue list lives inside each milestone section below.
+6. **`examples/counter-example/` is the install-experience gate.** Every PR that touches `packages/movehat/src/**`, `packages/movehat/bin/**`, or the published templates verifies the example still works (`pnpm test:example`, plus `pnpm test:smoke` for CLI-surface changes). M4 codifies this in CI; until then the gate is manual.
 
 ---
 
@@ -50,7 +52,19 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 
 **Goal**: Refactor core modules so they can be unit-tested without spawning real processes or relying on global state.
 
-**Definition of Done**:
+**Sub-issues** (each is a separate PR, executed in order; M1.4 may parallelize with M1.5/M1.6 once M1.3 lands):
+
+| Sub-PR | Issue | Focus | Closes |
+|--------|-------|-------|--------|
+| **M1.1** | (shipped in PR #76) | `utils/runCli.ts`, `utils/childProcessAdapter.ts`, `utils/address.ts` + tests; no migration | foundations |
+| M1.2 | [#77](https://github.com/gilbertsahumada/movehat/issues/77) | Migrate `fork/{manager,api,storage}.ts` to `utils/address.ts` | [#56](https://github.com/gilbertsahumada/movehat/issues/56) |
+| M1.3 | [#78](https://github.com/gilbertsahumada/movehat/issues/78) | Migrate the 8 `exec`/`spawn` callsites to `runCli` | [#58](https://github.com/gilbertsahumada/movehat/issues/58), completes [#43](https://github.com/gilbertsahumada/movehat/issues/43) |
+| M1.4 | [#79](https://github.com/gilbertsahumada/movehat/issues/79) | Extract `core/Publisher.ts` + per-deploy temp dir + SIGINT handler | [#19](https://github.com/gilbertsahumada/movehat/issues/19), [#36](https://github.com/gilbertsahumada/movehat/issues/36), [#37](https://github.com/gilbertsahumada/movehat/issues/37), [#38](https://github.com/gilbertsahumada/movehat/issues/38), [#53](https://github.com/gilbertsahumada/movehat/issues/53) |
+| M1.5 | [#80](https://github.com/gilbertsahumada/movehat/issues/80) | Remove `cachedRuntime` and the three `setupLocalTesting` singletons | [#21](https://github.com/gilbertsahumada/movehat/issues/21), [#55](https://github.com/gilbertsahumada/movehat/issues/55) |
+| M1.6 | [#81](https://github.com/gilbertsahumada/movehat/issues/81) | `loadUserConfig` mtime cache + `switchNetwork` returns runtime | [#46](https://github.com/gilbertsahumada/movehat/issues/46), [#62](https://github.com/gilbertsahumada/movehat/issues/62) |
+| M1.7 | [#82](https://github.com/gilbertsahumada/movehat/issues/82) | Strict types audit (`any`, `!`, `noUncheckedIndexedAccess`) | [#57](https://github.com/gilbertsahumada/movehat/issues/57) |
+
+**Definition of Done** (rolled up from the sub-issues):
 - [ ] `packages/movehat/src/utils/runCli.ts` exists; replaces all direct `exec`/`spawn` callers
 - [ ] `packages/movehat/src/utils/childProcessAdapter.ts` exists with injectable interface
 - [ ] `packages/movehat/src/utils/address.ts` exists; replaces ad-hoc normalization in `fork/manager.ts`, `fork/storage.ts`, `fork/api.ts`
@@ -60,6 +74,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [ ] Two parallel `deployContract` calls do **not** corrupt `~/.aptos/config.yaml` or `Move.toml`
 - [ ] SIGINT during deploy leaves no private key on disk
 - [ ] All previously passing 119 tests still green; new unit tests for `runCli`, `address`, `Publisher`
+- [ ] `examples/counter-example/` keeps passing through every sub-PR (per Decision 6)
 
 ### M2 — Hardhat-style Harness API (~6 days, issue #69)
 


### PR DESCRIPTION
## Summary

Tracking + policy PR — no source code changes.

- Recreates \`CLAUDE.md\` at repo root (it was deleted earlier) with the original four behavioral guidelines **plus two new rules**: split-big-work-into-sub-issues (#5) and verify-the-example (#6).
- Opens **6 sub-issues** for M1.2–M1.7 (#77–#82), each with its own Definition of Done.
- Wires those sub-issues into \`ROADMAP.md\` under M1 and adds two roadmap decisions matching the new CLAUDE.md rules.

## Type of change

- [x] Docs / chore / tooling

## What changed and why

**\`CLAUDE.md\` (new file).** The previous CLAUDE.md was tracked briefly and then reverted. This PR brings it back, intentionally, with the four behavioral guidelines users already approved, plus:
- \`## 5. Split Big Work Into Sub-Issues\` — any milestone needing more than one PR must be decomposed into GitHub sub-issues, each detailed in ROADMAP.md.
- \`## 6. Verify the Example Project\` — every PR touching \`packages/movehat/src/**\`, \`bin/**\`, or templates must run \`pnpm test:example\` (and \`pnpm test:smoke\` / \`pnpm test:e2e:quick\` where relevant) and report results in the PR description.

\`.gitignore\` gets a \`!CLAUDE.md\` exception so the file actually tracks.

**\`ROADMAP.md\`**.
- Two new decisions (5 and 6) mirroring the CLAUDE.md rules.
- M1 section now lists every sub-PR with its issue link:

| Sub-PR | Issue | Focus |
|--------|-------|-------|
| M1.1 | shipped (PR #76) | foundations |
| M1.2 | #77 | migrate address |
| M1.3 | #78 | migrate child_process |
| M1.4 | #79 | Publisher + temp dir + SIGINT |
| M1.5 | #80 | kill singletons |
| M1.6 | #81 | config cache + switchNetwork return |
| M1.7 | #82 | strict types audit |

**Sub-issues opened** (with full DoD on each):

- #77 [M1.2] Migrate address normalization to utils/address.ts
- #78 [M1.3] Migrate child_process callers to runCli
- #79 [M1.4] Publisher.ts extraction with per-deploy temp dir and SIGINT handler
- #80 [M1.5] Eliminate module-scoped mutable singletons
- #81 [M1.6] loadUserConfig mtime cache + switchNetwork returns runtime
- #82 [M1.7] Strict types audit

## How was this tested?

- \`pnpm --filter movehat test\` → 119/119 passing (no source code touched).
- \`pnpm --filter movehat exec tsc --noEmit\` → green.
- \`examples/counter-example/\` not run — this PR doesn't touch any published surface, so per rule #6 the manual gate is N/A. Verification of the example becomes mandatory starting with #77 (M1.2).

## Checklist

- [x] Tests pass locally
- [x] CHANGELOG \`[Unreleased]\` — N/A (pure docs/tooling, no user-visible change)
- [x] Conventional Commits used (3 commits)