### PR TITLE
docs: backfill ROADMAP progress + add rule (CLAUDE.md §7) keeping it in sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,24 @@ movehat/src/*  →  example uses it  →  README + docs describe it
 
 If a sub-PR breaks the example, fix it in the same sub-PR. The example is part of the entregable, not a separate concern. CI enforcement of the runtime gate is M4 work; auto-generated docs are M5; until then the typecheck gate is mechanical and the rest is honor-system but mandatory.
 
+## 7. Keep ROADMAP.md in Sync with Reality
+
+**Every sub-PR that lands a roadmap milestone item must update `ROADMAP.md` in the same PR — never in a follow-up.**
+
+The rule:
+
+- Tick off `- [ ]` → `- [x]` for every DoD bullet the PR satisfies. If a bullet is partially satisfied (e.g. "M1.4 finishes the rest"), annotate inline with the dependent sub-issue rather than leaving it ambiguous.
+- Update the milestone's sub-PR table:
+  - Add a `✅` to the Status column when the row's work merges.
+  - Append the shipped PR number to the row (e.g. `(shipped in PR #87)`).
+  - If a milestone got split mid-flight into sub-PRs (e.g. M1.3 → M1.3a + M1.3b + M1.3c), record the split in the table when the split is decided, not after.
+- Update the milestone header line itself (`### MX — …`) with `— ✅ shipped in PR #N` when every DoD bullet flips to `[x]`. That gives a one-line scan view of milestone-level progress.
+- For items mechanically impossible to satisfy (e.g. "CI green" while GitHub Actions are paused), use `[N/A]` plus a one-line reason rather than leaving them unchecked indefinitely.
+
+Why this matters: without this rule, the ROADMAP drifts from reality. M0 + M1.1 + M1.2 + M1.3a shipped before this rule was written, and every DoD bullet for those milestones was still `- [ ]` weeks later — making the ROADMAP useless as a status view and forcing readers to cross-reference issues and PR titles to know what's done.
+
+How to apply: when finalizing a sub-PR (before pushing), grep the ROADMAP for the milestone you just touched, and check off every bullet the PR satisfies. If you're unsure whether a bullet is satisfied, ask in the PR description rather than guessing.
+
 ---
 
 ## Project-Specific Context

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,20 +33,20 @@ This roadmap organizes the next phase of Movehat development. Each milestone has
 
 Each milestone below lists **explicit, mechanically verifiable** acceptance criteria. The criteria use exact file paths, command outputs, and CLI invocations so progress is unambiguous.
 
-### M0 — Repository housekeeping (~1.5 days, issue #67)
+### M0 — Repository housekeeping (~1.5 days, issue #67) — ✅ shipped in PR #75
 
 **Goal**: Bring the repo to standard open-source hygiene.
 
 **Definition of Done**:
-- [ ] `LICENSE` (MIT) at repo root
-- [ ] `SECURITY.md` at repo root with disclosure policy and contact
-- [ ] `CHANGELOG.md` (Keep-a-Changelog) with `[Unreleased]` section
-- [ ] `.github/ISSUE_TEMPLATE/{bug,feature,question}.md` + `config.yml`
-- [ ] `.github/PULL_REQUEST_TEMPLATE.md`
-- [ ] `commitlint` + `@commitlint/config-conventional` installed; `commitlint.config.js` extends conventional preset
-- [ ] husky `commit-msg` hook calls `commitlint --edit "$1"`
-- [ ] `git commit -m "test"` is **rejected** by the local hook; `git commit -m "chore: test"` is accepted
-- [ ] CI green after PR lands
+- [x] `LICENSE` (MIT) at repo root
+- [x] `SECURITY.md` at repo root with disclosure policy and contact
+- [x] `CHANGELOG.md` (Keep-a-Changelog) with `[Unreleased]` section
+- [x] `.github/ISSUE_TEMPLATE/{bug,feature,question}.md` + `config.yml`
+- [x] `.github/PULL_REQUEST_TEMPLATE.md`
+- [x] `commitlint` + `@commitlint/config-conventional` installed; `commitlint.config.cjs` extends conventional preset
+- [x] husky `commit-msg` hook calls `commitlint --edit "$1"`
+- [x] `git commit -m "test"` is **rejected** by the local hook; `git commit -m "chore: test"` is accepted
+- [N/A] CI green after PR lands — GitHub Actions paused by user; security checks (GitGuardian, Socket, CodeRabbit) green
 
 ### M1 — Testability refactors (~5 days, issue #68)
 
@@ -54,28 +54,29 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 
 **Sub-issues** (each is a separate PR. Execution order: M1.2 → M1.3 → M1.4 → M1.5 in serial — M1.4 and M1.5 both rewrite `runtime.ts` and would collide if run in parallel. M1.6 may parallelize with M1.4 or M1.5 because it touches `core/config.ts` and an isolated return signature. M1.7 may run at any time.):
 
-| Sub-PR | Issue | Focus | Closes |
-|--------|-------|-------|--------|
-| **M1.1** | (shipped in PR #76) | `utils/runCli.ts`, `utils/childProcessAdapter.ts`, `utils/address.ts` + tests; no migration | foundations |
-| M1.2 | [#77](https://github.com/gilbertsahumada/movehat/issues/77) | Migrate `fork/{manager,api,storage}.ts` to `utils/address.ts` | [#56](https://github.com/gilbertsahumada/movehat/issues/56) |
-| M1.3a | [#88](https://github.com/gilbertsahumada/movehat/issues/88) | Extend `ChildProcessAdapter` with `spawn()` + `inheritStdio` (foundations for M1.3 migration) | foundations |
-| M1.3b | [#78](https://github.com/gilbertsahumada/movehat/issues/78) | Migrate the 8 `exec`/`spawn` callsites to `runCli` using M1.3a foundations | [#58](https://github.com/gilbertsahumada/movehat/issues/58), completes [#43](https://github.com/gilbertsahumada/movehat/issues/43) |
-| M1.4 | [#79](https://github.com/gilbertsahumada/movehat/issues/79) | Extract `core/Publisher.ts` + per-deploy temp dir + SIGINT handler | [#19](https://github.com/gilbertsahumada/movehat/issues/19), [#36](https://github.com/gilbertsahumada/movehat/issues/36), [#37](https://github.com/gilbertsahumada/movehat/issues/37), [#38](https://github.com/gilbertsahumada/movehat/issues/38), [#53](https://github.com/gilbertsahumada/movehat/issues/53) |
-| M1.5 | [#80](https://github.com/gilbertsahumada/movehat/issues/80) | Remove `cachedRuntime` and the three `setupLocalTesting` singletons | [#21](https://github.com/gilbertsahumada/movehat/issues/21), [#55](https://github.com/gilbertsahumada/movehat/issues/55) |
-| M1.6 | [#81](https://github.com/gilbertsahumada/movehat/issues/81) | `loadUserConfig` mtime cache + `switchNetwork` returns runtime | [#46](https://github.com/gilbertsahumada/movehat/issues/46), [#62](https://github.com/gilbertsahumada/movehat/issues/62) |
-| M1.7 | [#82](https://github.com/gilbertsahumada/movehat/issues/82) | Strict types audit (`any`, `!`, `noUncheckedIndexedAccess`) | [#57](https://github.com/gilbertsahumada/movehat/issues/57) |
+| Status | Sub-PR | Issue | Focus | Closes |
+|---|---|---|---|---|
+| ✅ | M1.1 | (shipped in PR #76) | `utils/runCli.ts`, `utils/childProcessAdapter.ts`, `utils/address.ts` + tests; no migration | foundations |
+| ✅ | M1.2 | [#77](https://github.com/gilbertsahumada/movehat/issues/77) (shipped in PR #87) | Migrate `fork/{manager,api,storage}.ts` to `utils/address.ts` | [#56](https://github.com/gilbertsahumada/movehat/issues/56) |
+| ✅ | M1.3a | [#88](https://github.com/gilbertsahumada/movehat/issues/88) (shipped in PR #89) | Extend `ChildProcessAdapter` with `spawn()` + `inheritStdio` (foundations for M1.3 migration) | foundations |
+| ⏳ | M1.3b | [#90](https://github.com/gilbertsahumada/movehat/issues/90) | Migrate 6 simple callsites (`commands/{run,test,update,compile}`, `helpers/move-tests`, `fork/test`) to `runCli` | (partial of [#58](https://github.com/gilbertsahumada/movehat/issues/58)) |
+| ⏳ | M1.3c | [#78](https://github.com/gilbertsahumada/movehat/issues/78) | Migrate `runtime.ts` publish + `node/LocalNodeManager.ts` daemon + stderr-redaction unit test | completes [#58](https://github.com/gilbertsahumada/movehat/issues/58), completes [#43](https://github.com/gilbertsahumada/movehat/issues/43) |
+| ⏳ | M1.4 | [#79](https://github.com/gilbertsahumada/movehat/issues/79) | Extract `core/Publisher.ts` + per-deploy temp dir + SIGINT handler | [#19](https://github.com/gilbertsahumada/movehat/issues/19), [#36](https://github.com/gilbertsahumada/movehat/issues/36), [#37](https://github.com/gilbertsahumada/movehat/issues/37), [#38](https://github.com/gilbertsahumada/movehat/issues/38), [#53](https://github.com/gilbertsahumada/movehat/issues/53) |
+| ⏳ | M1.5 | [#80](https://github.com/gilbertsahumada/movehat/issues/80) | Remove `cachedRuntime` and the three `setupLocalTesting` singletons | [#21](https://github.com/gilbertsahumada/movehat/issues/21), [#55](https://github.com/gilbertsahumada/movehat/issues/55) |
+| ⏳ | M1.6 | [#81](https://github.com/gilbertsahumada/movehat/issues/81) | `loadUserConfig` mtime cache + `switchNetwork` returns runtime | [#46](https://github.com/gilbertsahumada/movehat/issues/46), [#62](https://github.com/gilbertsahumada/movehat/issues/62) |
+| ⏳ | M1.7 | [#82](https://github.com/gilbertsahumada/movehat/issues/82) | Strict types audit (`any`, `!`, `noUncheckedIndexedAccess`) | [#57](https://github.com/gilbertsahumada/movehat/issues/57) |
 
 **Definition of Done** (rolled up from the sub-issues):
-- [ ] `packages/movehat/src/utils/runCli.ts` exists; replaces all direct `exec`/`spawn` callers
-- [ ] `packages/movehat/src/utils/childProcessAdapter.ts` exists with injectable interface
-- [ ] `packages/movehat/src/utils/address.ts` exists; replaces ad-hoc normalization in `fork/manager.ts`, `fork/storage.ts`, `fork/api.ts`
-- [ ] `packages/movehat/src/core/Publisher.ts` exists; `runtime.deployContract` is a thin orchestrator over it
-- [ ] `grep -R "cachedRuntime\|currentForkServer\|currentForkManager\|currentLocalNode" packages/movehat/src` returns **no matches**
-- [ ] `loadUserConfig` cache by `path + mtimeMs` (no per-call module loader churn)
-- [ ] Two parallel `deployContract` calls do **not** corrupt `~/.aptos/config.yaml` or `Move.toml`
-- [ ] SIGINT during deploy leaves no private key on disk
-- [ ] All previously passing 119 tests still green; new unit tests for `runCli`, `address`, `Publisher`
-- [ ] `examples/counter-example/` keeps passing through every sub-PR (per Decision 6)
+- [x] `packages/movehat/src/utils/runCli.ts` exists (M1.1, #76) — replaces all direct `exec`/`spawn` callers ⏳ pending M1.3b/M1.3c
+- [x] `packages/movehat/src/utils/childProcessAdapter.ts` exists with injectable interface (M1.1, #76) — extended with `spawn()` + `inheritStdio` in M1.3a (#89)
+- [x] `packages/movehat/src/utils/address.ts` exists; replaces ad-hoc normalization in `fork/manager.ts`, `fork/storage.ts`, `fork/api.ts` (M1.2, #87)
+- [ ] `packages/movehat/src/core/Publisher.ts` exists; `runtime.deployContract` is a thin orchestrator over it — pending M1.4 (#79)
+- [ ] `grep -R "cachedRuntime\|currentForkServer\|currentForkManager\|currentLocalNode" packages/movehat/src` returns **no matches** — pending M1.5 (#80)
+- [ ] `loadUserConfig` cache by `path + mtimeMs` (no per-call module loader churn) — pending M1.6 (#81)
+- [ ] Two parallel `deployContract` calls do **not** corrupt `~/.aptos/config.yaml` or `Move.toml` — pending M1.4 (#79)
+- [ ] SIGINT during deploy leaves no private key on disk — pending M1.4 (#79)
+- [x] All previously passing 119 tests still green; new unit tests for `runCli`, `address` — `Publisher` tests pending M1.4 (currently **169/169** on develop)
+- [x] `examples/counter-example/` keeps passing through every sub-PR (per Decision 6) — mechanical typecheck gate enforced by pre-push since PR #84; runtime gate baseline 6/6 maintained (pre-existing #86 fails unrelated)
 
 ### M2 — Hardhat-style Harness API (~6 days, issue #69)
 


### PR DESCRIPTION
## Summary

Pure docs/tooling PR. Backfills the ROADMAP progress that should have been ticked along the way (M0 + M1.1 + M1.2 + M1.3a are all merged but every DoD bullet was still \`- [ ]\`), and adds a rule to CLAUDE.md to close the loop going forward.

User flagged the drift directly: *"¿por qué no se ha ido marcando nada en el ROADMAP.md como done a medida que avanzamos?"*

## Type of change

- [x] Docs / chore / tooling

## ROADMAP.md updates

**M0 — Repository housekeeping (#67, PR #75)**
- Header annotated: \`— ✅ shipped in PR #75\`.
- All 8 DoD bullets ticked. The "CI green after PR lands" bullet marked \`[N/A]\` because GitHub Actions were paused by the user shortly after M0 landed; security checks (GitGuardian, Socket, CodeRabbit) have stayed green and are the de-facto gate.

**M1 sub-PR table**
- New \`Status\` column with ✅ / ⏳ indicators.
- ✅ M1.1 (shipped in PR #76), ✅ M1.2 (shipped in PR #87), ✅ M1.3a (shipped in PR #89).
- M1.3 row split into M1.3b (#90 — the simple callsites batch we're about to ship) and M1.3c (#78 re-scoped to \`runtime.ts\` publish + \`LocalNodeManager\` + redaction test). The split happened mid-flight when M1.3 turned out to span three distinct invocation patterns; recording it here so the table stays load-bearing.

**M1 rolled-up DoD**
- \`utils/runCli.ts\`, \`utils/childProcessAdapter.ts\`, \`utils/address.ts\` rows ticked with shipped PRs noted inline.
- The \`runCli\` row carries \`⏳ pending M1.3b/M1.3c\` because while the file exists, "replaces all direct exec/spawn callers" isn't done yet.
- The remaining bullets (Publisher, singletons, mtime cache, SIGINT, parallel safety) are unticked with explicit \`pending M1.x (#N)\` annotations.
- The "All previously passing tests still green" row is ticked with the current count (\`169/169\`).
- The \`examples/counter-example\` row is ticked with a note that the mechanical typecheck gate has been enforced since PR #84.

## CLAUDE.md update

New **§7 — Keep ROADMAP.md in Sync with Reality**:

> Every sub-PR that lands a roadmap milestone item must update \`ROADMAP.md\` in the same PR — never in a follow-up. Tick DoD bullets, append shipped PR numbers to the sub-PR table, update the milestone header when every bullet flips to \`[x]\`, and use \`[N/A]\` (with a reason) for mechanically impossible bullets.

The rule cites the exact drift this PR is fixing as the rationale, so future readers understand why it exists.

## How was this tested?

- \`pnpm --filter movehat test\` → 169/169 (unchanged, no source code touched).
- \`pnpm check:example\` → exit 0 (auto-verified by pre-push hook on this branch's push).
- \`pnpm test:example\` — N/A — pure docs, no \`packages/movehat/src\` touched.

## Sub-issue tracking

- Opened **#90** (M1.3b) before pushing this PR so the new ROADMAP row links validly. #90's body documents the M1.3a / M1.3b / M1.3c split. #78 remains the M1.3c tracking issue and will be re-scoped via comment when M1.3c starts (separate from this PR).

## Checklist

- [x] \`pnpm test\` passes locally (169/169)
- [x] \`pnpm check:example\` passes (pre-push verified)
- [x] \`pnpm test:example\` — N/A (no source code changes)
- [x] CHANGELOG \`[Unreleased]\` — N/A (pure docs/tooling)
- [x] Conventional Commits used (1 commit)