### PR TITLE
[M1.3c] runtime.ts + LocalNodeManager → runCli, stderr redaction guard

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,14 +60,14 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 | ✅ | M1.2 | [#77](https://github.com/gilbertsahumada/movehat/issues/77) (shipped in PR #87) | Migrate `fork/{manager,api,storage}.ts` to `utils/address.ts` | [#56](https://github.com/gilbertsahumada/movehat/issues/56) |
 | ✅ | M1.3a | [#88](https://github.com/gilbertsahumada/movehat/issues/88) (shipped in PR #89) | Extend `ChildProcessAdapter` with `spawn()` + `inheritStdio` (foundations for M1.3 migration) | foundations |
 | ✅ | M1.3b | [#90](https://github.com/gilbertsahumada/movehat/issues/90) (shipped in PR #92) | Migrate 6 simple callsites (`commands/{run,test,update,compile}`, `helpers/move-tests`, `fork/test`) to `runCli` | (partial of [#58](https://github.com/gilbertsahumada/movehat/issues/58)) |
-| ⏳ | M1.3c | [#78](https://github.com/gilbertsahumada/movehat/issues/78) | Migrate `runtime.ts` publish + `node/LocalNodeManager.ts` daemon + stderr-redaction unit test | completes [#58](https://github.com/gilbertsahumada/movehat/issues/58), completes [#43](https://github.com/gilbertsahumada/movehat/issues/43) |
+| ✅ | M1.3c | [#78](https://github.com/gilbertsahumada/movehat/issues/78) | Migrate `runtime.ts` publish + `node/LocalNodeManager.ts` daemon + stderr-redaction unit test | completes [#58](https://github.com/gilbertsahumada/movehat/issues/58), completes [#43](https://github.com/gilbertsahumada/movehat/issues/43) |
 | ⏳ | M1.4 | [#79](https://github.com/gilbertsahumada/movehat/issues/79) | Extract `core/Publisher.ts` + per-deploy temp dir + SIGINT handler | [#19](https://github.com/gilbertsahumada/movehat/issues/19), [#36](https://github.com/gilbertsahumada/movehat/issues/36), [#37](https://github.com/gilbertsahumada/movehat/issues/37), [#38](https://github.com/gilbertsahumada/movehat/issues/38), [#53](https://github.com/gilbertsahumada/movehat/issues/53) |
 | ⏳ | M1.5 | [#80](https://github.com/gilbertsahumada/movehat/issues/80) | Remove `cachedRuntime` and the three `setupLocalTesting` singletons | [#21](https://github.com/gilbertsahumada/movehat/issues/21), [#55](https://github.com/gilbertsahumada/movehat/issues/55) |
 | ⏳ | M1.6 | [#81](https://github.com/gilbertsahumada/movehat/issues/81) | `loadUserConfig` mtime cache + `switchNetwork` returns runtime | [#46](https://github.com/gilbertsahumada/movehat/issues/46), [#62](https://github.com/gilbertsahumada/movehat/issues/62) |
 | ⏳ | M1.7 | [#82](https://github.com/gilbertsahumada/movehat/issues/82) | Strict types audit (`any`, `!`, `noUncheckedIndexedAccess`) | [#57](https://github.com/gilbertsahumada/movehat/issues/57) |
 
 **Definition of Done** (rolled up from the sub-issues):
-- [x] `packages/movehat/src/utils/runCli.ts` exists (M1.1, #76) — replaces all direct `exec`/`spawn` callers ⏳ partial: 6 of 8 sites migrated in M1.3b (#92); `runtime.ts` + `LocalNodeManager.ts` pending M1.3c (#78)
+- [x] `packages/movehat/src/utils/runCli.ts` exists (M1.1, #76) — replaces all direct `exec`/`spawn` callers (final 2 sites — `runtime.ts` + `LocalNodeManager.ts` — migrated in M1.3c)
 - [x] `packages/movehat/src/utils/childProcessAdapter.ts` exists with injectable interface (M1.1, #76) — extended with `spawn()` + `inheritStdio` in M1.3a (#89)
 - [x] `packages/movehat/src/utils/address.ts` exists; replaces ad-hoc normalization in `fork/manager.ts`, `fork/storage.ts`, `fork/api.ts` (M1.2, #87)
 - [ ] `packages/movehat/src/core/Publisher.ts` exists; `runtime.deployContract` is a thin orchestrator over it — pending M1.4 (#79)
@@ -75,7 +75,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [ ] `loadUserConfig` cache by `path + mtimeMs` (no per-call module loader churn) — pending M1.6 (#81)
 - [ ] Two parallel `deployContract` calls do **not** corrupt `~/.aptos/config.yaml` or `Move.toml` — pending M1.4 (#79)
 - [ ] SIGINT during deploy leaves no private key on disk — pending M1.4 (#79)
-- [x] All previously passing 119 tests still green; new unit tests for `runCli`, `address` — `Publisher` tests pending M1.4 (currently **169/169** on develop)
+- [x] All previously passing 119 tests still green; new unit tests for `runCli`, `address`, and `deployContract` stderr redaction — `Publisher` tests pending M1.4 (currently **171/171** on develop)
 - [x] `examples/counter-example/` keeps passing through every sub-PR (per Decision 6) — mechanical typecheck gate enforced by pre-push since PR #84; runtime gate **9/9 passing** as of PR closing #86 (`message.test.ts` rewritten to local-node, broken-scaffold `greeting-fork.test.ts` removed)
 
 ### M2 — Hardhat-style Harness API (~6 days, issue #69)

--- a/packages/movehat/src/__tests__/deployContract.test.ts
+++ b/packages/movehat/src/__tests__/deployContract.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CliExecutionError } from "../errors.js";
+import { initRuntime } from "../runtime.js";
+import type { ChildProcessAdapter, RunInput, RunResult } from "../utils/childProcessAdapter.js";
+
+/**
+ * Guards against the bug-#43 leak path: when `movement move publish`
+ * echoes `ed25519-priv-…` material in stdout/stderr, neither the
+ * thrown error nor anything reaching `console.error` may carry the
+ * raw key. The redaction is structurally guaranteed by runCli today
+ * — these tests make the guarantee *directly* asserted so a future
+ * PR adding a non-runCli code path can't silently re-leak.
+ */
+describe("runtime.deployContract — secret redaction", () => {
+  let tmpHome: string;
+  let tmpCwd: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "movehat-test-home-"));
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-test-cwd-"));
+
+    // Minimal movehat.config.js — testnet with no `accounts` means the
+    // auto-generated deterministic test key is used (config.ts:147-155).
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    }
+  }
+};
+`
+    );
+
+    // Minimal Move package layout. `extractNamedAddresses` reads
+    // <moveDir>/sources/*.move; the empty file produces an empty Set.
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]
+name = "dummy"
+version = "0.0.1"
+
+[addresses]
+`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// intentionally empty\n");
+
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  function makeAdapter(steps: { build: RunResult; publish: RunResult }): {
+    adapter: ChildProcessAdapter;
+    calls: RunInput[];
+  } {
+    const calls: RunInput[] = [];
+    const adapter: ChildProcessAdapter = {
+      async run(input) {
+        calls.push(input);
+        // The args layout is `["move", "build" | "publish", ...rest]`.
+        if (input.args[1] === "build") return steps.build;
+        if (input.args[1] === "publish") return steps.publish;
+        throw new Error(`unexpected movement subcommand: ${input.args[1]}`);
+      },
+      spawn() {
+        throw new Error("spawn not used in deployContract tests");
+      },
+    };
+    return { adapter, calls };
+  }
+
+  it("leak path #2 — rethrown error has redacted stderr (no raw ed25519-priv-)", async () => {
+    const rawKey = "ed25519-priv-0x" + "a".repeat(64);
+    const { adapter } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      publish: { exitCode: 1, stdout: "", stderr: `Movement publish failed: ${rawKey}` },
+    });
+
+    const runtime = await initRuntime();
+
+    let captured: unknown;
+    try {
+      await runtime.deployContract("mymodule", { adapter });
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(CliExecutionError);
+    const err = captured as CliExecutionError;
+    expect(err.stderr).toContain("***REDACTED***");
+    expect(err.stderr).not.toContain("ed25519-priv-");
+    expect(err.stderr).not.toContain(rawKey);
+
+    // Bonus: deployContract's finally block must have restored / removed the
+    // movement config file. If a future refactor breaks the finally, this
+    // assertion fires before any real damage.
+    expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+  });
+
+  it("leak path #1 — console.error on a noisy-but-successful publish never sees raw key", async () => {
+    const rawKey = "ed25519-priv-0x" + "a".repeat(64);
+    const { adapter } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      // Publish succeeds (exitCode 0) but emits a stderr line containing the key.
+      publish: {
+        exitCode: 0,
+        stdout: "Transaction hash: 0x" + "b".repeat(64),
+        stderr: `warning: ${rawKey}`,
+      },
+    });
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const runtime = await initRuntime();
+      await runtime.deployContract("mymodule", { adapter });
+
+      const allErr = errSpy.mock.calls.flat().join("\n");
+      const allLog = logSpy.mock.calls.flat().join("\n");
+      expect(allErr).not.toContain("ed25519-priv-");
+      expect(allErr).not.toContain(rawKey);
+      expect(allLog).not.toContain("ed25519-priv-");
+      expect(allLog).not.toContain(rawKey);
+    } finally {
+      errSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/packages/movehat/src/__tests__/deployContract.test.ts
+++ b/packages/movehat/src/__tests__/deployContract.test.ts
@@ -94,7 +94,7 @@ version = "0.0.1"
 
   it("leak path #2 — rethrown error has redacted stderr (no raw ed25519-priv-)", async () => {
     const rawKey = "ed25519-priv-0x" + "a".repeat(64);
-    const { adapter } = makeAdapter({
+    const { adapter, calls } = makeAdapter({
       build: { exitCode: 0, stdout: "build ok", stderr: "" },
       publish: { exitCode: 1, stdout: "", stderr: `Movement publish failed: ${rawKey}` },
     });
@@ -113,6 +113,18 @@ version = "0.0.1"
     expect(err.stderr).toContain("***REDACTED***");
     expect(err.stderr).not.toContain("ed25519-priv-");
     expect(err.stderr).not.toContain(rawKey);
+
+    // Pin the call shape: build then publish, args reach the adapter un-quoted.
+    // A previous regression (shell-escape mismatch fixed in 511fd95) survived
+    // unit tests because no assertion checked what landed in `args`.
+    expect(calls).toHaveLength(2);
+    expect(calls[0].command).toBe("movement");
+    expect(calls[0].args.slice(0, 2)).toEqual(["move", "build"]);
+    expect(calls[1].args.slice(0, 2)).toEqual(["move", "publish"]);
+    for (const arg of [...calls[0].args, ...calls[1].args]) {
+      expect(arg.startsWith("'")).toBe(false);
+      expect(arg.endsWith("'")).toBe(false);
+    }
 
     // Bonus: deployContract's finally block must have restored / removed the
     // movement config file. If a future refactor breaks the finally, this

--- a/packages/movehat/src/core/shell.ts
+++ b/packages/movehat/src/core/shell.ts
@@ -56,17 +56,15 @@ export function validateAndEscapePath(path: string, name: string = "path"): stri
 }
 
 /**
- * Validates that a profile name is safe
- *
- * @param profile - The profile name to validate
- * @returns The escaped profile name
+ * Validates that a profile name is safe and returns it unchanged. Mirrors
+ * `validatePathSafety` — use this for callers that pass the profile to
+ * spawn-with-args (no shell), where shell quoting would be incorrect.
  */
-export function validateAndEscapeProfile(profile: string): string {
+export function validateProfileSafety(profile: string): string {
   if (!profile || typeof profile !== "string") {
     throw new Error("Invalid profile name: must be a non-empty string");
   }
 
-  // Profile names should only contain alphanumeric, hyphens, underscores
   const safePattern = /^[a-zA-Z0-9_-]+$/;
   if (!safePattern.test(profile)) {
     throw new Error(
@@ -75,5 +73,14 @@ export function validateAndEscapeProfile(profile: string): string {
     );
   }
 
-  return escapeShellArg(profile);
+  return profile;
+}
+
+/**
+ * Validates a profile and returns the shell-escaped form. Wraps
+ * `validateProfileSafety` for callers that pass the profile into shell-style
+ * commands (e.g. `exec`).
+ */
+export function validateAndEscapeProfile(profile: string): string {
+  return escapeShellArg(validateProfileSafety(profile));
 }

--- a/packages/movehat/src/node/LocalNodeManager.ts
+++ b/packages/movehat/src/node/LocalNodeManager.ts
@@ -1,7 +1,11 @@
-import { spawn, ChildProcess } from "child_process";
 import { existsSync, rmSync } from "fs";
 import { join } from "path";
 import { Account } from "@aptos-labs/ts-sdk";
+import {
+  defaultChildProcessAdapter,
+  type ChildProcessAdapter,
+  type SpawnedProcess,
+} from "../utils/childProcessAdapter.js";
 
 export interface LocalNodeOptions {
   testDir?: string;           // Directory for node data (default: .movehat/local-node)
@@ -10,6 +14,11 @@ export interface LocalNodeOptions {
   apiPort?: number;           // API/RPC port (default: 8080)
   readyPort?: number;         // Ready server port (default: 8070)
   silent?: boolean;           // Suppress node output
+  /**
+   * Override the child-process adapter. Tests inject a fake adapter so
+   * the daemon spawn never reaches the real `movement` binary.
+   */
+  adapter?: ChildProcessAdapter;
 }
 
 export interface LocalNodeInfo {
@@ -29,11 +38,14 @@ export interface LocalNodeInfo {
  * - Cleanup on shutdown
  */
 export class LocalNodeManager {
-  private process: ChildProcess | null = null;
-  private options: Required<LocalNodeOptions>;
+  private spawned: SpawnedProcess | null = null;
+  private killed = false;
+  private options: Required<Omit<LocalNodeOptions, "adapter">>;
+  private readonly adapter: ChildProcessAdapter;
   private starting: boolean = false;
 
   constructor(options: LocalNodeOptions = {}) {
+    this.adapter = options.adapter ?? defaultChildProcessAdapter;
     this.options = {
       testDir: options.testDir || join(process.cwd(), ".movehat", "local-node"),
       forceRestart: options.forceRestart ?? false,
@@ -50,7 +62,7 @@ export class LocalNodeManager {
    * @returns LocalNodeInfo with connection details
    */
   async start(): Promise<LocalNodeInfo> {
-    if (this.process) {
+    if (this.spawned) {
       console.log("Local node already running");
       return this.getNodeInfo();
     }
@@ -88,22 +100,24 @@ export class LocalNodeManager {
         args.push("--force-restart");
       }
 
-      // Start the node process
-      this.process = spawn("movement", args, {
+      // Start the node process via the injectable adapter.
+      this.killed = false;
+      this.spawned = this.adapter.spawn({
+        command: "movement",
+        args,
         stdio: this.options.silent ? "ignore" : "pipe",
-        detached: false,
       });
 
       // Handle process output
-      if (!this.options.silent && this.process.stdout && this.process.stderr) {
-        this.process.stdout.on("data", (data) => {
+      if (!this.options.silent && this.spawned.stdout && this.spawned.stderr) {
+        this.spawned.stdout.on("data", (data: Buffer) => {
           const output = data.toString().trim();
           if (output) {
             console.log(`[Node] ${output}`);
           }
         });
 
-        this.process.stderr.on("data", (data) => {
+        this.spawned.stderr.on("data", (data: Buffer) => {
           const output = data.toString().trim();
           if (output && !output.includes("WARN")) {
             console.error(`[Node Error] ${output}`);
@@ -111,17 +125,15 @@ export class LocalNodeManager {
         });
       }
 
-      // Handle process exit
-      this.process.on("exit", (code) => {
-        if (code !== 0 && code !== null) {
+      // The adapter's `exited` promise settles on both natural exit and on
+      // spawn-time error (e.g. ENOENT). On error the code is `null` — we don't
+      // log a generic "spawn failed" message here because `waitForReady` will
+      // surface a detailed timeout-with-hints error if movement never starts.
+      void this.spawned.exited.then(({ code }) => {
+        if (code !== null && code !== 0) {
           console.error(`\n❌ Local node exited with code ${code}`);
         }
-        this.process = null;
-      });
-
-      this.process.on("error", (error) => {
-        console.error(`\n❌ Failed to start local node: ${error.message}`);
-        this.process = null;
+        this.spawned = null;
       });
 
       // Wait for node to be ready
@@ -137,9 +149,10 @@ export class LocalNodeManager {
       this.starting = false;
 
       // Cleanup on failure
-      if (this.process) {
-        this.process.kill();
-        this.process = null;
+      if (this.spawned) {
+        this.killed = true;
+        this.spawned.kill();
+        this.spawned = null;
       }
 
       throw error;
@@ -150,42 +163,45 @@ export class LocalNodeManager {
    * Stop the local node
    */
   async stop(): Promise<void> {
-    if (!this.process) {
+    if (!this.spawned) {
       return;
     }
 
     console.log("\n🛑 Stopping local Movement node...");
 
-    return new Promise((resolve) => {
-      if (!this.process) {
-        resolve();
-        return;
+    const spawned = this.spawned;
+
+    // Mark killed synchronously so isRunning() reflects the intent right away,
+    // mirroring node's ChildProcess.killed semantics.
+    this.killed = true;
+
+    // Send SIGTERM for graceful shutdown
+    spawned.kill("SIGTERM");
+
+    // Force kill after 5 seconds if still running
+    const forceTimer = setTimeout(() => {
+      if (this.spawned === spawned) {
+        console.log("⚠️  Force killing node...");
+        spawned.kill("SIGKILL");
       }
+    }, 5000);
 
-      this.process.once("exit", () => {
-        console.log("✅ Local node stopped\n");
-        this.process = null;
-        resolve();
-      });
-
-      // Send SIGTERM for graceful shutdown
-      this.process.kill("SIGTERM");
-
-      // Force kill after 5 seconds if still running
-      setTimeout(() => {
-        if (this.process) {
-          console.log("⚠️  Force killing node...");
-          this.process.kill("SIGKILL");
-        }
-      }, 5000);
-    });
+    try {
+      await spawned.exited;
+      console.log("✅ Local node stopped\n");
+    } finally {
+      clearTimeout(forceTimer);
+      if (this.spawned === spawned) {
+        this.spawned = null;
+      }
+    }
   }
 
   /**
    * Check if the node is running
    */
   isRunning(): boolean {
-    return this.process !== null && !this.process.killed;
+    return this.spawned !== null && !this.killed;
   }
 
   /**

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -17,8 +17,10 @@ import {
   DeploymentInfo,
   validateSafeName,
 } from "./core/deployments.js";
-import { ModuleAlreadyDeployedError } from "./errors.js";
+import { CliExecutionError, ModuleAlreadyDeployedError } from "./errors.js";
 import { AccountManager } from "./core/AccountManager.js";
+import { runCli } from "./utils/runCli.js";
+import type { ChildProcessAdapter } from "./utils/childProcessAdapter.js";
 
 let cachedRuntime: MovehatRuntime | null = null;
 
@@ -83,19 +85,17 @@ export async function initRuntime(
     moduleName: string,
     options?: {
       packageDir?: string;
+      adapter?: ChildProcessAdapter;
     }
   ): Promise<DeploymentInfo> => {
     // Validate moduleName early
     validateSafeName(moduleName, "module");
 
-    const { exec } = await import("child_process");
-    const { promisify } = await import("util");
-    const { existsSync, mkdirSync, writeFileSync, chmodSync } = await import("fs");
+    const { existsSync, mkdirSync, writeFileSync } = await import("fs");
     const { join } = await import("path");
     const { homedir } = await import("os");
     const yaml = await import("js-yaml");
     const { validateAndEscapePath, validateAndEscapeProfile } = await import("./core/shell.js");
-    const execAsync = promisify(exec);
 
     // Check if --redeploy flag was passed via CLI
     const forceRedeploy = process.env.MH_CLI_REDEPLOY === 'true';
@@ -157,23 +157,29 @@ export async function initRuntime(
       const { extractNamedAddresses } = await import("./commands/compile.js");
       const detectedAddresses = extractNamedAddresses(dir);
 
-      // Build named addresses argument - use deployer address for all detected addresses
-      let namedAddressesArg = "";
-      if (detectedAddresses.size > 0) {
-        const addressPairs = Array.from(detectedAddresses)
-          .map(name => `${name}=${deployerAddress}`)
-          .join(",");
-        namedAddressesArg = `--named-addresses ${addressPairs}`;
-      }
+      // Build named addresses argument - use deployer address for all detected addresses.
+      // Stored as a pre-split args fragment so the spawn path never has to parse
+      // shell tokens; an empty fragment becomes a no-op via spread.
+      const namedAddrArgs: string[] = detectedAddresses.size > 0
+        ? [
+            "--named-addresses",
+            Array.from(detectedAddresses)
+              .map(name => `${name}=${deployerAddress}`)
+              .join(","),
+          ]
+        : [];
 
       // Build first with named addresses
       console.log("🔨 Building package...");
-      const buildCmd = `movement move build --package-dir ${safeDir} ${namedAddressesArg}`.trim();
-      const { stdout: buildOut } = await execAsync(buildCmd, {
-        timeout: 120000, // 2 minutes for git dependency downloads
-        maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large outputs
-      });
-      if (buildOut) console.log(buildOut.trim());
+      const buildResult = await runCli(
+        {
+          command: "movement",
+          args: ["move", "build", "--package-dir", safeDir, ...namedAddrArgs],
+          timeoutMs: 120000, // 2 minutes for git dependency downloads
+        },
+        { adapter: options?.adapter }
+      );
+      if (buildResult.stdout) console.log(buildResult.stdout.trim());
 
       // Publish using direct parameters (avoid config file issues)
       console.log("📤 Publishing to blockchain...");
@@ -254,15 +260,27 @@ export async function initRuntime(
         const configYaml = yaml.dump(movementConfig);
         writeFileSync(movementConfigPath, configYaml, { mode: 0o600 });
 
-        // Execute publish command without exposing private key in CLI
-        // Include named addresses for publish as well
-        const publishCmd = `movement move publish --package-dir ${safeDir} --url ${config.rpc} --profile ${safeProfile} --assume-yes ${namedAddressesArg}`.trim();
-        const result = await execAsync(publishCmd, {
-          timeout: 120000, // 2 minutes for blockchain transactions
-          maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large outputs
-        });
-        publishOut = result.stdout || '';
-        publishErr = result.stderr || '';
+        // Execute publish command without exposing private key in CLI.
+        // Routed through runCli so stdout/stderr are redacted of any
+        // `ed25519-priv-…` shape before reaching console.log/console.error
+        // or the thrown CliExecutionError — that's bug #43.
+        const publishResult = await runCli(
+          {
+            command: "movement",
+            args: [
+              "move", "publish",
+              "--package-dir", safeDir,
+              "--url", config.rpc,
+              "--profile", safeProfile,
+              "--assume-yes",
+              ...namedAddrArgs,
+            ],
+            timeoutMs: 120000, // 2 minutes for blockchain transactions
+          },
+          { adapter: options?.adapter }
+        );
+        publishOut = publishResult.stdout;
+        publishErr = publishResult.stderr;
         if (publishOut) console.log(publishOut.trim());
         if (publishErr) console.error(publishErr.trim());
       } finally {
@@ -317,15 +335,20 @@ export async function initRuntime(
 
       return deployment;
     } catch (error: any) {
-      // Enhanced error reporting with stderr if available
-      let errorMsg = error.message;
-      if (error.stderr) {
-        errorMsg += `\n${error.stderr}`;
+      if (error instanceof CliExecutionError) {
+        // stdout/stderr are already redacted by runCli before reaching here,
+        // so this branch is safe to log verbatim.
+        if (error.stdoutPreview) console.log(error.stdoutPreview);
+        console.error(`❌ Failed to publish module: ${error.message}\n${error.stderr}`);
+      } else {
+        // Preserve existing behaviour for non-CLI errors (filesystem write
+        // failures from Move.toml / ~/.aptos/config.yaml, yaml parse errors,
+        // etc.). These paths can't carry private-key material so logging raw
+        // is safe.
+        const errorMsg = error.stderr ? `${error.message}\n${error.stderr}` : error.message;
+        if (error.stdout) console.log(error.stdout);
+        console.error(`❌ Failed to publish module: ${errorMsg}`);
       }
-      if (error.stdout) {
-        console.log(error.stdout);
-      }
-      console.error(`❌ Failed to publish module: ${errorMsg}`);
       throw error;
     }
   };

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -95,7 +95,7 @@ export async function initRuntime(
     const { join } = await import("path");
     const { homedir } = await import("os");
     const yaml = await import("js-yaml");
-    const { validateAndEscapePath, validateAndEscapeProfile } = await import("./core/shell.js");
+    const { validatePathSafety, validateProfileSafety } = await import("./core/shell.js");
 
     // Check if --redeploy flag was passed via CLI
     const forceRedeploy = process.env.MH_CLI_REDEPLOY === 'true';
@@ -143,9 +143,11 @@ export async function initRuntime(
     const dir = options?.packageDir || config.moveDir;
     const profile = config.profile || "default";
 
-    // Validate and escape to prevent command injection
-    const safeDir = validateAndEscapePath(dir, "package directory");
-    const safeProfile = validateAndEscapeProfile(profile);
+    // Validate (no shell escape — runCli uses spawn, which takes args
+    // verbatim and would treat the single-quote wrapping as part of the
+    // literal path/profile, breaking Movement CLI argument parsing).
+    const safeDir = validatePathSafety(dir, "package directory");
+    const safeProfile = validateProfileSafety(profile);
 
     console.log(`📦 Publishing module "${moduleName}" from ${dir}...`);
 

--- a/packages/movehat/src/types/runtime.ts
+++ b/packages/movehat/src/types/runtime.ts
@@ -2,6 +2,7 @@ import { Aptos, Account } from "@aptos-labs/ts-sdk";
 import { MovehatConfig } from "./config.js";
 import { MoveContract } from "../core/contract.js";
 import { DeploymentInfo } from "../core/deployments.js";
+import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
 
 export interface NetworkInfo {
   name: string;
@@ -33,6 +34,11 @@ export interface MovehatRuntime {
     moduleName: string,
     options?: {
       packageDir?: string;
+      /**
+       * Override the child-process adapter. Test-only: production callers
+       * leave this undefined so the default spawn-based adapter is used.
+       */
+      adapter?: ChildProcessAdapter;
     }
   ) => Promise<DeploymentInfo>;
   getDeployment: (moduleName: string) => DeploymentInfo | null;


### PR DESCRIPTION
## Summary

Final M1.3 sub-PR. Migrates the two high-risk `child_process` callsites
that touch the private-key flow to the injectable adapter introduced in
M1.3a (#89), and adds a unit test that asserts `runtime.deployContract`
never lets `ed25519-priv-…` material reach `console` or thrown errors.

This **closes the runCli replacement DoD bullet** of M1: no
`child_process` import remains in `packages/movehat/src/**` outside
`utils/`.

## Changes (4 commits)

1. **`refactor(node): LocalNodeManager → adapter.spawn() + SpawnedProcess`** (5566793) — daemon now flows through the adapter; `exit`/`error` handlers collapsed into the settled-once `exited` promise; `killed` tracked explicitly.
2. **`refactor(runtime): deployContract build+publish through runCli`** (c57ab7f) — both `movement move build` and `movement move publish` route through runCli; catch block gets a narrowed `CliExecutionError` branch (already-redacted fields) with the pre-existing fallback preserved for non-CLI errors; new `{ adapter? }` option for test injection. The try/finally that restores `~/.aptos/config.yaml` + `Move.toml` is byte-identical.
3. **`test(runtime): redaction guard for deployContract publish stderr`** (4c6c1d5) — two tests, one per leak path identified in #43:
   - Leak path #2 (rethrown error): publish exit 1 with `ed25519-priv-…` in stderr → asserts `CliExecutionError.stderr` is redacted.
   - Leak path #1 (`console.error` on noisy-but-successful publish): publish exit 0 with key in stderr → asserts every `console.error`/`console.log` capture is clean.
   - Setup uses real temp dir + `HOME` override (not memfs) — see plan file for rationale; bonus assertion: `~/.aptos/config.yaml` cleaned up by the finally block.
4. **`fix(runtime): drop shell-escape on safeDir/safeProfile`** (511fd95) — caught by `test:example` on first run. Under runCli's spawn path the single-quote wrapping that `validateAndEscape*` adds is taken literally by Movement CLI. Adds `validateProfileSafety` (mirrors existing `validatePathSafety`); runtime uses the non-escaping forms.

## Related issues

- Closes #78
- Completes #58 (the original migrate-callsites issue)
- Completes #43 (stderr key leak from publish)
- Tracks #68

## How was this tested?

**Tier 1 (mechanical):**
- `pnpm --filter movehat exec tsc --noEmit` — clean.
- `pnpm --filter movehat test` — **171/171** (was 169; +2 new tests in `__tests__/deployContract.test.ts`).
- `pnpm check:example` — passes via pre-push hook.
- DoD grep: `grep -RnE "node:child_process|'child_process'|\"child_process\"" packages/movehat/src | grep -v /utils/` → **empty**.

**Tier 2 (per CLAUDE.md §6.2 — mandatory because `runtime.ts` was touched):**
- `pnpm test:example` — **9/9 passing** (Counter, Greeting, Greeting Fork, Message; full local-node + fork lifecycles). Required one rebuild between the regression fix and re-run since `test:example` doesn't pre-build `dist/`.
- `pnpm test:smoke` — pass (npm pack → global install → CLI smoke + init flow).

## Checklist

- [x] `pnpm test` passes locally (171/171)
- [x] **Tier 2 install verification** (per CLAUDE.md §6.2):
  - [x] `pnpm test:example` (9/9)
  - [x] `pnpm test:smoke` (pass)
- [ ] CHANGELOG `[Unreleased]` updated — **N/A**: internal refactor, no consumer-visible API change. Same exemption as M1.1, M1.2, M1.3a, M1.3b.
- [x] Docs updated — **N/A**: public API surface unchanged except for the optional test-only `adapter` parameter on `deployContract`.
- [x] ROADMAP `[ ]` → `[x]` ticked for M1.3c + the rolled-up runCli replacement bullet (count updated to 171/171). CLAUDE.md §7.
- [x] Conventional Commits in commit messages

## Stale baseline note (for reviewers)

The #78 issue body cites `test:example` baseline as "6 passing, 6 failing (pre-existing #86)". That baseline is no longer current — #94 rewrote `message.test.ts` to `setupTestFixture` and #96 fixed the config-derivation gap, so the current baseline on `develop` is **9/9**. This PR uses 9/9 as the gate.

## Self-review

Per CLAUDE.md §8, posting a structured self-review next as a separate review comment.