### PR TITLE
docs(claude): add §8 — Self-Review Before Merge — Unconditional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,14 +162,14 @@ The rule:
   - 🟡 worth fixing before merge (real concerns, fragile assumptions, deferred-but-noted)
   - 🟢 nits (style, naming, polish)
 - If the review surfaces **🔴 or 🟡** findings, either fix them on the same branch and post a resolution comment listing what was resolved vs deferred, or explicitly note in the resolution why a 🟡 is being deferred to a follow-up sub-PR.
-- Merge happens only after **(a)** review is posted, **(b)** 🟡-or-worse findings are resolved or explicitly deferred with a reason, **(c)** mergeable state is CLEAN.
+- Merge happens only after **(a)** review is posted, **(b)** 🟡-or-worse findings are resolved or explicitly deferred with a reason, **(c)** mergeable state is CLEAN, **(d)** install-verification gates from §6.2 / §6.3 have been run (or marked N/A in the PR body with reason).
 - Even "pure docs" / "single-line fix" / "obviously trivial" PRs go through this. The 30 seconds of forced re-reading catches dead links, terminology drift, misaligned tables, stale references, and assumption gaps that the author missed precisely because they thought the change was trivial.
 
 Why this matters: PRs #91 (ROADMAP backfill), #93 (install gate doc), and #94 (#86 fix) all merged without a self-review, each rationalized as "small / obvious / pure-docs". The retroactive review of #94 surfaced two real 🟡 items (duplicated derivation between `config.ts` and `runtime.ts:69`; silent `""` fallback in `deriveAccountAddress` masking malformed-key errors) and two 🟢 findings that the author had missed. The discipline is unconditional because the author's confidence is exactly what review is meant to challenge.
 
 How to apply: when ready to merge, the sequence is **always**:
 1. `gh pr review N --comment --body "..."` (post structured findings; "no findings, ready to merge" is a valid review body for genuinely trivial PRs, but the re-read still happens).
-2. Apply 🟡 fixes if any → push → post resolution comment.
+2. Apply 🟡 fixes if any → push → post resolution comment listing what was addressed and what was deferred. Skip this step entirely if the review surfaced only 🟢 nits or no findings.
 3. `gh pr merge N --merge --delete-branch`.
 
 If step 1 is skipped, the merge violates this rule and a retroactive review must be posted on the merged PR plus any follow-up sub-PRs needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,29 @@ Why this matters: without this rule, the ROADMAP drifts from reality. M0 + M1.1 
 
 How to apply: when finalizing a sub-PR (before pushing), grep the ROADMAP for the milestone you just touched, and check off every bullet the PR satisfies. If you're unsure whether a bullet is satisfied, ask in the PR description rather than guessing.
 
+## 8. Self-Review Before Merge — Unconditional
+
+**Every PR gets a structured self-review before `gh pr merge` runs. No exceptions — including pure-docs PRs, one-line fixes, single-file edits, and PRs the author is confident about.**
+
+The rule:
+
+- Before calling `gh pr merge N`, post a self-review via `gh pr review N --comment` using the same severity-tiered structure used on prior PRs:
+  - 🔴 blockers (correctness, security, broken contracts)
+  - 🟡 worth fixing before merge (real concerns, fragile assumptions, deferred-but-noted)
+  - 🟢 nits (style, naming, polish)
+- If the review surfaces **🔴 or 🟡** findings, either fix them on the same branch and post a resolution comment listing what was resolved vs deferred, or explicitly note in the resolution why a 🟡 is being deferred to a follow-up sub-PR.
+- Merge happens only after **(a)** review is posted, **(b)** 🟡-or-worse findings are resolved or explicitly deferred with a reason, **(c)** mergeable state is CLEAN.
+- Even "pure docs" / "single-line fix" / "obviously trivial" PRs go through this. The 30 seconds of forced re-reading catches dead links, terminology drift, misaligned tables, stale references, and assumption gaps that the author missed precisely because they thought the change was trivial.
+
+Why this matters: PRs #91 (ROADMAP backfill), #93 (install gate doc), and #94 (#86 fix) all merged without a self-review, each rationalized as "small / obvious / pure-docs". The retroactive review of #94 surfaced two real 🟡 items (duplicated derivation between `config.ts` and `runtime.ts:69`; silent `""` fallback in `deriveAccountAddress` masking malformed-key errors) and two 🟢 findings that the author had missed. The discipline is unconditional because the author's confidence is exactly what review is meant to challenge.
+
+How to apply: when ready to merge, the sequence is **always**:
+1. `gh pr review N --comment --body "..."` (post structured findings; "no findings, ready to merge" is a valid review body for genuinely trivial PRs, but the re-read still happens).
+2. Apply 🟡 fixes if any → push → post resolution comment.
+3. `gh pr merge N --merge --delete-branch`.
+
+If step 1 is skipped, the merge violates this rule and a retroactive review must be posted on the merged PR plus any follow-up sub-PRs needed.
+
 ---
 
 ## Project-Specific Context


### PR DESCRIPTION
## Summary

Adds CLAUDE.md §8 making the \"self-review via \`gh pr review --comment\` before \`gh pr merge\`\" discipline **explicit and unconditional**. The rule was implicit until now — followed on PRs #76, #84, #87, #89, #92 but skipped on #91, #93, #94, each time rationalized as \"pure docs / small / obvious\". User flagged the gap directly.

## Type of change

- [x] Docs / chore / tooling

## What changed

One new section in CLAUDE.md, inserted between §7 (ROADMAP sync) and the project-specific context block. It spells out:

1. **The hard rule**: \`gh pr review N --comment\` runs before every \`gh pr merge\`. No exceptions.
2. **Tier structure** (🔴 / 🟡 / 🟢) consistent with prior reviews.
3. **Resolution discipline**: 🟡-or-worse findings get fixed or explicitly deferred with reason.
4. **The merge sequence**: review → fix-if-needed → resolution comment → merge.
5. **Retroactive obligation** if the rule was violated — exactly the case for #94 (retroactive review just posted at https://github.com/gilbertsahumada/movehat/pull/94).

The \"Why this matters\" section names PRs #91, #93, #94 by number and cites the two real 🟡 findings the missed review on #94 would have caught (duplicated address derivation in \`config.ts\` vs \`runtime.ts:69\`; silent \`\"\"\` fallback in \`deriveAccountAddress\`).

## How was this tested?

- \`pnpm --filter movehat test\` → 169/169 passing (no source code touched).
- \`pnpm check:example\` → exit 0 (auto-verified on push by pre-push hook).
- \`pnpm test:example\` — N/A (no \`packages/movehat/src\`, \`bin/\`, or template surface touched).
- \`pnpm test:smoke\` — N/A (same reason).

## Follow-ups (tracked separately)

The retroactive review of #94 surfaced two 🟡 findings worth addressing:

1. **Duplicated derivation** between \`packages/movehat/src/core/config.ts:deriveAccountAddress\` and \`packages/movehat/src/runtime.ts:69\`. The \`runtime.ts:69\` write is now dead code for the \`initRuntime\` path (config is already populated by \`resolveNetworkConfig\`). Worth either deleting or extracting to a shared helper. Naturally folds into M1.5 (singleton removal) or M1.6 (config refactor).

2. **Silent fallback** in \`deriveAccountAddress\` returns \`\"\"\` on parse failure, which can reproduce the exact \"Hex string is too short\" surface error this PR was supposed to eliminate — just from a different code path. A \`console.warn\` in the catch would surface bad PRIVATE_KEY misconfigurations loud-and-clear at the right moment.

Both will land as part of M1.5 / M1.6 or as a tiny standalone \`fix(config)\` sub-PR — flagged in this PR's discussion rather than opening separate issues for now since the workaround (clear PRIVATE_KEY) is trivial and the duplication isn't currently load-bearing.

## Checklist

- [x] \`pnpm test\` passes locally (169/169)
- [x] Tier 2 install verification — N/A (no \`packages/movehat/src\`, \`bin\`, or templates touched)
- [x] CHANGELOG \`[Unreleased]\` — N/A (pure docs)
- [x] Docs updated — yes, this PR is the docs update
- [x] ROADMAP — no DoD bullet for this rule; it's a CLAUDE.md addition, not a milestone item
- [x] Conventional Commits used (1 commit)
- [x] **Self-review will run before merge** — this PR's existence is also a reaffirmation of that discipline