### PR TITLE
refactor: M1.3b migrate 6 simple callsites to runCli

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,7 +59,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 | ✅ | M1.1 | (shipped in PR #76) | `utils/runCli.ts`, `utils/childProcessAdapter.ts`, `utils/address.ts` + tests; no migration | foundations |
 | ✅ | M1.2 | [#77](https://github.com/gilbertsahumada/movehat/issues/77) (shipped in PR #87) | Migrate `fork/{manager,api,storage}.ts` to `utils/address.ts` | [#56](https://github.com/gilbertsahumada/movehat/issues/56) |
 | ✅ | M1.3a | [#88](https://github.com/gilbertsahumada/movehat/issues/88) (shipped in PR #89) | Extend `ChildProcessAdapter` with `spawn()` + `inheritStdio` (foundations for M1.3 migration) | foundations |
-| ⏳ | M1.3b | [#90](https://github.com/gilbertsahumada/movehat/issues/90) | Migrate 6 simple callsites (`commands/{run,test,update,compile}`, `helpers/move-tests`, `fork/test`) to `runCli` | (partial of [#58](https://github.com/gilbertsahumada/movehat/issues/58)) |
+| ✅ | M1.3b | [#90](https://github.com/gilbertsahumada/movehat/issues/90) (shipped in PR #92) | Migrate 6 simple callsites (`commands/{run,test,update,compile}`, `helpers/move-tests`, `fork/test`) to `runCli` | (partial of [#58](https://github.com/gilbertsahumada/movehat/issues/58)) |
 | ⏳ | M1.3c | [#78](https://github.com/gilbertsahumada/movehat/issues/78) | Migrate `runtime.ts` publish + `node/LocalNodeManager.ts` daemon + stderr-redaction unit test | completes [#58](https://github.com/gilbertsahumada/movehat/issues/58), completes [#43](https://github.com/gilbertsahumada/movehat/issues/43) |
 | ⏳ | M1.4 | [#79](https://github.com/gilbertsahumada/movehat/issues/79) | Extract `core/Publisher.ts` + per-deploy temp dir + SIGINT handler | [#19](https://github.com/gilbertsahumada/movehat/issues/19), [#36](https://github.com/gilbertsahumada/movehat/issues/36), [#37](https://github.com/gilbertsahumada/movehat/issues/37), [#38](https://github.com/gilbertsahumada/movehat/issues/38), [#53](https://github.com/gilbertsahumada/movehat/issues/53) |
 | ⏳ | M1.5 | [#80](https://github.com/gilbertsahumada/movehat/issues/80) | Remove `cachedRuntime` and the three `setupLocalTesting` singletons | [#21](https://github.com/gilbertsahumada/movehat/issues/21), [#55](https://github.com/gilbertsahumada/movehat/issues/55) |
@@ -67,7 +67,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 | ⏳ | M1.7 | [#82](https://github.com/gilbertsahumada/movehat/issues/82) | Strict types audit (`any`, `!`, `noUncheckedIndexedAccess`) | [#57](https://github.com/gilbertsahumada/movehat/issues/57) |
 
 **Definition of Done** (rolled up from the sub-issues):
-- [x] `packages/movehat/src/utils/runCli.ts` exists (M1.1, #76) — replaces all direct `exec`/`spawn` callers ⏳ pending M1.3b/M1.3c
+- [x] `packages/movehat/src/utils/runCli.ts` exists (M1.1, #76) — replaces all direct `exec`/`spawn` callers ⏳ partial: 6 of 8 sites migrated in M1.3b (#92); `runtime.ts` + `LocalNodeManager.ts` pending M1.3c (#78)
 - [x] `packages/movehat/src/utils/childProcessAdapter.ts` exists with injectable interface (M1.1, #76) — extended with `spawn()` + `inheritStdio` in M1.3a (#89)
 - [x] `packages/movehat/src/utils/address.ts` exists; replaces ad-hoc normalization in `fork/manager.ts`, `fork/storage.ts`, `fork/api.ts` (M1.2, #87)
 - [ ] `packages/movehat/src/core/Publisher.ts` exists; `runtime.deployContract` is a thin orchestrator over it — pending M1.4 (#79)

--- a/packages/movehat/src/commands/compile.ts
+++ b/packages/movehat/src/commands/compile.ts
@@ -189,8 +189,9 @@ async function runMovementBuild(
   args: readonly string[],
   cwd: string
 ): Promise<void> {
-  // runCli throws CliExecutionError on non-zero exit, which is what the
-  // outer catch in compileMove() turns into a "Compilation failed" message.
+  // Use throwOnNonZeroExit:false so we can log stdout/stderr in both
+  // success and failure paths, matching the behavior of the previous
+  // exec-based helper.
   const result = await runCli(
     {
       command: "movement",
@@ -198,10 +199,15 @@ async function runMovementBuild(
       cwd,
       timeoutMs: 120000, // 2 minutes for git dependency downloads
     },
-    { throwOnNonZeroExit: true }
+    { throwOnNonZeroExit: false }
   );
+
   if (result.stdout) console.log(result.stdout.trim());
   if (result.stderr) console.error(result.stderr.trim());
+
+  if (result.exitCode !== 0) {
+    throw new Error(`movement move build exited with code ${result.exitCode}`);
+  }
 }
 
 /**

--- a/packages/movehat/src/commands/compile.ts
+++ b/packages/movehat/src/commands/compile.ts
@@ -1,9 +1,9 @@
 import fs from "fs";
 import path from "path";
-import { exec } from "child_process";
 import { loadUserConfig } from "../core/config.js";
-import { validateAndEscapePath, escapeShellArg } from "../core/shell.js";
+import { validatePathSafety } from "../core/shell.js";
 import { logger } from "../ui/index.js";
+import { runCli } from "../utils/runCli.js";
 
 /**
  * Recursively find all .move files in a directory
@@ -185,22 +185,23 @@ export function updateMoveToml(moveDir: string, detectedAddresses: Set<string>):
   return missingAddresses;
 }
 
-function run(command: string, cwd: string) {
-  return new Promise<void>((resolve, reject) => {
-    exec(command, {
+async function runMovementBuild(
+  args: readonly string[],
+  cwd: string
+): Promise<void> {
+  // runCli throws CliExecutionError on non-zero exit, which is what the
+  // outer catch in compileMove() turns into a "Compilation failed" message.
+  const result = await runCli(
+    {
+      command: "movement",
+      args,
       cwd,
-      timeout: 120000, // 2 minutes for git dependency downloads
-      maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large outputs
-    }, (error, stdout, stderr) => {
-      if (stdout) console.log(stdout.trim());
-      if (stderr) console.error(stderr.trim());
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
+      timeoutMs: 120000, // 2 minutes for git dependency downloads
+    },
+    { throwOnNonZeroExit: true }
+  );
+  if (result.stdout) console.log(result.stdout.trim());
+  if (result.stderr) console.error(result.stderr.trim());
 }
 
 /**
@@ -233,8 +234,9 @@ export default async function compileCommand() {
       process.exit(1);
     }
 
-    // Validate and escape to prevent command injection
-    const safeMoveDir = validateAndEscapePath(moveDir, "Move directory");
+    // Validate the move directory before passing it to the child process.
+    // No shell escaping needed — runCli uses spawn-with-args, not exec.
+    const safeMoveDir = validatePathSafety(moveDir, "Move directory");
 
     // Auto-detect named addresses from Move files
     const detectedAddresses = extractNamedAddresses(moveDir);
@@ -257,11 +259,10 @@ export default async function compileCommand() {
       }
     }
 
-    let namedAddressesArg = "";
+    let namedAddressesValue = "";
 
     if (Object.keys(namedAddresses).length > 0) {
-      // Validate and escape each address name and value
-      const escapedAddresses = Object.entries(namedAddresses)
+      namedAddressesValue = Object.entries(namedAddresses)
         .map(([k, v]) => {
           // Validate address name (alphanumeric, underscore only)
           if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(k)) {
@@ -279,15 +280,15 @@ export default async function compileCommand() {
             );
           }
 
-          // No need to escape since we validated the format
           return `${k}=${v}`;
         })
         .join(",");
-
-      namedAddressesArg = `--named-addresses ${escapeShellArg(escapedAddresses)}`;
     }
 
-    const command = `movement move build --package-dir ${safeMoveDir} ${namedAddressesArg}`.trim();
+    const args: string[] = ["move", "build", "--package-dir", safeMoveDir];
+    if (namedAddressesValue) {
+      args.push("--named-addresses", namedAddressesValue);
+    }
 
     logger.kv('Move directory', moveDir, 2);
     if (detectedAddresses.size > 0) {
@@ -301,7 +302,7 @@ export default async function compileCommand() {
     }
     logger.newline();
 
-    await run(command, moveDir);
+    await runMovementBuild(args, moveDir);
 
     logger.newline();
     logger.success('Compilation finished successfully');

--- a/packages/movehat/src/commands/run.ts
+++ b/packages/movehat/src/commands/run.ts
@@ -1,8 +1,8 @@
-import { spawn } from "child_process";
 import { resolve, extname, dirname, join } from "path";
 import { existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
+import { runCli } from "../utils/runCli.js";
 
 export default async function runCommand(scriptPath: string) {
   if (!scriptPath) {
@@ -79,21 +79,23 @@ export default async function runCommand(scriptPath: string) {
   }
 
   // Execute script with tsx (handles both .ts and .js files)
-  // Using 'node' to execute tsx for cross-platform compatibility
-  const child = spawn("node", [tsxPath, fullPath], {
-    stdio: "inherit",
-    env: {
-      ...process.env,
-      // MH_CLI_NETWORK is already set by the CLI hook
-    },
-  });
-
-  child.on("exit", (code) => {
-    process.exit(code || 0);
-  });
-
-  child.on("error", (error) => {
-    console.error(`❌ Failed to execute script: ${error.message}`);
+  // Using 'node' to execute tsx for cross-platform compatibility.
+  try {
+    const result = await runCli(
+      {
+        command: "node",
+        args: [tsxPath, fullPath],
+        env: {
+          ...process.env,
+          // MH_CLI_NETWORK is already set by the CLI hook
+        },
+        inheritStdio: true,
+      },
+      { throwOnNonZeroExit: false }
+    );
+    process.exit(result.exitCode || 0);
+  } catch (error) {
+    console.error(`❌ Failed to execute script: ${(error as Error).message}`);
     process.exit(1);
-  });
+  }
 }

--- a/packages/movehat/src/commands/test.ts
+++ b/packages/movehat/src/commands/test.ts
@@ -1,9 +1,9 @@
-import { spawn } from "child_process";
 import { join } from "path";
 import { existsSync } from "fs";
 import prompts from "prompts";
 import { runMoveTests } from "../helpers/move-tests.js";
 import { logger, colors, symbols } from "../ui/index.js";
+import { runCli } from "../utils/runCli.js";
 
 interface TestOptions {
   move?: boolean;
@@ -194,57 +194,69 @@ async function runAllTests(filter?: string): Promise<void> {
 /**
  * Run TypeScript tests using Mocha
  */
-function runTypeScriptTests(watch: boolean = false): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const testDir = join(process.cwd(), "tests");
+async function runTypeScriptTests(watch: boolean = false): Promise<void> {
+  const testDir = join(process.cwd(), "tests");
 
-    if (!existsSync(testDir)) {
-      console.log(`${colors.muted(symbols.info)} No TypeScript tests found ${colors.muted("(tests/ directory not found)")}`);
-      console.log(`   ${colors.muted("Skipping TypeScript tests...")}`);
-      logger.newline();
-      resolve();
-      return;
-    }
+  if (!existsSync(testDir)) {
+    console.log(`${colors.muted(symbols.info)} No TypeScript tests found ${colors.muted("(tests/ directory not found)")}`);
+    console.log(`   ${colors.muted("Skipping TypeScript tests...")}`);
+    logger.newline();
+    return;
+  }
 
-    const mochaPath = join(process.cwd(), "node_modules", ".bin", "mocha");
+  const mochaPath = join(process.cwd(), "node_modules", ".bin", "mocha");
 
-    if (!existsSync(mochaPath)) {
-      logger.error("Mocha not found in project dependencies");
-      console.log(`   ${colors.muted("Install it with:")} ${colors.info("npm install --save-dev mocha")}`);
-      reject(new Error("Mocha not found"));
-      return;
-    }
+  if (!existsSync(mochaPath)) {
+    logger.error("Mocha not found in project dependencies");
+    console.log(`   ${colors.muted("Install it with:")} ${colors.info("npm install --save-dev mocha")}`);
+    throw new Error("Mocha not found");
+  }
 
-    const args = watch ? ["--watch"] : [];
+  const args = watch ? ["--watch"] : [];
 
-    const child = spawn(mochaPath, args, {
-      stdio: "inherit",
-      env: {
-        ...process.env,
+  // Watch mode: Mocha never exits. We fire-and-forget runCli so it owns the
+  // terminal until the user Ctrl+Cs the parent (which kills the child via
+  // inherited stdio). Attach .catch so a spawn-time failure doesn't become
+  // an unhandled rejection.
+  if (watch) {
+    runCli(
+      {
+        command: mochaPath,
+        args,
+        env: { ...process.env },
+        inheritStdio: true,
       },
+      { throwOnNonZeroExit: false }
+    ).catch((error) => {
+      logger.error(`Mocha watch crashed: ${(error as Error).message}`);
+      process.exit(1);
     });
 
-    // In watch mode, Mocha never exits, so resolve immediately
-    if (watch) {
-      console.log(`${colors.info(symbols.info)} Watch mode active. Press Ctrl+C to exit.`);
-      logger.newline();
-      resolve();
-      return;
-    }
+    console.log(`${colors.info(symbols.info)} Watch mode active. Press Ctrl+C to exit.`);
+    logger.newline();
+    return;
+  }
 
-    // Non-watch mode: wait for exit
-    child.on("exit", (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        const exitCode = typeof code === "number" ? code : 1;
-        reject(new Error(`TypeScript tests failed with exit code ${exitCode}`));
-      }
-    });
+  // Non-watch mode: await the run, surface the exit code as a thrown error
+  // so the orchestrator above can summarize the failure.
+  let result;
+  try {
+    result = await runCli(
+      {
+        command: mochaPath,
+        args,
+        env: { ...process.env },
+        inheritStdio: true,
+      },
+      { throwOnNonZeroExit: false }
+    );
+  } catch (error) {
+    logger.error(`Failed to run TypeScript tests: ${(error as Error).message}`);
+    throw error;
+  }
 
-    child.on("error", (error) => {
-      logger.error(`Failed to run TypeScript tests: ${error.message}`);
-      reject(error);
-    });
-  });
+  if (result.exitCode === 0) {
+    return;
+  }
+  throw new Error(`TypeScript tests failed with exit code ${result.exitCode}`);
 }

--- a/packages/movehat/src/commands/update.ts
+++ b/packages/movehat/src/commands/update.ts
@@ -1,4 +1,3 @@
-import { spawn } from "child_process";
 import { readFileSync, existsSync } from "fs";
 import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
@@ -7,6 +6,7 @@ import prompts from "prompts";
 import { isNewerVersion } from "../helpers/semver-utils.js";
 import { fetchLatestVersion } from "../helpers/npm-registry.js";
 import { logger, withSpinner, box, colors } from "../ui/index.js";
+import { runCli } from "../utils/runCli.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -159,35 +159,38 @@ export default async function updateCommand() {
         break;
     }
 
-    // Execute update
-    // Use home directory as cwd to avoid packageManager conflicts from local package.json
-    const child = spawn(packageManager, updateArgs, {
-      stdio: "inherit",
-      cwd: homedir() || process.cwd(),
-    });
+    // Execute update.
+    // Use home directory as cwd to avoid packageManager conflicts from local package.json.
+    try {
+      const result = await runCli(
+        {
+          command: packageManager,
+          args: updateArgs,
+          cwd: homedir() || process.cwd(),
+          inheritStdio: true,
+        },
+        { throwOnNonZeroExit: false }
+      );
 
-    child.on("exit", (code) => {
-      if (code === 0) {
+      if (result.exitCode === 0) {
         logger.newline();
         logger.success(`Successfully updated to version ${latestVersion}!`);
         logger.newline();
         process.exit(0);
       } else {
         logger.newline();
-        logger.error('Update failed');
+        logger.error("Update failed");
         logger.plain(`   Try manually: ${packageManager} ${updateArgs.join(" ")}`);
         logger.newline();
         process.exit(1);
       }
-    });
-
-    child.on("error", (error) => {
+    } catch (error) {
       logger.newline();
-      logger.error(`Failed to update: ${error.message}`);
+      logger.error(`Failed to update: ${(error as Error).message}`);
       logger.plain(`   Try manually: ${packageManager} ${updateArgs.join(" ")}`);
       logger.newline();
       process.exit(1);
-    });
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logger.newline();

--- a/packages/movehat/src/core/shell.ts
+++ b/packages/movehat/src/core/shell.ts
@@ -16,19 +16,20 @@ export function escapeShellArg(arg: string): string {
 }
 
 /**
- * Validates that a path is safe (no command injection characters)
- * and returns the escaped version
+ * Validates that a path is safe (no command injection characters) and
+ * returns it unchanged. Use this for callers that pass paths to spawn-with-
+ * args (no shell), where shell quoting would be incorrect.
  *
- * @param path - The path to validate and escape
+ * @param path - The path to validate
  * @param name - Name for error messages (e.g., "package directory")
- * @returns The escaped path safe for shell execution
+ * @returns The original path, after validation
  */
-export function validateAndEscapePath(path: string, name: string = "path"): string {
+export function validatePathSafety(path: string, name: string = "path"): string {
   if (!path || typeof path !== "string") {
     throw new Error(`Invalid ${name}: must be a non-empty string`);
   }
 
-  // Check for obvious command injection attempts
+  // Check for obvious command injection attempts.
   const dangerousChars = /[;&|`$(){}[\]<>]/;
   if (dangerousChars.test(path)) {
     throw new Error(
@@ -38,8 +39,20 @@ export function validateAndEscapePath(path: string, name: string = "path"): stri
     );
   }
 
-  // Escape for shell safety
-  return escapeShellArg(path);
+  return path;
+}
+
+/**
+ * Validates a path and returns the shell-escaped form. Wraps
+ * `validatePathSafety` for callers that pass paths into shell-style
+ * commands (e.g. `exec`).
+ *
+ * @param path - The path to validate and escape
+ * @param name - Name for error messages
+ * @returns The escaped path safe for shell execution
+ */
+export function validateAndEscapePath(path: string, name: string = "path"): string {
+  return escapeShellArg(validatePathSafety(path, name));
 }
 
 /**

--- a/packages/movehat/src/fork/test.ts
+++ b/packages/movehat/src/fork/test.ts
@@ -1,9 +1,6 @@
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { join } from 'path';
 import { existsSync } from 'fs';
-
-const execFileAsync = promisify(execFile);
+import { runCli } from '../utils/runCli.js';
 
 export interface SnapshotOptions {
   path?: string;
@@ -40,15 +37,17 @@ export async function snapshot(options: SnapshotOptions = {}): Promise<string> {
   console.log(`📸 Creating snapshot: ${name}...`);
 
   try {
-    // Initialize fork/snapshot using aptos CLI
-    // Use execFile with argument array to prevent command injection
-    const { stdout, stderr } = await execFileAsync('aptos', [
-      'move',
-      'sim',
-      'init',
-      '--path',
-      snapshotPath
-    ]);
+    // Initialize fork/snapshot using aptos CLI.
+    // runCli uses spawn-with-args under the hood (no shell), preventing
+    // command injection. Pass throwOnNonZeroExit:false so we can keep the
+    // existing "stderr-without-Success → throw" check intact.
+    const { stdout, stderr } = await runCli(
+      {
+        command: 'aptos',
+        args: ['move', 'sim', 'init', '--path', snapshotPath],
+      },
+      { throwOnNonZeroExit: false }
+    );
 
     if (stderr && !stderr.includes('Success')) {
       throw new Error(stderr);
@@ -125,18 +124,24 @@ export async function viewForkResource(
   resourceType: string
 ): Promise<any> {
   try {
-    // Use execFile with argument array to prevent command injection
-    const { stdout } = await execFileAsync('aptos', [
-      'move',
-      'sim',
-      'view-resource',
-      '--session',
-      sessionPath,
-      '--account',
-      account,
-      '--resource',
-      resourceType
-    ]);
+    // runCli uses spawn-with-args (no shell) to prevent command injection.
+    const { stdout } = await runCli(
+      {
+        command: 'aptos',
+        args: [
+          'move',
+          'sim',
+          'view-resource',
+          '--session',
+          sessionPath,
+          '--account',
+          account,
+          '--resource',
+          resourceType,
+        ],
+      },
+      { throwOnNonZeroExit: false }
+    );
 
     const result = JSON.parse(stdout);
 

--- a/packages/movehat/src/helpers/move-tests.ts
+++ b/packages/movehat/src/helpers/move-tests.ts
@@ -1,7 +1,7 @@
-import { spawn } from "child_process";
 import { existsSync } from "fs";
 import { resolve } from "path";
 import { loadUserConfig } from "../core/config.js";
+import { runCli } from "../utils/runCli.js";
 
 interface RunMoveTestsOptions {
   filter?: string;
@@ -44,25 +44,29 @@ export async function runMoveTests(options: RunMoveTestsOptions = {}): Promise<v
     args.push("--ignore-compile-warnings");
   }
 
-  return new Promise<void>((resolve, reject) => {
-    const child = spawn("movement", args, {
-      stdio: "inherit",
-      cwd: process.cwd(),
-    });
+  let result;
+  try {
+    result = await runCli(
+      {
+        command: "movement",
+        args,
+        cwd: process.cwd(),
+        inheritStdio: true,
+      },
+      { throwOnNonZeroExit: false }
+    );
+  } catch (error) {
+    // Spawn-time failure (ENOENT, etc.). The original code logged a
+    // Movement-CLI-install hint here; keep that.
+    console.error(`Failed to run Move tests: ${(error as Error).message}`);
+    console.error("   Make sure Movement CLI is installed");
+    throw error;
+  }
 
-    child.on("exit", (code) => {
-      if (code === 0) {
-        console.log("\n✓ Move tests passed");
-        resolve();
-      } else {
-        reject(new Error("Move tests failed"));
-      }
-    });
+  if (result.exitCode === 0) {
+    console.log("\n✓ Move tests passed");
+    return;
+  }
 
-    child.on("error", (error) => {
-      console.error(`Failed to run Move tests: ${error.message}`);
-      console.error("   Make sure Movement CLI is installed");
-      reject(error);
-    });
-  });
+  throw new Error("Move tests failed");
 }


### PR DESCRIPTION
## Summary

Migrates the 6 low-risk callsites from #78's original scope to \`runCli\` using the M1.3a foundations (#89). The 2 high-risk callsites (runtime.ts publish + LocalNodeManager daemon) plus the stderr-redaction unit test stay in #78, now re-scoped to M1.3c.

Closes #90.
Refs #78 (M1.3c remainder), #68 (M1 meta), partial of #58.

## Type of change

- [x] Refactor (internal — no public API change)

## What's in this PR

**3 commits:**

### \`refactor(commands,helpers): migrate Pattern B callsites to runCli with inheritStdio\`
Four interactive callsites with \`stdio: 'inherit'\` migrated to \`runCli({ inheritStdio: true }, { throwOnNonZeroExit: false })\`:
- \`commands/run.ts\` — spawns tsx, propagates exit code via \`process.exit\`.
- \`commands/test.ts\` — spawns mocha. **Watch mode** uses fire-and-forget \`runCli().catch()\` because Mocha never exits.
- \`commands/update.ts\` — spawns the package manager, logs success/failure.
- \`helpers/move-tests.ts\` — spawns \`movement move test\`; cleanly separates spawn-time errors from non-zero exit.

### \`refactor(commands,fork): migrate Pattern A callsites to runCli\`
Two one-shot capturing callsites migrated:
- \`commands/compile.ts\` — replaced the local shell-string \`run()\` helper with an args-array \`runMovementBuild()\` calling \`runCli\` directly.
- \`fork/test.ts\` — two \`execFile\` calls (\`aptos move sim init\` + view-resource) → \`runCli({ throwOnNonZeroExit: false })\`.

Also extracted \`validatePathSafety\` out of \`validateAndEscapePath\` in \`core/shell.ts\` — spawn-with-args needs validation without shell escaping. \`validateAndEscapePath\` keeps identical behavior for existing callers via composition.

### \`docs(roadmap): tick M1.3b shipped in PR #92\`
Per CLAUDE.md §7 (rule added in #91): mark M1.3b row ✅ in the M1 sub-PR table and annotate the rolled-up DoD that 6 of 8 callsites are now migrated.

## How was this tested?

- \`pnpm --filter movehat test\` → **169/169 passing** (unchanged from develop baseline).
- \`pnpm --filter movehat exec tsc --noEmit\` → clean.
- \`pnpm check:example\` → exit 0. Auto-verified by pre-push hook.
- \`pnpm test:example\` runtime gate → **6 passing / 6 failing**, same as develop. The 6 passing exercise fork + helpers code paths that this PR touches (Counter.test.ts, greeting.test.ts, greeting-fork.test.ts). The 6 failing are all \`message.test.ts\` and are pre-existing (#86) — confirmed unrelated to this PR.
- DoD grep: \`grep -RnE "node:child_process|'child_process'" packages/movehat/src | grep -v "/utils/"\` returns exactly 2 hits (runtime.ts, LocalNodeManager.ts) — the M1.3c scope.

## DoD coverage (#90)

- ✅ All 6 callsites use \`runCli\` (Pattern A) or \`runCli({ inheritStdio: true })\` (Pattern B).
- ✅ Imports of \`child_process\` removed from all 6 files.
- ✅ Grep reduced from 8 → 2 callsites (M1.3c closes the rest).
- ✅ 169/169 unit tests stay green.
- ✅ \`pnpm check:example\` exit 0.
- ✅ Runtime gate baseline (6/6) preserved.

## Checklist

- [x] \`pnpm test\` passes locally (169/169)
- [x] \`pnpm test:example\` passes — fork-related tests pass; pre-existing #86 failures unchanged
- [x] CHANGELOG \`[Unreleased]\` — N/A (internal refactor, no consumer-visible behavior change)
- [x] Conventional Commits used (3 commits)
- [x] ROADMAP updated per CLAUDE.md §7

## Next

M1.3c (#78): runtime.ts publish + LocalNodeManager + the stderr-redaction unit test on \`runtime.deployContract\`. That sub-PR finishes the migration and is the highest-risk one in M1 because it touches the private-key flow.