### PR TITLE
refactor(fork): M1.2 migrate address normalization to utils/address

### DIFF
--- a/packages/movehat/src/fork/__tests__/storage.test.ts
+++ b/packages/movehat/src/fork/__tests__/storage.test.ts
@@ -257,5 +257,25 @@ describe('ForkStorage', () => {
         storage.saveResource('0x123/../../etc', 'test::Resource', { value: 1 });
       }).toThrow('Invalid address format');
     });
+
+    it('should reject addresses with more than 64 hex chars (Aptos/Movement cap)', () => {
+      const storage = new ForkStorage(forkPath);
+      const sixtyFiveHex = '0x' + 'a'.repeat(65);
+
+      expect(() => {
+        storage.saveResource(sixtyFiveHex, 'test::Resource', { value: 1 });
+      }).toThrow('Invalid address format');
+    });
+
+    it('should accept addresses exactly at the 64 hex char limit', () => {
+      const storage = new ForkStorage(forkPath);
+      const sixtyFourHex = '0x' + 'a'.repeat(64);
+
+      expect(() => {
+        storage.saveResource(sixtyFourHex, 'test::Resource', { value: 1 });
+      }).not.toThrow();
+
+      expect(vol.existsSync(`${forkPath}/resources/${sixtyFourHex}.json`)).toBe(true);
+    });
   });
 });

--- a/packages/movehat/src/fork/api.ts
+++ b/packages/movehat/src/fork/api.ts
@@ -2,6 +2,7 @@ import https from 'https';
 import http from 'http';
 import { URL } from 'url';
 import type { LedgerInfo, AccountData, AccountResource } from '../types/fork.js';
+import { normalizeAddressShort } from '../utils/address.js';
 
 /**
  * Client for interacting with Movement/Aptos-compatible JSON API
@@ -82,10 +83,7 @@ export class MovementApiClient {
    * Get account information
    */
   async getAccount(address: string): Promise<AccountData> {
-    // Normalize address (ensure 0x prefix and lowercase)
-    const normalizedAddress = address.toLowerCase().startsWith('0x')
-      ? address.toLowerCase()
-      : `0x${address.toLowerCase()}`;
+    const normalizedAddress = normalizeAddressShort(address);
 
     return this.get<AccountData>(this.apiPath(`/accounts/${normalizedAddress}`));
   }
@@ -94,9 +92,7 @@ export class MovementApiClient {
    * Get a specific account resource
    */
   async getAccountResource(address: string, resourceType: string): Promise<any> {
-    const normalizedAddress = address.toLowerCase().startsWith('0x')
-      ? address.toLowerCase()
-      : `0x${address.toLowerCase()}`;
+    const normalizedAddress = normalizeAddressShort(address);
 
     // URL encode the resource type
     const encodedType = encodeURIComponent(resourceType);
@@ -108,9 +104,7 @@ export class MovementApiClient {
    * Get all resources for an account
    */
   async getAccountResources(address: string): Promise<AccountResource[]> {
-    const normalizedAddress = address.toLowerCase().startsWith('0x')
-      ? address.toLowerCase()
-      : `0x${address.toLowerCase()}`;
+    const normalizedAddress = normalizeAddressShort(address);
 
     return this.get<AccountResource[]>(this.apiPath(`/accounts/${normalizedAddress}/resources`));
   }

--- a/packages/movehat/src/fork/manager.ts
+++ b/packages/movehat/src/fork/manager.ts
@@ -1,6 +1,7 @@
 import { MovementApiClient } from './api.js';
 import { ForkStorage } from './storage.js';
 import type { ForkMetadata, AccountState } from '../types/fork.js';
+import { normalizeAddress } from '../utils/address.js';
 
 /**
  * Manager for fork operations
@@ -72,7 +73,7 @@ export class ForkManager {
    */
   async getAccount(address: string): Promise<AccountState> {
     // Normalize address
-    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedAddress = normalizeAddress(address);
 
     // Check cache first
     let accountState = this.storage.getAccount(normalizedAddress);
@@ -103,7 +104,7 @@ export class ForkManager {
    * Get a specific resource (with lazy loading)
    */
   async getResource(address: string, resourceType: string): Promise<any> {
-    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedAddress = normalizeAddress(address);
 
     // Check cache first
     let resource = this.storage.getResource(normalizedAddress, resourceType);
@@ -138,7 +139,7 @@ export class ForkManager {
    * Get all resources for an account (with lazy loading)
    */
   async getAllResources(address: string): Promise<Record<string, any>> {
-    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedAddress = normalizeAddress(address);
 
     // Check if we have any cached resources
     let resources = this.storage.getAllResources(normalizedAddress);
@@ -169,7 +170,7 @@ export class ForkManager {
    * Set a resource value (for testing/mocking)
    */
   async setResource(address: string, resourceType: string, data: any): Promise<void> {
-    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedAddress = normalizeAddress(address);
     this.storage.saveResource(normalizedAddress, resourceType, data);
     console.log(`  ✓ Updated resource ${resourceType} for ${normalizedAddress}`);
   }
@@ -178,7 +179,7 @@ export class ForkManager {
    * Fund an account with coins (adds to existing balance)
    */
   async fundAccount(address: string, amount: number, coinType: string = '0x1::aptos_coin::AptosCoin'): Promise<void> {
-    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedAddress = normalizeAddress(address);
     const resourceType = `0x1::coin::CoinStore<${coinType}>`;
 
     // Try to get existing coin store
@@ -235,24 +236,6 @@ export class ForkManager {
     }
 
     console.log(`  ✓ Funded ${normalizedAddress} with ${amount} coins`);
-  }
-
-  /**
-   * Normalize address format
-   */
-  private normalizeAddress(address: string): string {
-    let normalized = address.toLowerCase();
-
-    if (!normalized.startsWith('0x')) {
-      normalized = `0x${normalized}`;
-    }
-
-    // Pad to 66 characters (0x + 64 hex chars)
-    if (normalized.length < 66) {
-      normalized = '0x' + normalized.slice(2).padStart(64, '0');
-    }
-
-    return normalized;
   }
 
   /**
@@ -317,7 +300,7 @@ export class ForkManager {
    * const account = await forkManager.getOrCreateAccount("0x123...");
    */
   async getOrCreateAccount(address: string): Promise<AccountState> {
-    const normalizedAddress = this.normalizeAddress(address);
+    const normalizedAddress = normalizeAddress(address);
 
     // Try to get existing account
     try {

--- a/packages/movehat/src/fork/storage.ts
+++ b/packages/movehat/src/fork/storage.ts
@@ -1,25 +1,22 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import type { ForkMetadata, AccountState } from '../types/fork.js';
+import { isHexAddress } from '../utils/address.js';
 
 /**
- * Sanitize address to create a safe filename
- * Prevents path traversal by encoding the address
+ * Sanitize address to create a safe filename. Validates the address through
+ * the shared `isHexAddress` helper (length 1–64 hex chars, optional `0x`),
+ * then rebuilds a canonical `0x…` form. The trailing path-separator check is
+ * defense-in-depth: unreachable after `isHexAddress`, but cheap to keep.
  */
 function sanitizeAddressForFilename(address: string): string {
-  // Remove any path separators and normalize
-  const normalized = address.toLowerCase().replace(/^0x/, '');
-
-  // Validate that it's a valid hex string
-  if (!/^[0-9a-f]+$/.test(normalized)) {
+  if (!isHexAddress(address)) {
     throw new Error(`Invalid address format: ${address}. Expected hexadecimal string.`);
   }
 
-  // Encode to prevent any path traversal
-  // Use the normalized hex string directly as it's safe
+  const normalized = address.toLowerCase().replace(/^0x/, '');
   const safe = `0x${normalized}`;
 
-  // Validate no path separators in result
   if (safe.includes('/') || safe.includes('\\') || safe.includes('..')) {
     throw new Error(`Address contains invalid characters: ${address}`);
   }


### PR DESCRIPTION
## Summary

First sub-PR of M1 on the new \`develop\` branch. Migrates the three scattered address-normalization patterns in \`fork/\` to the centralized helpers landed in #76 (\`utils/address.ts\`). Pure behavior-preserving substitution, except one deliberate strictness tightening in \`storage.ts\` that's documented inline.

Closes #56, refs #77, tracks #68.

## Type of change

- [x] Refactor (no functional change to public API)

## Changes

**2 commits, each a complete functional unit:**

### \`refactor(fork): migrate manager and api to utils/address helpers\`
- \`fork/manager.ts\` — 6 call sites switched from \`this.normalizeAddress(x)\` to \`normalizeAddress(x)\`; private method removed (~14 lines).
- \`fork/api.ts\` — \`getAccount\`, \`getAccountResource\`, \`getAccountResources\` now call \`normalizeAddressShort(x)\` instead of the three identical inline patterns.

### \`refactor(fork): route storage filename sanitization through isHexAddress\`
- \`fork/storage.ts:sanitizeAddressForFilename\` now validates via \`isHexAddress\` (length 1–64 hex, optional \`0x\`) instead of its private regex. Defense-in-depth path-traversal check preserved.
- **Strictness change documented**: addresses with more than 64 hex chars now throw at validation time instead of producing a runaway filename. Consistent with the 32-byte address limit in Aptos/Movement protocol. Current fixtures use short addresses (\`0x1\`–\`0x3\`, \`0x123\`, etc.) — no test impact.

## DoD verification (#77)

\`\`\`bash
$ grep -RnE "toLowerCase\\(\\)\\.startsWith\\('0x'\\)" packages/movehat/src/fork
# (empty)

$ grep -n "private normalizeAddress" packages/movehat/src/fork/manager.ts
# (empty)

$ grep -RnE "padStart\\(64" packages/movehat/src/fork/
# (empty — pad logic lives only in utils/address.ts now)
\`\`\`

All three DoD greps return empty. Public \`ForkManager\` / \`MovementApiClient\` signatures unchanged.

## How was this tested?

- **Unit tests**: \`pnpm --filter movehat test\` → **159/159 passing** (no regression).
- **Type check**: \`pnpm --filter movehat exec tsc --noEmit\` → clean.
- **Fast example gate** (mechanical): \`pnpm check:example\` → builds movehat + \`tsc --noEmit\` over counter-example, both exit 0. Pre-push hook auto-verified this on push.
- **Runtime gate** (manual, per CLAUDE.md §6.2 because this touches \`fork/*.ts\`): \`pnpm test:example\` → **6 passing, 6 failing**. The 6 passing exercise the fork code path I refactored (\`Counter.test.ts\`, \`greeting.test.ts\`, \`greeting-fork.test.ts\`). The 6 failing are all \`message.test.ts\`, with \`Hex string is too short\` errors from the Aptos SDK on the testnet flow.

  **Pre-existing breakage, NOT introduced by this PR.** Verified by running the same suite on \`develop\` before applying these changes — identical 6/6 split, identical error messages. The fork code path my PR refactors works end-to-end. The \`setupTestEnvironment\` testnet flow that \`message.test.ts\` uses was already broken on \`develop\`. Tracked separately in **#86**.

## Checklist

- [x] \`pnpm test\` passes locally (159/159)
- [x] \`pnpm check:example\` passes (mechanical gate)
- [x] \`pnpm test:example\` runtime gate — fork-related tests pass; pre-existing message.test.ts failures tracked in #86. This PR neither introduced nor masks them.
- [x] CHANGELOG \`[Unreleased]\` — N/A (internal refactor, no public surface change)
- [x] Conventional Commits used (2 commits)

## What's NOT done (intentional)

- Did not fix \`message.test.ts\` — out of scope for an address-normalization refactor. Tracked in #86 with the discovery context.
- Did not touch \`runtime.ts\`, \`helpers/setupLocalTesting\`, \`commands/\`, or anything outside \`fork/\`. Other M1 sub-PRs cover those.

## Next

After merge to \`develop\`: M1.3 (#78) — migrate the 8 \`exec\`/\`spawn\` callsites to \`runCli\`. Higher risk because it touches the publish path that handles private keys. The mechanical gate from #84 will catch any surface break, but the runtime gate becomes more important since M1.3 changes how CLI processes are spawned.