### PR TITLE
fix: address CodeRabbit findings on PR #100 (timeout / signal forwarding / fork exitCode)

### DIFF
--- a/packages/movehat/src/commands/run.ts
+++ b/packages/movehat/src/commands/run.ts
@@ -93,7 +93,18 @@ export default async function runCommand(scriptPath: string) {
       },
       { throwOnNonZeroExit: false }
     );
-    process.exit(result.exitCode || 0);
+
+    // When the user's script dies via signal (Ctrl+C, SIGTERM from a
+    // wrapper, etc.), runCli returns exitCode:-1 with signal populated.
+    // Re-raise the signal on the parent to preserve process-group
+    // semantics — shells reading $? see 128+N as expected, and wrappers
+    // can distinguish "killed by user" from generic "exit 1". A plain
+    // process.exit(-1) would mask to 255 on Unix and drop that context.
+    if (result.signal) {
+      process.kill(process.pid, result.signal);
+      return;
+    }
+    process.exit(result.exitCode >= 0 ? result.exitCode : 1);
   } catch (error) {
     console.error(`❌ Failed to execute script: ${(error as Error).message}`);
     process.exit(1);

--- a/packages/movehat/src/fork/__tests__/test.test.ts
+++ b/packages/movehat/src/fork/__tests__/test.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { snapshot, viewForkResource } from '../test.js';
+import type { ChildProcessAdapter, RunResult } from '../../utils/childProcessAdapter.js';
+
+/**
+ * Guards the exitCode-failure path that CodeRabbit flagged on PR #100:
+ * before this hardening, an `aptos` command that exited non-zero with a
+ * stderr containing the word "Success" (or no stderr at all) could slip
+ * past the stderr-defense check in `snapshot`, and a non-JSON stderr from
+ * `view-resource` produced a cryptic JSON parse error instead of the
+ * actual aptos failure.
+ */
+describe('fork/test — exitCode failure paths', () => {
+  let tmpCwd: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), 'movehat-fork-test-'));
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      rmSync(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  function adapterReturning(result: RunResult): ChildProcessAdapter {
+    return {
+      async run() {
+        return result;
+      },
+      spawn() {
+        throw new Error('spawn not used in fork/test failure-path tests');
+      },
+    };
+  }
+
+  it("snapshot throws on non-zero exit even when stderr contains 'Success'", async () => {
+    // The pre-fix edge case: aptos exits 1, stderr says
+    // "Failed: Success criteria not met" → the stderr.includes('Success')
+    // gate returned false-positive ok, and a stale directory from a prior
+    // run would mask the failure entirely.
+    const adapter = adapterReturning({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'Failed: Success criteria not met for snapshot init',
+    });
+
+    await expect(snapshot({ name: 'edge', adapter })).rejects.toThrow(
+      /Success criteria not met/
+    );
+  });
+
+  it('viewForkResource throws on non-zero exit with non-JSON stderr (informative message)', async () => {
+    // Pre-fix the failure surfaced as "Unexpected token ..." from
+    // JSON.parse, which obscured the actual aptos error.
+    const adapter = adapterReturning({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'Error: session not found',
+    });
+
+    await expect(
+      viewForkResource('/nonexistent/session', '0x1', '0x1::coin::CoinStore', {
+        adapter,
+      })
+    ).rejects.toThrow(/session not found/);
+  });
+});

--- a/packages/movehat/src/fork/test.ts
+++ b/packages/movehat/src/fork/test.ts
@@ -1,10 +1,17 @@
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { runCli } from '../utils/runCli.js';
+import type { ChildProcessAdapter } from '../utils/childProcessAdapter.js';
 
 export interface SnapshotOptions {
   path?: string;
   name?: string;
+  /**
+   * Override the child-process adapter. Test-only — production callers
+   * leave this undefined so the default spawn-based adapter is used.
+   * Mirrors the M1.3c pattern on `runtime.deployContract`.
+   */
+  adapter?: ChildProcessAdapter;
 }
 
 export interface ForkInfo {
@@ -39,15 +46,20 @@ export async function snapshot(options: SnapshotOptions = {}): Promise<string> {
   try {
     // Initialize fork/snapshot using aptos CLI.
     // runCli uses spawn-with-args under the hood (no shell), preventing
-    // command injection. Pass throwOnNonZeroExit:false so we can keep the
-    // existing "stderr-without-Success → throw" check intact.
-    const { stdout, stderr } = await runCli(
+    // command injection. Pass throwOnNonZeroExit:false so the exitCode is
+    // observable below — the stderr/dir defenses are belt-and-suspenders
+    // on top of the exitCode check.
+    const { stdout, stderr, exitCode } = await runCli(
       {
         command: 'aptos',
         args: ['move', 'sim', 'init', '--path', snapshotPath],
       },
-      { throwOnNonZeroExit: false }
+      { throwOnNonZeroExit: false, adapter: options.adapter }
     );
+
+    if (exitCode !== 0) {
+      throw new Error(stderr || `aptos move sim init failed with exit code ${exitCode}`);
+    }
 
     if (stderr && !stderr.includes('Success')) {
       throw new Error(stderr);
@@ -121,11 +133,12 @@ export async function getForkInfo(path: string): Promise<ForkInfo> {
 export async function viewForkResource(
   sessionPath: string,
   account: string,
-  resourceType: string
+  resourceType: string,
+  options: { adapter?: ChildProcessAdapter } = {}
 ): Promise<any> {
   try {
     // runCli uses spawn-with-args (no shell) to prevent command injection.
-    const { stdout } = await runCli(
+    const { stdout, stderr, exitCode } = await runCli(
       {
         command: 'aptos',
         args: [
@@ -140,8 +153,14 @@ export async function viewForkResource(
           resourceType,
         ],
       },
-      { throwOnNonZeroExit: false }
+      { throwOnNonZeroExit: false, adapter: options.adapter }
     );
+
+    if (exitCode !== 0) {
+      throw new Error(
+        stderr || `aptos move sim view-resource failed with exit code ${exitCode}`
+      );
+    }
 
     const result = JSON.parse(stdout);
 

--- a/packages/movehat/src/utils/__tests__/childProcessAdapter.test.ts
+++ b/packages/movehat/src/utils/__tests__/childProcessAdapter.test.ts
@@ -214,4 +214,31 @@ describe('defaultChildProcessAdapter.run with inheritStdio', () => {
     expect(result.stdout).toBe('');
     expect(result.stderr).toBe('');
   });
+
+  it('explicit timeoutMs is still honored under inheritStdio', async () => {
+    // Positive control: the conditional-skip applies only when timeoutMs
+    // is omitted. An explicit value forces the timer back on.
+    await expect(
+      defaultChildProcessAdapter.run({
+        command: NODE,
+        args: ['-e', 'setTimeout(() => {}, 5000)'],
+        inheritStdio: true,
+        timeoutMs: 50,
+      })
+    ).rejects.toThrow(/timed out after 50ms/);
+  });
+
+  it('omits the default timeout when inheritStdio is true (short child completes naturally)', async () => {
+    // We can't wait 5 minutes to prove the default timeout isn't set, but
+    // we can prove that a child running with inheritStdio:true and no
+    // explicit timeoutMs completes via the natural exit path with no
+    // timeout-derived rejection. Combined with the test above, the
+    // conditional-skip behavior is pinned in both directions.
+    const result = await defaultChildProcessAdapter.run({
+      command: NODE,
+      args: ['-e', "setTimeout(() => process.exit(0), 50)"],
+      inheritStdio: true,
+    });
+    expect(result.exitCode).toBe(0);
+  });
 });

--- a/packages/movehat/src/utils/childProcessAdapter.ts
+++ b/packages/movehat/src/utils/childProcessAdapter.ts
@@ -97,7 +97,14 @@ const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 
 class DefaultChildProcessAdapter implements ChildProcessAdapter {
   run(input: RunInput): Promise<RunResult> {
-    const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    // Skip the default 5-minute timeout when the caller wires stdio
+    // through to the terminal — interactive sessions (mocha, tsx scripts,
+    // `movement move test`, `pnpm install`) routinely exceed 5 minutes and
+    // SIGTERM'ing them silently is a regression vs the direct-spawn code
+    // these callers used before M1.3a. An explicitly-passed `timeoutMs`
+    // is always honored, regardless of `inheritStdio`.
+    const timeoutMs =
+      input.timeoutMs ?? (input.inheritStdio ? undefined : DEFAULT_TIMEOUT_MS);
 
     return new Promise<RunResult>((resolve, reject) => {
       const child = spawn(input.command, [...input.args], {
@@ -113,10 +120,17 @@ class DefaultChildProcessAdapter implements ChildProcessAdapter {
       child.stdout?.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
       child.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
 
-      const timeoutHandle = setTimeout(() => {
-        child.kill('SIGTERM');
-        reject(new Error(`Command timed out after ${timeoutMs}ms: ${input.command}`));
-      }, timeoutMs);
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      const clearTimer = () => {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+      };
+
+      if (timeoutMs !== undefined) {
+        timeoutHandle = setTimeout(() => {
+          child.kill('SIGTERM');
+          reject(new Error(`Command timed out after ${timeoutMs}ms: ${input.command}`));
+        }, timeoutMs);
+      }
 
       const onAbort = () => {
         child.kill('SIGTERM');
@@ -124,7 +138,7 @@ class DefaultChildProcessAdapter implements ChildProcessAdapter {
 
       if (input.signal) {
         if (input.signal.aborted) {
-          clearTimeout(timeoutHandle);
+          clearTimer();
           child.kill('SIGTERM');
           reject(new Error('Command aborted before start'));
           return;
@@ -133,13 +147,13 @@ class DefaultChildProcessAdapter implements ChildProcessAdapter {
       }
 
       child.on('error', (err) => {
-        clearTimeout(timeoutHandle);
+        clearTimer();
         input.signal?.removeEventListener('abort', onAbort);
         reject(err);
       });
 
       child.on('close', (code, signal) => {
-        clearTimeout(timeoutHandle);
+        clearTimer();
         input.signal?.removeEventListener('abort', onAbort);
         const result: RunResult = {
           exitCode: code !== null ? code : -1,


### PR DESCRIPTION
## Summary

Three fixes from the CodeRabbit review on the running batch PR #100. Verified each against the actual code on \`develop\` — none were false positives. Severity range 🔴 → 🟡, all addressed in one fix-up PR so PR #100's diff converges before more milestone work lands.

## Findings addressed

| # | File | Severity | Fix |
|---|---|---|---|
| 1 | \`utils/childProcessAdapter.ts\` | 🔴 (regression introduced in M1.3a) | Default 5min timeout now skipped when \`inheritStdio: true\`. Explicit \`timeoutMs\` still honored. Restores pre-M1.3a behavior for interactive callers (mocha big suites, \`movement move test\`, \`pnpm install\`, \`movehat run script.ts\`). |
| 2 | \`commands/run.ts\` | 🟡 | Forward signal termination via \`process.kill(process.pid, signal)\` instead of \`process.exit(-1)\` (which masks to 255 on Unix). Preserves process-group semantics for shells / wrappers reading \`\$?\`. |
| 3 | \`fork/test.ts\` | 🟡 | Assert \`exitCode === 0\` before the existing stderr / JSON defenses on both \`snapshot()\` and \`viewForkResource()\`. Adds optional \`adapter?\` parameter to both for test injection (mirrors M1.3c precedent on \`deployContract\`). |

## Commit-by-commit

| Commit | Topic |
|---|---|
| \`fd18376\` | \`fix(utils): skip default timeout when inheritStdio is true\` + 2 new unit tests (positive control + happy path) |
| \`05a1a54\` | \`fix(commands/run): forward signal termination instead of masking to exit 255\` — no unit test (\`process.kill(process.pid)\` would kill vitest) |
| \`9031c39\` | \`fix(fork/test): assert exitCode on aptos snapshot + view-resource paths\` + new test file (first coverage for this module — 2 tests) |

## Type of change

- [x] Bug fix (non-breaking — Finding 1 is a regression repair; Findings 2 and 3 close edge cases that pre-existed and weren't covered by tests)
- [x] Refactor (adapter injection on \`snapshot()\` / \`viewForkResource()\` — non-breaking, optional, test-only)

## Related issues

- Refs PR #100 (the running develop→main batch — this fix-up converges its diff)
- Refs #68 (M1 meta)
- No issues close from this PR; the CodeRabbit findings live as inline review comments on #100.

## How was this tested?

**Tier 1 (mechanical, all on \`fix/coderabbit-pr100-findings\` HEAD \`9031c39\`):**
- \`pnpm --filter movehat exec tsc --noEmit\` — clean.
- \`pnpm --filter movehat test\` — **175 / 175** (171 → +4 new tests: 2 in \`childProcessAdapter.test.ts\`, 2 in new \`fork/__tests__/test.test.ts\`).
- \`pnpm check:example\` — pass via pre-push hook.

**Tier 2 (CLAUDE.md §6.2 — mandatory because \`packages/movehat/src/**\` changes):**
- \`pnpm test:example\` — **9 / 9** passing (Counter, Greeting, Greeting Fork, Message — full local-node + fork lifecycles).
- \`pnpm test:smoke\` — **pass** (npm pack → global install → CLI surface checks).

## Checklist

- [x] \`pnpm test\` passes locally (175 / 175)
- [x] \`pnpm test:example\` (9 / 9)
- [x] \`pnpm test:smoke\` (pass)
- [x] CHANGELOG \`[Unreleased]\` updated — N/A: internal bug-fix of refactor work that hasn't reached \`main\` yet (same exemption as M1.x sub-PRs)
- [x] Docs updated — N/A: no public API surface change beyond the test-only \`adapter?\` parameters
- [x] Conventional Commits used (3 \`fix(scope):\` commits)
- [ ] Self-review per CLAUDE.md §8 — posted as a separate comment immediately after PR opens

## Self-review

Per CLAUDE.md §8 (unconditional), a structured 🔴/🟡/🟢 review will be posted as the next action on this PR.