### PR TITLE
[M1.4] Extract Publisher.ts + close parallel-deploy / signal-leak / Move.toml mutation bugs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 | ✅ | M1.3a | [#88](https://github.com/gilbertsahumada/movehat/issues/88) (shipped in PR #89) | Extend `ChildProcessAdapter` with `spawn()` + `inheritStdio` (foundations for M1.3 migration) | foundations |
 | ✅ | M1.3b | [#90](https://github.com/gilbertsahumada/movehat/issues/90) (shipped in PR #92) | Migrate 6 simple callsites (`commands/{run,test,update,compile}`, `helpers/move-tests`, `fork/test`) to `runCli` | (partial of [#58](https://github.com/gilbertsahumada/movehat/issues/58)) |
 | ✅ | M1.3c | [#78](https://github.com/gilbertsahumada/movehat/issues/78) (shipped in PR #97) | Migrate `runtime.ts` publish + `node/LocalNodeManager.ts` daemon + stderr-redaction unit test | completes [#58](https://github.com/gilbertsahumada/movehat/issues/58), completes [#43](https://github.com/gilbertsahumada/movehat/issues/43) |
-| ⏳ | M1.4 | [#79](https://github.com/gilbertsahumada/movehat/issues/79) | Extract `core/Publisher.ts` + per-deploy temp dir + SIGINT handler | [#19](https://github.com/gilbertsahumada/movehat/issues/19), [#36](https://github.com/gilbertsahumada/movehat/issues/36), [#37](https://github.com/gilbertsahumada/movehat/issues/37), [#38](https://github.com/gilbertsahumada/movehat/issues/38), [#53](https://github.com/gilbertsahumada/movehat/issues/53) |
+| ✅ | M1.4 | [#79](https://github.com/gilbertsahumada/movehat/issues/79) | Extract `core/Publisher.ts` + per-deploy unique profile + signal handler | [#19](https://github.com/gilbertsahumada/movehat/issues/19), [#36](https://github.com/gilbertsahumada/movehat/issues/36), [#37](https://github.com/gilbertsahumada/movehat/issues/37), [#38](https://github.com/gilbertsahumada/movehat/issues/38), [#53](https://github.com/gilbertsahumada/movehat/issues/53) |
 | ⏳ | M1.5 | [#80](https://github.com/gilbertsahumada/movehat/issues/80) | Remove `cachedRuntime` and the three `setupLocalTesting` singletons | [#21](https://github.com/gilbertsahumada/movehat/issues/21), [#55](https://github.com/gilbertsahumada/movehat/issues/55) |
 | ⏳ | M1.6 | [#81](https://github.com/gilbertsahumada/movehat/issues/81) | `loadUserConfig` mtime cache + `switchNetwork` returns runtime | [#46](https://github.com/gilbertsahumada/movehat/issues/46), [#62](https://github.com/gilbertsahumada/movehat/issues/62) |
 | ⏳ | M1.7 | [#82](https://github.com/gilbertsahumada/movehat/issues/82) | Strict types audit (`any`, `!`, `noUncheckedIndexedAccess`) | [#57](https://github.com/gilbertsahumada/movehat/issues/57) |
@@ -70,12 +70,12 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `packages/movehat/src/utils/runCli.ts` exists (M1.1, #76) — replaces all direct `exec`/`spawn` callers (final 2 sites — `runtime.ts` + `LocalNodeManager.ts` — migrated in M1.3c)
 - [x] `packages/movehat/src/utils/childProcessAdapter.ts` exists with injectable interface (M1.1, #76) — extended with `spawn()` + `inheritStdio` in M1.3a (#89)
 - [x] `packages/movehat/src/utils/address.ts` exists; replaces ad-hoc normalization in `fork/manager.ts`, `fork/storage.ts`, `fork/api.ts` (M1.2, #87)
-- [ ] `packages/movehat/src/core/Publisher.ts` exists; `runtime.deployContract` is a thin orchestrator over it — pending M1.4 (#79)
+- [x] `packages/movehat/src/core/Publisher.ts` exists; `runtime.deployContract` is a thin orchestrator over it (17 lines on develop, M1.4)
 - [ ] `grep -R "cachedRuntime\|currentForkServer\|currentForkManager\|currentLocalNode" packages/movehat/src` returns **no matches** — pending M1.5 (#80)
 - [ ] `loadUserConfig` cache by `path + mtimeMs` (no per-call module loader churn) — pending M1.6 (#81)
-- [ ] Two parallel `deployContract` calls do **not** corrupt `~/.aptos/config.yaml` or `Move.toml` — pending M1.4 (#79)
-- [ ] SIGINT during deploy leaves no private key on disk — pending M1.4 (#79)
-- [x] All previously passing 119 tests still green; new unit tests for `runCli`, `address`, and `deployContract` stderr redaction — `Publisher` tests pending M1.4 (currently **171/171** on develop)
+- [x] Two parallel `deployContract` calls do **not** corrupt `~/.aptos/config.yaml` or `Move.toml` (M1.4: unique profile per deploy + Move.toml never mutated)
+- [x] SIGINT during deploy leaves no private key on disk (M1.4: process-level signal handler + sync profile cleanup)
+- [x] All previously passing 119 tests still green; new unit tests for `runCli`, `address`, `deployContract` stderr redaction, Move.toml integrity, parallel-deploy, and signal-handler cleanup (currently **184/184** on develop)
 - [x] `examples/counter-example/` keeps passing through every sub-PR (per Decision 6) — mechanical typecheck gate enforced by pre-push since PR #84; runtime gate **9/9 passing** as of PR closing #86 (`message.test.ts` rewritten to local-node, broken-scaffold `greeting-fork.test.ts` removed)
 
 ### M2 — Hardhat-style Harness API (~6 days, issue #69)

--- a/packages/movehat/src/__tests__/deployContract.test.ts
+++ b/packages/movehat/src/__tests__/deployContract.test.ts
@@ -9,8 +9,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import * as yaml from "js-yaml";
 import { CliExecutionError } from "../errors.js";
 import { initRuntime } from "../runtime.js";
+import { Publisher } from "../core/Publisher.js";
+import { AccountManager } from "../core/AccountManager.js";
+import { resolveNetworkConfig } from "../core/config.js";
 import type { ChildProcessAdapter, RunInput, RunResult } from "../utils/childProcessAdapter.js";
 
 /**
@@ -137,6 +141,110 @@ version = "0.0.1"
     // movement config file. If a future refactor breaks the finally, this
     // assertion fires before any real damage.
     expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+  });
+
+  it("two concurrent deploys do not corrupt ~/.aptos/config.yaml (#37)", async () => {
+    // Pre-fix #37: both deploys overwrote ~/.aptos/config.yaml with the
+    // SAME profile name ("default" by default), then both restored
+    // independently. The second deploy's restore would overwrite the
+    // first's profile mid-publish → potential cross-contamination of
+    // private keys / accounts. Post-fix: each deploy uses a unique
+    // movehat-deploy-<uuid> profile name and only deletes its own key
+    // on cleanup. The user's other profiles never get touched.
+    //
+    // The mutex is what makes this safe — without it, the
+    // read-modify-write cycles would race and silently drop a profile.
+
+    // Seed the yaml with an unrelated user profile that MUST survive.
+    const aptosDir = join(tmpHome, ".aptos");
+    mkdirSync(aptosDir, { recursive: true });
+    const preExisting = {
+      profiles: {
+        user_main: {
+          private_key: "0x" + "1".repeat(64),
+          public_key: "0x" + "2".repeat(64),
+          account: "0x" + "3".repeat(64),
+          rest_url: "https://example.invalid/v1",
+        },
+      },
+    };
+    const configPath = join(aptosDir, "config.yaml");
+    writeFileSync(configPath, yaml.dump(preExisting), { mode: 0o600 });
+
+    // Set up two Publisher instances with fake adapters that record their
+    // own --profile argument and inject a small delay on publish so the
+    // critical sections overlap.
+    function makeDelayedAdapter(label: string): {
+      adapter: ChildProcessAdapter;
+      captured: { publishCall?: RunInput };
+    } {
+      const captured: { publishCall?: RunInput } = {};
+      const adapter: ChildProcessAdapter = {
+        async run(input) {
+          if (input.args[1] === "build") {
+            return { exitCode: 0, stdout: `built ${label}`, stderr: "" };
+          }
+          if (input.args[1] === "publish") {
+            captured.publishCall = input;
+            // Hold the lock-protected critical section open long enough
+            // for the other deploy's addProfile to compete.
+            await new Promise((r) => setTimeout(r, 30));
+            return {
+              exitCode: 0,
+              stdout: `Transaction hash: 0x${"d".repeat(64)}`,
+              stderr: "",
+            };
+          }
+          throw new Error(`unexpected: ${input.args[1]}`);
+        },
+        spawn() {
+          throw new Error("spawn not used");
+        },
+      };
+      return { adapter, captured };
+    }
+
+    const a = makeDelayedAdapter("A");
+    const b = makeDelayedAdapter("B");
+
+    // Build a minimal config + account once via initRuntime, then call
+    // Publisher directly (bypasses the loadDeployment cache that would
+    // throw on the second deploy if both used moduleName "test").
+    const runtime = await initRuntime();
+    const { config, account } = runtime;
+
+    await Promise.all([
+      new Publisher({ adapter: a.adapter }).deploy({
+        moduleName: "concurrent_a",
+        config,
+        account,
+        packageDir: join(tmpCwd, "move"),
+      }),
+      new Publisher({ adapter: b.adapter }).deploy({
+        moduleName: "concurrent_b",
+        config,
+        account,
+        packageDir: join(tmpCwd, "move"),
+      }),
+    ]);
+
+    // Both publish calls captured distinct --profile args.
+    const argsA = a.captured.publishCall!.args;
+    const argsB = b.captured.publishCall!.args;
+    const profileArgA = argsA[argsA.indexOf("--profile") + 1];
+    const profileArgB = argsB[argsB.indexOf("--profile") + 1];
+    expect(profileArgA).toMatch(/^movehat-deploy-/);
+    expect(profileArgB).toMatch(/^movehat-deploy-/);
+    expect(profileArgA).not.toBe(profileArgB);
+
+    // After both deploys finish, ~/.aptos/config.yaml contains the
+    // user's original profile and zero movehat-deploy-* profiles.
+    const finalYaml: any = yaml.load(readFileSync(configPath, "utf8"));
+    expect(finalYaml.profiles).toBeDefined();
+    expect(Object.keys(finalYaml.profiles)).toEqual(["user_main"]);
+    expect(finalYaml.profiles.user_main.private_key).toBe(
+      preExisting.profiles.user_main.private_key
+    );
   });
 
   it("does not mutate Move.toml during deploy (#38)", async () => {

--- a/packages/movehat/src/__tests__/deployContract.test.ts
+++ b/packages/movehat/src/__tests__/deployContract.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CliExecutionError } from "../errors.js";
@@ -130,6 +137,46 @@ version = "0.0.1"
     // movement config file. If a future refactor breaks the finally, this
     // assertion fires before any real damage.
     expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+  });
+
+  it("does not mutate Move.toml during deploy (#38)", async () => {
+    // Pre-fix #38: deployContract overwrote every entry under [addresses]
+    // with the deployer address, then relied on `finally` to restore.
+    // Post-fix: Move.toml is never touched — `--named-addresses` carries
+    // the overrides on the CLI line for both build and publish.
+    const moveTomlPath = join(tmpCwd, "move", "Move.toml");
+    const moveTomlContent = `[package]
+name = "dummy"
+version = "0.0.1"
+
+[addresses]
+counter = "0x42"
+greeting = "0xcafe"
+`;
+    writeFileSync(moveTomlPath, moveTomlContent);
+
+    // Move source that references "counter" so extractNamedAddresses picks
+    // it up — otherwise the --named-addresses arg is empty and the test
+    // is uninteresting.
+    writeFileSync(
+      join(tmpCwd, "move", "sources", "dummy.move"),
+      "module counter::dummy { }\n"
+    );
+
+    const { adapter } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      publish: {
+        exitCode: 0,
+        stdout: "Transaction hash: 0x" + "c".repeat(64),
+        stderr: "",
+      },
+    });
+
+    const runtime = await initRuntime();
+    await runtime.deployContract("counter", { adapter });
+
+    const after = readFileSync(moveTomlPath, "utf8");
+    expect(after).toBe(moveTomlContent);
   });
 
   it("leak path #1 — console.error on a noisy-but-successful publish never sees raw key", async () => {

--- a/packages/movehat/src/__tests__/deployContract.test.ts
+++ b/packages/movehat/src/__tests__/deployContract.test.ts
@@ -8,14 +8,18 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { spawn } from "node:child_process";
 import * as yaml from "js-yaml";
 import { CliExecutionError } from "../errors.js";
 import { initRuntime } from "../runtime.js";
 import { Publisher } from "../core/Publisher.js";
-import { AccountManager } from "../core/AccountManager.js";
-import { resolveNetworkConfig } from "../core/config.js";
 import type { ChildProcessAdapter, RunInput, RunResult } from "../utils/childProcessAdapter.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 
 /**
  * Guards against the bug-#43 leak path: when `movement move publish`
@@ -246,6 +250,109 @@ version = "0.0.1"
       preExisting.profiles.user_main.private_key
     );
   });
+
+  it("SIGINT mid-deploy cleans the profile from ~/.aptos/config.yaml (#36)", async () => {
+    // Pre-fix #36: between the yaml write (private key persisted) and the
+    // finally block, a SIGINT would skip cleanup and leave the user's
+    // private key sitting in ~/.aptos/config.yaml at mode 0o600.
+    // Post-fix: a sync signal handler runs synchronously before exit,
+    // removing the deploy's unique profile from the yaml.
+    //
+    // This test spawns a child process running a harness that drives
+    // Publisher.deploy() with a 3-second-delayed publish, then sends
+    // SIGINT mid-flight. Vitest's own process is unaffected because
+    // the SIGINT goes to the child.
+
+    // Seed an unrelated user profile that MUST survive.
+    const aptosDir = join(tmpHome, ".aptos");
+    mkdirSync(aptosDir, { recursive: true });
+    const configPath = join(aptosDir, "config.yaml");
+    writeFileSync(
+      configPath,
+      yaml.dump({
+        profiles: {
+          user_main: {
+            private_key: "0x" + "a".repeat(64),
+            public_key: "0x" + "b".repeat(64),
+            account: "0x" + "c".repeat(64),
+            rest_url: "https://example.invalid/v1",
+          },
+        },
+      }),
+      { mode: 0o600 }
+    );
+
+    const harnessPath = join(__dirname, "fixtures", "sigint-deploy-harness.ts");
+    // Resolve tsx's CLI binary by absolute path — the test's tmp cwd has
+    // no node_modules, so a bare `tsx` import would fail to resolve.
+    // `require.resolve("tsx")` returns the package's main (dist/loader.mjs);
+    // the binary is two levels up from there, in `<root>/dist/cli.mjs`
+    // (same trick `commands/run.ts:49-53` uses).
+    const tsxMain = require.resolve("tsx");
+    const tsxCliPath = join(dirname(dirname(tsxMain)), "dist", "cli.mjs");
+    const child = spawn(
+      process.execPath,
+      [tsxCliPath, harnessPath],
+      {
+        env: { ...process.env, HOME: tmpHome },
+        cwd: tmpCwd,
+        stdio: ["ignore", "pipe", "pipe"],
+      }
+    );
+
+    // Wait for the harness to announce its unique profile name via stdout
+    // (it writes a JSON line `{"profile":"movehat-deploy-XXXX"}` just
+    // before entering the slow publish step).
+    let announced: string | undefined;
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdoutBuf += chunk.toString();
+      for (const line of stdoutBuf.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("{")) continue;
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (typeof parsed.profile === "string") announced = parsed.profile;
+        } catch {
+          /* not a JSON line we care about */
+        }
+      }
+    });
+    child.stderr?.on("data", (c: Buffer) => (stderrBuf += c.toString()));
+
+    // Poll until the harness has announced OR 8s timeout (the import +
+    // SDK initialization can take a few seconds in CI/cold-start).
+    const start = Date.now();
+    while (!announced && Date.now() - start < 8000) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    if (!announced) {
+      child.kill("SIGKILL");
+      throw new Error(
+        `harness never announced profile in 8s.\n` +
+          `stdout so far:\n${stdoutBuf}\n---\nstderr so far:\n${stderrBuf}`
+      );
+    }
+
+    expect(announced).toMatch(/^movehat-deploy-/);
+
+    // Deliver SIGINT mid-publish and wait for the harness to exit.
+    child.kill("SIGINT");
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.on("exit", (code) => resolve(code));
+    });
+    expect(exitCode).toBe(130);
+
+    // The yaml on disk contains the user's original profile and NO
+    // movehat-deploy-* leftovers.
+    expect(existsSync(configPath)).toBe(true);
+    const finalYaml: any = yaml.load(readFileSync(configPath, "utf8"));
+    expect(finalYaml.profiles).toBeDefined();
+    expect(Object.keys(finalYaml.profiles).sort()).toEqual(["user_main"]);
+    expect(finalYaml.profiles.user_main.private_key).toBe("0x" + "a".repeat(64));
+  }, 15000);
 
   it("does not mutate Move.toml during deploy (#38)", async () => {
     // Pre-fix #38: deployContract overwrote every entry under [addresses]

--- a/packages/movehat/src/__tests__/fixtures/sigint-deploy-harness.ts
+++ b/packages/movehat/src/__tests__/fixtures/sigint-deploy-harness.ts
@@ -1,0 +1,95 @@
+/**
+ * Stand-alone child-process harness for the SIGINT-cleanup test in
+ * `deployContract.test.ts`. Run via tsx by the parent test; never picked
+ * up by vitest's test glob (default matches `*.{test,spec}.?(c|m)[jt]s`).
+ *
+ * Behavior:
+ *   1. Build a fake ChildProcessAdapter whose `publish` step awaits a
+ *      long delay (3 seconds) — gives the parent test plenty of time to
+ *      send SIGINT mid-flight.
+ *   2. Drive `Publisher.deploy()` against the fake adapter using a
+ *      synthetic MovehatConfig + Account read from env vars.
+ *   3. Write the chosen `movehat-deploy-<uuid>` profile name to stdout
+ *      as JSON (`{"profile": "..."}`) before the slow publish so the
+ *      parent test knows which key to look for after SIGINT.
+ *   4. If the deploy completes naturally (test failure case), exit 0.
+ *   5. When SIGINT arrives, Publisher's signal handler runs synchronous
+ *      cleanup and `setImmediate(() => process.exit(130))`.
+ *
+ * The parent test does NOT import this file — it spawns it via
+ * `child_process.spawn(node, [tsx, harness, ...])` so the harness runs
+ * in its own process with its own signal-handler installation.
+ */
+
+import { Account, Ed25519PrivateKey } from "@aptos-labs/ts-sdk";
+import { Publisher } from "../../core/Publisher.js";
+import type {
+  ChildProcessAdapter,
+  RunInput,
+  RunResult,
+} from "../../utils/childProcessAdapter.js";
+import type { MovehatConfig } from "../../types/config.js";
+
+// Deterministic test key — must satisfy the Aptos SDK's Ed25519 parser.
+// Same key the testnet auto-config uses in `core/config.ts:147-155`.
+const TEST_PRIVATE_KEY =
+  "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+async function main() {
+  const account = Account.fromPrivateKey({
+    privateKey: new Ed25519PrivateKey(TEST_PRIVATE_KEY),
+  });
+
+  const config: MovehatConfig = {
+    network: "testnet",
+    rpc: "https://testnet.invalid/v1",
+    privateKey: TEST_PRIVATE_KEY,
+    allAccounts: [TEST_PRIVATE_KEY],
+    profile: "default",
+    moveDir: "./move",
+    account: account.accountAddress.toString(),
+    namedAddresses: {},
+    networkConfig: {
+      url: "https://testnet.invalid/v1",
+      chainId: "testnet",
+    },
+  };
+
+  const slowPublishAdapter: ChildProcessAdapter = {
+    async run(input: RunInput): Promise<RunResult> {
+      if (input.args[1] === "build") {
+        return { exitCode: 0, stdout: "built", stderr: "" };
+      }
+      if (input.args[1] === "publish") {
+        // Surface the unique profile name to the parent BEFORE blocking.
+        const profileIdx = input.args.indexOf("--profile");
+        const profile = profileIdx >= 0 ? input.args[profileIdx + 1] : "";
+        process.stdout.write(JSON.stringify({ profile }) + "\n");
+        // Hold long enough for the parent to deliver SIGINT.
+        await new Promise((r) => setTimeout(r, 3000));
+        return {
+          exitCode: 0,
+          stdout: "Transaction hash: 0x" + "f".repeat(64),
+          stderr: "",
+        };
+      }
+      throw new Error(`unexpected subcommand: ${input.args[1]}`);
+    },
+    spawn() {
+      throw new Error("spawn not used");
+    },
+  };
+
+  const publisher = new Publisher({ adapter: slowPublishAdapter });
+  await publisher.deploy({
+    moduleName: "sigint_harness",
+    config,
+    account,
+    packageDir: process.cwd(),
+  });
+}
+
+main().catch((err) => {
+  process.stderr.write(`harness error: ${(err as Error).message}\n`);
+  process.exit(2);
+});

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { readFile, writeFile, unlink } from "fs/promises";
+import { readFile, unlink } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import * as yaml from "js-yaml";
@@ -149,28 +149,11 @@ export class Publisher {
         cleanPrivateKey = cleanPrivateKey.replace("ed25519-priv-", "");
       }
 
-      // Read Move.toml to update named addresses with deployer address
-      const moveTomlPath = join(dir, "Move.toml");
-      let originalMoveToml = "";
-
-      if (existsSync(moveTomlPath)) {
-        originalMoveToml = await readFile(moveTomlPath, "utf-8");
-
-        // Replace addresses in [addresses] section with deployer address
-        const updatedMoveToml = originalMoveToml.replace(
-          /\[addresses\]([\s\S]*?)(?=\n\[|$)/,
-          (_match, addressesSection) => {
-            const updatedSection = addressesSection.replace(
-              /^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*"0x[a-fA-F0-9]+"/gm,
-              `$1 = "${deployerAddress}"`
-            );
-            return `[addresses]${updatedSection}`;
-          }
-        );
-
-        // Write updated Move.toml temporarily
-        await writeFile(moveTomlPath, updatedMoveToml, "utf-8");
-      }
+      // Bug #38: Move.toml is NOT mutated. All address overrides flow
+      // through the `--named-addresses` flag above, which Movement CLI
+      // applies during build + publish. The previous regex rewrite +
+      // restore-in-finally was destructive: if the process died between
+      // write and restore, the user's Move.toml stayed mutated.
 
       let publishOut = "";
       let publishErr = "";
@@ -254,11 +237,8 @@ export class Publisher {
             await unlink(movementConfigPath).catch(() => {});
           }
         }
-
-        // Restore original Move.toml
-        if (originalMoveToml && existsSync(moveTomlPath)) {
-          await writeFile(moveTomlPath, originalMoveToml, "utf-8");
-        }
+        // Note: Move.toml restoration removed — bug #38 fix means
+        // Move.toml is never mutated in the first place.
       }
 
       // Extract transaction hash from output

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -1,0 +1,315 @@
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { readFile, writeFile, unlink } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+import * as yaml from "js-yaml";
+import { Account } from "@aptos-labs/ts-sdk";
+import { MovehatConfig } from "../types/config.js";
+import { extractNamedAddresses } from "../commands/compile.js";
+import {
+  saveDeployment,
+  loadDeployment,
+  DeploymentInfo,
+  validateSafeName,
+} from "./deployments.js";
+import { validatePathSafety, validateProfileSafety } from "./shell.js";
+import { CliExecutionError, ModuleAlreadyDeployedError } from "../errors.js";
+import { runCli } from "../utils/runCli.js";
+import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
+
+/** @internal */
+export interface PublisherDeps {
+  adapter?: ChildProcessAdapter;
+}
+
+/** @internal */
+export interface PublishInput {
+  moduleName: string;
+  config: MovehatConfig;
+  account: Account;
+  packageDir?: string;
+}
+
+/**
+ * Publishes a Move module via the Movement CLI.
+ *
+ * Extracted from `runtime.deployContract` (M1.4 / #79). Carries the
+ * destructive Move.toml-rewrite + shared-yaml-write semantics of the
+ * original closure verbatim in this scaffold commit — bug fixes for
+ * #36 / #37 / #38 land in subsequent commits.
+ *
+ * @internal
+ */
+export class Publisher {
+  constructor(private readonly deps: PublisherDeps = {}) {}
+
+  async deploy(input: PublishInput): Promise<DeploymentInfo> {
+    const { moduleName, config, account } = input;
+
+    // Validate moduleName early
+    validateSafeName(moduleName, "module");
+
+    // Check if --redeploy flag was passed via CLI
+    const forceRedeploy = process.env.MH_CLI_REDEPLOY === "true";
+
+    // Check if already deployed
+    const existingDeployment = loadDeployment(config.network, moduleName);
+    if (existingDeployment && !forceRedeploy) {
+      // Build detailed error message with all deployment info
+      const errorDetails = [
+        `Module "${moduleName}" is already deployed on ${config.network}`,
+        `Address: ${existingDeployment.address}`,
+        `Deployed at: ${new Date(existingDeployment.timestamp).toLocaleString()}`,
+        existingDeployment.txHash ? `Transaction: ${existingDeployment.txHash}` : null,
+        `\nTo redeploy, run with the --redeploy flag:`,
+        `movehat run <script> --network ${config.network} --redeploy`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      // Log formatted error message for user
+      const formattedMessage = [
+        `\n❌ Module "${moduleName}" is already deployed on ${config.network}`,
+        `   Address: ${existingDeployment.address}`,
+        `   Deployed at: ${new Date(existingDeployment.timestamp).toLocaleString()}`,
+        existingDeployment.txHash ? `   Transaction: ${existingDeployment.txHash}` : null,
+        `\n💡 To redeploy, run with the --redeploy flag:`,
+        `   movehat run <script> --network ${config.network} --redeploy\n`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      console.error(formattedMessage);
+
+      // Throw custom error with complete context for programmatic handling
+      throw new ModuleAlreadyDeployedError(
+        errorDetails,
+        moduleName,
+        config.network,
+        existingDeployment.address,
+        existingDeployment.timestamp,
+        existingDeployment.txHash
+      );
+    }
+
+    if (forceRedeploy && existingDeployment) {
+      console.log(`🔄 Redeploying module "${moduleName}" on ${config.network}...`);
+    }
+
+    const dir = input.packageDir || config.moveDir;
+    const profile = config.profile || "default";
+
+    // Validate (no shell escape — runCli uses spawn, which takes args
+    // verbatim and would treat the single-quote wrapping as part of the
+    // literal path/profile, breaking Movement CLI argument parsing).
+    const safeDir = validatePathSafety(dir, "package directory");
+    const safeProfile = validateProfileSafety(profile);
+
+    console.log(`📦 Publishing module "${moduleName}" from ${dir}...`);
+
+    try {
+      // Get the deployer address to use for named addresses
+      const deployerAddress = account.accountAddress.toString();
+
+      // Detect named addresses from Move files
+      const detectedAddresses = extractNamedAddresses(dir);
+
+      // Build named addresses argument - use deployer address for all detected addresses.
+      // Stored as a pre-split args fragment so the spawn path never has to parse
+      // shell tokens; an empty fragment becomes a no-op via spread.
+      const namedAddrArgs: string[] =
+        detectedAddresses.size > 0
+          ? [
+              "--named-addresses",
+              Array.from(detectedAddresses)
+                .map((name) => `${name}=${deployerAddress}`)
+                .join(","),
+            ]
+          : [];
+
+      // Build first with named addresses
+      console.log("🔨 Building package...");
+      const buildResult = await runCli(
+        {
+          command: "movement",
+          args: ["move", "build", "--package-dir", safeDir, ...namedAddrArgs],
+          timeoutMs: 120000, // 2 minutes for git dependency downloads
+        },
+        { adapter: this.deps.adapter }
+      );
+      if (buildResult.stdout) console.log(buildResult.stdout.trim());
+
+      // Publish using direct parameters (avoid config file issues)
+      console.log("📤 Publishing to blockchain...");
+
+      // Use parameters directly instead of relying on config file
+      // Strip any ed25519-priv- prefix if present
+      let cleanPrivateKey = config.privateKey;
+      if (cleanPrivateKey.startsWith("ed25519-priv-")) {
+        cleanPrivateKey = cleanPrivateKey.replace("ed25519-priv-", "");
+      }
+
+      // Read Move.toml to update named addresses with deployer address
+      const moveTomlPath = join(dir, "Move.toml");
+      let originalMoveToml = "";
+
+      if (existsSync(moveTomlPath)) {
+        originalMoveToml = await readFile(moveTomlPath, "utf-8");
+
+        // Replace addresses in [addresses] section with deployer address
+        const updatedMoveToml = originalMoveToml.replace(
+          /\[addresses\]([\s\S]*?)(?=\n\[|$)/,
+          (_match, addressesSection) => {
+            const updatedSection = addressesSection.replace(
+              /^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*"0x[a-fA-F0-9]+"/gm,
+              `$1 = "${deployerAddress}"`
+            );
+            return `[addresses]${updatedSection}`;
+          }
+        );
+
+        // Write updated Move.toml temporarily
+        await writeFile(moveTomlPath, updatedMoveToml, "utf-8");
+      }
+
+      let publishOut = "";
+      let publishErr = "";
+
+      // Setup Movement CLI config with private key securely
+      // Movement CLI uses .aptos config directory (not .movement)
+      const movementConfigDir = join(homedir(), ".aptos");
+      const movementConfigPath = join(movementConfigDir, "config.yaml");
+      let originalMovementConfig = "";
+
+      try {
+        // Ensure .aptos directory exists
+        if (!existsSync(movementConfigDir)) {
+          mkdirSync(movementConfigDir, { recursive: true, mode: 0o700 });
+        }
+
+        // Backup original config if it exists
+        if (existsSync(movementConfigPath)) {
+          originalMovementConfig = await readFile(movementConfigPath, "utf-8");
+        }
+
+        // Create Movement config with private key
+        // Movement CLI reads from ~/.aptos/config.yaml
+        const movementConfig: any = originalMovementConfig
+          ? yaml.load(originalMovementConfig)
+          : {};
+
+        // Set profile with private key
+        // Use unescaped profile name as YAML key (YAML handles escaping automatically)
+        if (!movementConfig.profiles) {
+          movementConfig.profiles = {};
+        }
+        if (!movementConfig.profiles[profile]) {
+          movementConfig.profiles[profile] = {};
+        }
+
+        movementConfig.profiles[profile].private_key = cleanPrivateKey;
+        movementConfig.profiles[profile].public_key = account.publicKey.toString();
+        movementConfig.profiles[profile].account = deployerAddress;
+        movementConfig.profiles[profile].rest_url = config.rpc;
+
+        // Write config file with restrictive permissions
+        const configYaml = yaml.dump(movementConfig);
+        writeFileSync(movementConfigPath, configYaml, { mode: 0o600 });
+
+        // Execute publish command without exposing private key in CLI.
+        // Routed through runCli so stdout/stderr are redacted of any
+        // `ed25519-priv-…` shape before reaching console.log/console.error
+        // or the thrown CliExecutionError — that's bug #43.
+        const publishResult = await runCli(
+          {
+            command: "movement",
+            args: [
+              "move",
+              "publish",
+              "--package-dir",
+              safeDir,
+              "--url",
+              config.rpc,
+              "--profile",
+              safeProfile,
+              "--assume-yes",
+              ...namedAddrArgs,
+            ],
+            timeoutMs: 120000, // 2 minutes for blockchain transactions
+          },
+          { adapter: this.deps.adapter }
+        );
+        publishOut = publishResult.stdout;
+        publishErr = publishResult.stderr;
+        if (publishOut) console.log(publishOut.trim());
+        if (publishErr) console.error(publishErr.trim());
+      } finally {
+        // Restore original Movement config
+        if (existsSync(movementConfigPath)) {
+          if (originalMovementConfig) {
+            // Restore original config
+            writeFileSync(movementConfigPath, originalMovementConfig, { mode: 0o600 });
+          } else {
+            // Remove config file if it didn't exist before
+            await unlink(movementConfigPath).catch(() => {});
+          }
+        }
+
+        // Restore original Move.toml
+        if (originalMoveToml && existsSync(moveTomlPath)) {
+          await writeFile(moveTomlPath, originalMoveToml, "utf-8");
+        }
+      }
+
+      // Extract transaction hash from output
+      // Look for patterns like "Transaction hash: 0x..." or "Txn: 0x..." or just a 64-char hex
+      // The regex tries to match with context first, then falls back to any 64-char hex
+      let txHash: string | undefined;
+      const txHashMatchWithContext = publishOut.match(
+        /(?:transaction\s*(?:hash)?|txn\s*(?:hash)?|hash):\s*(0x[a-fA-F0-9]{64})\b/i
+      );
+      if (txHashMatchWithContext) {
+        txHash = txHashMatchWithContext[1];
+      } else {
+        // Fallback: try to find any 64-char hex string (exactly, not more)
+        const txHashMatch = publishOut.match(/\b(0x[a-fA-F0-9]{64})\b/);
+        if (txHashMatch) {
+          txHash = txHashMatch[1];
+        }
+      }
+
+      console.log(`✅ Module published successfully!`);
+
+      // Create deployment info
+      const deployment: DeploymentInfo = {
+        address: account.accountAddress.toString(),
+        moduleName,
+        network: config.network,
+        deployer: account.accountAddress.toString(),
+        timestamp: Date.now(),
+        txHash,
+      };
+
+      // Save deployment
+      saveDeployment(deployment);
+
+      return deployment;
+    } catch (error: any) {
+      if (error instanceof CliExecutionError) {
+        // stdout/stderr are already redacted by runCli before reaching here,
+        // so this branch is safe to log verbatim.
+        if (error.stdoutPreview) console.log(error.stdoutPreview);
+        console.error(`❌ Failed to publish module: ${error.message}\n${error.stderr}`);
+      } else {
+        // Preserve existing behaviour for non-CLI errors (filesystem write
+        // failures from Move.toml / ~/.aptos/config.yaml, yaml parse errors,
+        // etc.). These paths can't carry private-key material so logging raw
+        // is safe.
+        const errorMsg = error.stderr ? `${error.message}\n${error.stderr}` : error.message;
+        if (error.stdout) console.log(error.stdout);
+        console.error(`❌ Failed to publish module: ${errorMsg}`);
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -1,7 +1,15 @@
-import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { readFile, unlink } from "fs/promises";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { readFile } from "fs/promises";
 import { homedir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
+import { randomUUID } from "crypto";
 import * as yaml from "js-yaml";
 import { Account } from "@aptos-labs/ts-sdk";
 import { MovehatConfig } from "../types/config.js";
@@ -16,6 +24,93 @@ import { validatePathSafety, validateProfileSafety } from "./shell.js";
 import { CliExecutionError, ModuleAlreadyDeployedError } from "../errors.js";
 import { runCli } from "../utils/runCli.js";
 import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
+
+/**
+ * In-process serializer for `~/.aptos/config.yaml` mutations. Without it,
+ * two concurrent `Publisher.deploy()` calls would race in the
+ * read-modify-write cycle and the second writer would silently drop the
+ * first deploy's profile. See #37.
+ */
+let yamlLock: Promise<unknown> = Promise.resolve();
+function withYamlLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = yamlLock;
+  // .then(success, failure) — continue even if the previous holder rejected,
+  // so a failure in one deploy doesn't poison the lock for the others.
+  const next = prev.then(
+    () => fn(),
+    () => fn()
+  );
+  yamlLock = next.catch(() => {}); // swallow on the shared chain; caller still gets the original
+  return next;
+}
+
+interface ProfileData {
+  private_key: string;
+  public_key: string;
+  account: string;
+  rest_url: string;
+}
+
+/**
+ * Atomic write: write payload to a temp sibling → chmod the temp to 0o600
+ * → rename over the target. The chmod-before-rename order eliminates a
+ * window where the target file could be observable with default umask
+ * perms (typically 0o644) while carrying the private key.
+ */
+function atomicWriteYaml(path: string, content: string): void {
+  const tmpPath = `${path}.tmp.${randomUUID().slice(0, 8)}`;
+  writeFileSync(tmpPath, content, { mode: 0o600 });
+  chmodSync(tmpPath, 0o600); // defense in depth in case umask filtered the open mode
+  renameSync(tmpPath, path);
+}
+
+/** Add the deploy's profile to ~/.aptos/config.yaml. Creates the file if absent. */
+async function addProfile(
+  configPath: string,
+  name: string,
+  data: ProfileData
+): Promise<void> {
+  const configDir = dirname(configPath);
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  }
+  let yamlObj: any = {};
+  if (existsSync(configPath)) {
+    const raw = await readFile(configPath, "utf-8");
+    yamlObj = (yaml.load(raw) as any) || {};
+  }
+  if (!yamlObj.profiles) yamlObj.profiles = {};
+  yamlObj.profiles[name] = data;
+  atomicWriteYaml(configPath, yaml.dump(yamlObj));
+}
+
+/**
+ * Remove the deploy's profile from ~/.aptos/config.yaml. Idempotent —
+ * a missing file or missing profile is a no-op. If removal leaves the
+ * yaml with only an empty `profiles:` block, the whole file is unlinked
+ * to preserve the "didn't exist before" semantic for the first-ever deploy.
+ */
+async function removeProfile(configPath: string, name: string): Promise<void> {
+  if (!existsSync(configPath)) return;
+  const raw = await readFile(configPath, "utf-8");
+  const yamlObj: any = (yaml.load(raw) as any) || {};
+  if (!yamlObj.profiles || !(name in yamlObj.profiles)) return;
+  delete yamlObj.profiles[name];
+
+  const profilesEmpty = Object.keys(yamlObj.profiles).length === 0;
+  const onlyProfilesKey =
+    Object.keys(yamlObj).length === 1 && "profiles" in yamlObj;
+  if (profilesEmpty && onlyProfilesKey) {
+    // We created this file fresh; remove it.
+    try {
+      unlinkSync(configPath);
+    } catch {
+      // best-effort
+    }
+    return;
+  }
+  atomicWriteYaml(configPath, yaml.dump(yamlObj));
+}
 
 /** @internal */
 export interface PublisherDeps {
@@ -97,7 +192,13 @@ export class Publisher {
     }
 
     const dir = input.packageDir || config.moveDir;
-    const profile = config.profile || "default";
+
+    // Bug #37: use a UUID-suffixed profile name per deploy so concurrent
+    // Publisher.deploy() calls in the same process don't fight over the
+    // same key in ~/.aptos/config.yaml. The previous code reused
+    // config.profile (default "default"), which meant two parallel
+    // deploys would clobber each other's profile data mid-publish.
+    const profile = `movehat-deploy-${randomUUID().slice(0, 8)}`;
 
     // Validate (no shell escape — runCli uses spawn, which takes args
     // verbatim and would treat the single-quote wrapping as part of the
@@ -158,47 +259,24 @@ export class Publisher {
       let publishOut = "";
       let publishErr = "";
 
-      // Setup Movement CLI config with private key securely
-      // Movement CLI uses .aptos config directory (not .movement)
-      const movementConfigDir = join(homedir(), ".aptos");
-      const movementConfigPath = join(movementConfigDir, "config.yaml");
-      let originalMovementConfig = "";
+      // Setup Movement CLI config with private key securely.
+      // Movement CLI uses .aptos config directory (not .movement).
+      const movementConfigPath = join(homedir(), ".aptos", "config.yaml");
+
+      // Add our deploy profile under the unique key. The mutex serializes
+      // read-modify-write cycles so concurrent deploys in the same process
+      // can't drop each other's profiles. Other user profiles in the same
+      // file are preserved untouched.
+      await withYamlLock(() =>
+        addProfile(movementConfigPath, profile, {
+          private_key: cleanPrivateKey,
+          public_key: account.publicKey.toString(),
+          account: deployerAddress,
+          rest_url: config.rpc,
+        })
+      );
 
       try {
-        // Ensure .aptos directory exists
-        if (!existsSync(movementConfigDir)) {
-          mkdirSync(movementConfigDir, { recursive: true, mode: 0o700 });
-        }
-
-        // Backup original config if it exists
-        if (existsSync(movementConfigPath)) {
-          originalMovementConfig = await readFile(movementConfigPath, "utf-8");
-        }
-
-        // Create Movement config with private key
-        // Movement CLI reads from ~/.aptos/config.yaml
-        const movementConfig: any = originalMovementConfig
-          ? yaml.load(originalMovementConfig)
-          : {};
-
-        // Set profile with private key
-        // Use unescaped profile name as YAML key (YAML handles escaping automatically)
-        if (!movementConfig.profiles) {
-          movementConfig.profiles = {};
-        }
-        if (!movementConfig.profiles[profile]) {
-          movementConfig.profiles[profile] = {};
-        }
-
-        movementConfig.profiles[profile].private_key = cleanPrivateKey;
-        movementConfig.profiles[profile].public_key = account.publicKey.toString();
-        movementConfig.profiles[profile].account = deployerAddress;
-        movementConfig.profiles[profile].rest_url = config.rpc;
-
-        // Write config file with restrictive permissions
-        const configYaml = yaml.dump(movementConfig);
-        writeFileSync(movementConfigPath, configYaml, { mode: 0o600 });
-
         // Execute publish command without exposing private key in CLI.
         // Routed through runCli so stdout/stderr are redacted of any
         // `ed25519-priv-…` shape before reaching console.log/console.error
@@ -227,18 +305,11 @@ export class Publisher {
         if (publishOut) console.log(publishOut.trim());
         if (publishErr) console.error(publishErr.trim());
       } finally {
-        // Restore original Movement config
-        if (existsSync(movementConfigPath)) {
-          if (originalMovementConfig) {
-            // Restore original config
-            writeFileSync(movementConfigPath, originalMovementConfig, { mode: 0o600 });
-          } else {
-            // Remove config file if it didn't exist before
-            await unlink(movementConfigPath).catch(() => {});
-          }
-        }
-        // Note: Move.toml restoration removed — bug #38 fix means
-        // Move.toml is never mutated in the first place.
+        // Always remove our profile from the shared yaml — never restore
+        // a "snapshot" of the whole file (that's what the old code did,
+        // and that's the bug #37 race). Removing only our key leaves
+        // other concurrent deploys' profiles intact.
+        await withYamlLock(() => removeProfile(movementConfigPath, profile));
       }
 
       // Extract transaction hash from output

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -2,6 +2,7 @@ import {
   chmodSync,
   existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   unlinkSync,
   writeFileSync,
@@ -110,6 +111,69 @@ async function removeProfile(configPath: string, name: string): Promise<void> {
     return;
   }
   atomicWriteYaml(configPath, yaml.dump(yamlObj));
+}
+
+/**
+ * Synchronous twin of `removeProfile` for the SIGINT/SIGTERM handler.
+ * The event loop is dead by the time the handler runs — we cannot
+ * await. Bypasses the async mutex because signal handlers are
+ * sequential by construction; the operation is idempotent so a
+ * benign double-delete (handler then finally, or vice versa) is fine.
+ */
+function removeProfileSync(configPath: string, name: string): void {
+  try {
+    if (!existsSync(configPath)) return;
+    const raw = readFileSync(configPath, "utf-8");
+    const yamlObj: any = (yaml.load(raw) as any) || {};
+    if (!yamlObj.profiles || !(name in yamlObj.profiles)) return;
+    delete yamlObj.profiles[name];
+
+    const profilesEmpty = Object.keys(yamlObj.profiles).length === 0;
+    const onlyProfilesKey =
+      Object.keys(yamlObj).length === 1 && "profiles" in yamlObj;
+    if (profilesEmpty && onlyProfilesKey) {
+      unlinkSync(configPath);
+      return;
+    }
+    atomicWriteYaml(configPath, yaml.dump(yamlObj));
+  } catch {
+    // Signal handlers should never throw — swallow and exit. Better to
+    // leave a stale profile (recoverable by re-running the deploy) than
+    // to crash the parent process mid-shutdown.
+  }
+}
+
+/**
+ * Process-level signal handling. A single registered handler iterates
+ * the per-deploy cleanup callbacks. Install-once because multiple
+ * concurrent deploys share the same parent process — installing per
+ * deploy would re-add the listener and exceed Node's max-listeners
+ * warning threshold under heavy parallelism.
+ */
+const cleanupCallbacks = new Set<() => void>();
+let signalHandlerInstalled = false;
+
+function ensureSignalHandler(): void {
+  if (signalHandlerInstalled) return;
+  signalHandlerInstalled = true;
+  const handler = (sig: NodeJS.Signals) => {
+    // Synchronous cleanup of every active deploy's profile entry.
+    for (const cb of [...cleanupCallbacks]) {
+      try {
+        cb();
+      } catch {
+        /* sync best-effort */
+      }
+    }
+    // Defer the actual exit one tick so other listeners (vitest's own
+    // SIGINT handler, app-level shutdown hooks) still get to run.
+    // Without this we'd stomp on vitest's afterEach if a dev Ctrl+C'd
+    // a test run mid-suite.
+    const code = sig === "SIGTERM" ? 143 : 130;
+    setImmediate(() => process.exit(code));
+  };
+  process.on("SIGINT", handler);
+  process.on("SIGTERM", handler);
 }
 
 /** @internal */
@@ -263,6 +327,16 @@ export class Publisher {
       // Movement CLI uses .aptos config directory (not .movement).
       const movementConfigPath = join(homedir(), ".aptos", "config.yaml");
 
+      // Register a sync cleanup hook BEFORE writing the private key.
+      // If the user Ctrl+C's (or the process is SIGTERM'd) between the
+      // yaml write and our async finally, the SIGINT handler iterates
+      // every registered callback and removes this deploy's profile
+      // synchronously — closes bug #36 (private key persisting on disk
+      // after abnormal exit).
+      ensureSignalHandler();
+      const syncCleanup = () => removeProfileSync(movementConfigPath, profile);
+      cleanupCallbacks.add(syncCleanup);
+
       // Add our deploy profile under the unique key. The mutex serializes
       // read-modify-write cycles so concurrent deploys in the same process
       // can't drop each other's profiles. Other user profiles in the same
@@ -310,6 +384,9 @@ export class Publisher {
         // and that's the bug #37 race). Removing only our key leaves
         // other concurrent deploys' profiles intact.
         await withYamlLock(() => removeProfile(movementConfigPath, profile));
+        // Unregister the sync cleanup hook — normal path. (The signal
+        // handler stays installed for the process lifetime; cheap.)
+        cleanupCallbacks.delete(syncCleanup);
       }
 
       // Extract transaction hash from output

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -10,16 +10,13 @@ import { MovehatUserConfig } from "./types/config.js";
 import { loadUserConfig, resolveNetworkConfig } from "./core/config.js";
 import { getContract, MoveContract } from "./core/contract.js";
 import {
-  saveDeployment,
   loadDeployment,
   getAllDeployments,
   getDeployedAddress,
   DeploymentInfo,
-  validateSafeName,
 } from "./core/deployments.js";
-import { CliExecutionError, ModuleAlreadyDeployedError } from "./errors.js";
 import { AccountManager } from "./core/AccountManager.js";
-import { runCli } from "./utils/runCli.js";
+import { Publisher } from "./core/Publisher.js";
 import type { ChildProcessAdapter } from "./utils/childProcessAdapter.js";
 
 let cachedRuntime: MovehatRuntime | null = null;
@@ -88,271 +85,15 @@ export async function initRuntime(
       adapter?: ChildProcessAdapter;
     }
   ): Promise<DeploymentInfo> => {
-    // Validate moduleName early
-    validateSafeName(moduleName, "module");
-
-    const { existsSync, mkdirSync, writeFileSync } = await import("fs");
-    const { join } = await import("path");
-    const { homedir } = await import("os");
-    const yaml = await import("js-yaml");
-    const { validatePathSafety, validateProfileSafety } = await import("./core/shell.js");
-
-    // Check if --redeploy flag was passed via CLI
-    const forceRedeploy = process.env.MH_CLI_REDEPLOY === 'true';
-
-    // Check if already deployed
-    const existingDeployment = loadDeployment(config.network, moduleName);
-    if (existingDeployment && !forceRedeploy) {
-      // Build detailed error message with all deployment info
-      const errorDetails = [
-        `Module "${moduleName}" is already deployed on ${config.network}`,
-        `Address: ${existingDeployment.address}`,
-        `Deployed at: ${new Date(existingDeployment.timestamp).toLocaleString()}`,
-        existingDeployment.txHash ? `Transaction: ${existingDeployment.txHash}` : null,
-        `\nTo redeploy, run with the --redeploy flag:`,
-        `movehat run <script> --network ${config.network} --redeploy`,
-      ].filter(Boolean).join('\n');
-
-      // Log formatted error message for user
-      const formattedMessage = [
-        `\n❌ Module "${moduleName}" is already deployed on ${config.network}`,
-        `   Address: ${existingDeployment.address}`,
-        `   Deployed at: ${new Date(existingDeployment.timestamp).toLocaleString()}`,
-        existingDeployment.txHash ? `   Transaction: ${existingDeployment.txHash}` : null,
-        `\n💡 To redeploy, run with the --redeploy flag:`,
-        `   movehat run <script> --network ${config.network} --redeploy\n`,
-      ].filter(Boolean).join('\n');
-
-      console.error(formattedMessage);
-
-      // Throw custom error with complete context for programmatic handling
-      throw new ModuleAlreadyDeployedError(
-        errorDetails,
-        moduleName,
-        config.network,
-        existingDeployment.address,
-        existingDeployment.timestamp,
-        existingDeployment.txHash
-      );
-    }
-
-    if (forceRedeploy && existingDeployment) {
-      console.log(`🔄 Redeploying module "${moduleName}" on ${config.network}...`);
-    }
-
-    const dir = options?.packageDir || config.moveDir;
-    const profile = config.profile || "default";
-
-    // Validate (no shell escape — runCli uses spawn, which takes args
-    // verbatim and would treat the single-quote wrapping as part of the
-    // literal path/profile, breaking Movement CLI argument parsing).
-    const safeDir = validatePathSafety(dir, "package directory");
-    const safeProfile = validateProfileSafety(profile);
-
-    console.log(`📦 Publishing module "${moduleName}" from ${dir}...`);
-
-    try {
-      // Get the deployer address to use for named addresses
-      const deployerAddress = account.accountAddress.toString();
-
-      // Detect named addresses from Move files
-      const { extractNamedAddresses } = await import("./commands/compile.js");
-      const detectedAddresses = extractNamedAddresses(dir);
-
-      // Build named addresses argument - use deployer address for all detected addresses.
-      // Stored as a pre-split args fragment so the spawn path never has to parse
-      // shell tokens; an empty fragment becomes a no-op via spread.
-      const namedAddrArgs: string[] = detectedAddresses.size > 0
-        ? [
-            "--named-addresses",
-            Array.from(detectedAddresses)
-              .map(name => `${name}=${deployerAddress}`)
-              .join(","),
-          ]
-        : [];
-
-      // Build first with named addresses
-      console.log("🔨 Building package...");
-      const buildResult = await runCli(
-        {
-          command: "movement",
-          args: ["move", "build", "--package-dir", safeDir, ...namedAddrArgs],
-          timeoutMs: 120000, // 2 minutes for git dependency downloads
-        },
-        { adapter: options?.adapter }
-      );
-      if (buildResult.stdout) console.log(buildResult.stdout.trim());
-
-      // Publish using direct parameters (avoid config file issues)
-      console.log("📤 Publishing to blockchain...");
-
-      // Use parameters directly instead of relying on config file
-      // Strip any ed25519-priv- prefix if present
-      let cleanPrivateKey = config.privateKey;
-      if (cleanPrivateKey.startsWith('ed25519-priv-')) {
-        cleanPrivateKey = cleanPrivateKey.replace('ed25519-priv-', '');
-      }
-
-      // deployerAddress is already declared above
-
-      // Read Move.toml to update named addresses with deployer address
-      const moveTomlPath = join(dir, 'Move.toml');
-      let originalMoveToml = '';
-
-      if (existsSync(moveTomlPath)) {
-        const { readFile, writeFile } = await import('fs').then(fs => fs.promises);
-        originalMoveToml = await readFile(moveTomlPath, 'utf-8');
-
-        // Replace addresses in [addresses] section with deployer address
-        const updatedMoveToml = originalMoveToml.replace(
-          /\[addresses\]([\s\S]*?)(?=\n\[|$)/,
-          (match, addressesSection) => {
-            const updatedSection = addressesSection.replace(
-              /^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*"0x[a-fA-F0-9]+"/gm,
-              `$1 = "${deployerAddress}"`
-            );
-            return `[addresses]${updatedSection}`;
-          }
-        );
-
-        // Write updated Move.toml temporarily
-        await writeFile(moveTomlPath, updatedMoveToml, 'utf-8');
-      }
-
-      let publishOut = '';
-      let publishErr = '';
-
-      // Setup Movement CLI config with private key securely
-      // Movement CLI uses .aptos config directory (not .movement)
-      const movementConfigDir = join(homedir(), '.aptos');
-      const movementConfigPath = join(movementConfigDir, 'config.yaml');
-      let originalMovementConfig = '';
-
-      try {
-        // Ensure .aptos directory exists
-        if (!existsSync(movementConfigDir)) {
-          mkdirSync(movementConfigDir, { recursive: true, mode: 0o700 });
-        }
-
-        // Backup original config if it exists
-        if (existsSync(movementConfigPath)) {
-          const { readFile } = await import('fs').then(fs => fs.promises);
-          originalMovementConfig = await readFile(movementConfigPath, 'utf-8');
-        }
-
-        // Create Movement config with private key
-        // Movement CLI reads from ~/.aptos/config.yaml
-        const movementConfig: any = originalMovementConfig ? yaml.load(originalMovementConfig) : {};
-
-        // Set profile with private key
-        // Use unescaped profile name as YAML key (YAML handles escaping automatically)
-        if (!movementConfig.profiles) {
-          movementConfig.profiles = {};
-        }
-        if (!movementConfig.profiles[profile]) {
-          movementConfig.profiles[profile] = {};
-        }
-
-        movementConfig.profiles[profile].private_key = cleanPrivateKey;
-        movementConfig.profiles[profile].public_key = account.publicKey.toString();
-        movementConfig.profiles[profile].account = deployerAddress;
-        movementConfig.profiles[profile].rest_url = config.rpc;
-
-        // Write config file with restrictive permissions
-        const configYaml = yaml.dump(movementConfig);
-        writeFileSync(movementConfigPath, configYaml, { mode: 0o600 });
-
-        // Execute publish command without exposing private key in CLI.
-        // Routed through runCli so stdout/stderr are redacted of any
-        // `ed25519-priv-…` shape before reaching console.log/console.error
-        // or the thrown CliExecutionError — that's bug #43.
-        const publishResult = await runCli(
-          {
-            command: "movement",
-            args: [
-              "move", "publish",
-              "--package-dir", safeDir,
-              "--url", config.rpc,
-              "--profile", safeProfile,
-              "--assume-yes",
-              ...namedAddrArgs,
-            ],
-            timeoutMs: 120000, // 2 minutes for blockchain transactions
-          },
-          { adapter: options?.adapter }
-        );
-        publishOut = publishResult.stdout;
-        publishErr = publishResult.stderr;
-        if (publishOut) console.log(publishOut.trim());
-        if (publishErr) console.error(publishErr.trim());
-      } finally {
-        // Restore original Movement config
-        if (existsSync(movementConfigPath)) {
-          if (originalMovementConfig) {
-            // Restore original config
-            writeFileSync(movementConfigPath, originalMovementConfig, { mode: 0o600 });
-          } else {
-            // Remove config file if it didn't exist before
-            const { unlink } = await import('fs').then(fs => fs.promises);
-            await unlink(movementConfigPath).catch(() => {});
-          }
-        }
-
-        // Restore original Move.toml
-        if (originalMoveToml && existsSync(moveTomlPath)) {
-          const { writeFile } = await import('fs').then(fs => fs.promises);
-          await writeFile(moveTomlPath, originalMoveToml, 'utf-8');
-        }
-      }
-
-      // Extract transaction hash from output
-      // Look for patterns like "Transaction hash: 0x..." or "Txn: 0x..." or just a 64-char hex
-      // The regex tries to match with context first, then falls back to any 64-char hex
-      let txHash: string | undefined;
-      const txHashMatchWithContext = publishOut.match(/(?:transaction\s*(?:hash)?|txn\s*(?:hash)?|hash):\s*(0x[a-fA-F0-9]{64})\b/i);
-      if (txHashMatchWithContext) {
-        txHash = txHashMatchWithContext[1];
-      } else {
-        // Fallback: try to find any 64-char hex string (exactly, not more)
-        const txHashMatch = publishOut.match(/\b(0x[a-fA-F0-9]{64})\b/);
-        if (txHashMatch) {
-          txHash = txHashMatch[1];
-        }
-      }
-
-      console.log(`✅ Module published successfully!`);
-
-      // Create deployment info
-      const deployment: DeploymentInfo = {
-        address: account.accountAddress.toString(),
-        moduleName,
-        network: config.network,
-        deployer: account.accountAddress.toString(),
-        timestamp: Date.now(),
-        txHash,
-      };
-
-      // Save deployment
-      saveDeployment(deployment);
-
-      return deployment;
-    } catch (error: any) {
-      if (error instanceof CliExecutionError) {
-        // stdout/stderr are already redacted by runCli before reaching here,
-        // so this branch is safe to log verbatim.
-        if (error.stdoutPreview) console.log(error.stdoutPreview);
-        console.error(`❌ Failed to publish module: ${error.message}\n${error.stderr}`);
-      } else {
-        // Preserve existing behaviour for non-CLI errors (filesystem write
-        // failures from Move.toml / ~/.aptos/config.yaml, yaml parse errors,
-        // etc.). These paths can't carry private-key material so logging raw
-        // is safe.
-        const errorMsg = error.stderr ? `${error.message}\n${error.stderr}` : error.message;
-        if (error.stdout) console.log(error.stdout);
-        console.error(`❌ Failed to publish module: ${errorMsg}`);
-      }
-      throw error;
-    }
+    // Thin orchestrator over Publisher (M1.4 / #79). The 250-line closure
+    // body lives in core/Publisher.ts and carries the bug fixes for
+    // #36 / #37 / #38.
+    return new Publisher({ adapter: options?.adapter }).deploy({
+      moduleName,
+      config,
+      account,
+      packageDir: options?.packageDir,
+    });
   };
 
   const getDeployment = (moduleName: string): DeploymentInfo | null => {


### PR DESCRIPTION
## Summary

Closes the M1.4 milestone (#79). The 273-line `runtime.deployContract` closure becomes a 17-line orchestrator over a new `src/core/Publisher.ts` class, and the three open security bugs that lived inside it are fixed along the way: #36 (signal leak), #37 (parallel-deploy race), #38 (destructive Move.toml mutation).

5 commits, each a complete functional unit:

| Commit | Topic |
|---|---|
| `930442d` | `refactor(core): extract Publisher.ts scaffold (behavior-identical)` |
| `d92992e` | `fix(core/Publisher): drop destructive Move.toml mutation (#38)` |
| `a869ce5` | `fix(core/Publisher): unique aptos profile name per deploy + yaml mutex (#37)` |
| `4d14d0c` | `fix(core/Publisher): signal-handler sync profile cleanup (#36)` |
| `2e38b58` | `docs(roadmap): tick M1.4 + rolled-up DoD bullets` |

## Design (decisions locked in plan, confirmed by Tier 2)

- **Path A — no per-deploy temp directory.** `#79`'s issue body suggested copying Move sources to a `mkdtemp` dir; instead we drop the Move.toml mutation entirely (closes #38) and rely on `--named-addresses` to convey deployer overrides. Verified by `pnpm test:example` (9/9) immediately after commit 2.
- **In-place yaml mutation, gated by an in-process async mutex.** Each deploy adds a unique `movehat-deploy-<uuid>` profile to `~/.aptos/config.yaml` and removes only that key on cleanup. The mutex serializes read-modify-write cycles so two `Promise.all` deploys can't drop each other's profile.
- **Atomic write order**: `writeFileSync` → `chmodSync 0o600` → `renameSync`. Eliminates the umask-derived window where the yaml could be world-readable while carrying the private key.
- **Signal-handler exit strategy**: cleanup synchronously, then `setImmediate(() => process.exit(code))` so vitest's own SIGINT handler and any other listener still get to run. Exit code 130 (SIGINT) / 143 (SIGTERM) — the standard 128+N convention.
- **`Publisher` marked `@internal`** — not part of the published movehat API surface (revisit at M5 / TypeDoc).

## Related issues

- Closes #19 — Move.toml + yaml integrity under parallel deploys.
- Closes #36 — Private key leaks when deploy is signal-killed mid-flight.
- Closes #37 — Race condition: concurrent deploys corrupt shared config.
- Closes #38 — Destructive Move.toml mutation.
- Closes #53 — Extract `deployContract` into a Publisher class.
- Refs #68 (M1 meta — M1.5/M1.6/M1.7 still pending before the next `develop → main` batch).

## How was this tested?

**Tier 1 (mechanical):**
- `pnpm --filter movehat exec tsc --noEmit` — clean.
- `pnpm --filter movehat test` — **184 / 184** (181 → +3 new: Move.toml-unchanged, parallel-deploy, signal-cleanup). The signal-cleanup test spawns a child process via tsx's resolved CLI binary and SIGINT's it mid-publish to verify synchronous yaml cleanup.
- DoD greps:
  - `grep -RnE "writeFile.*Move\.toml" packages/movehat/src` → empty.
  - `grep -n "process\.on\(.SIG" packages/movehat/src/core/Publisher.ts` → one match (the install).
  - `runtime.deployContract` is 17 lines (DoD ceiling: 30).

**Tier 2 (CLAUDE.md §6.2 — mandatory for runtime / Publisher changes):**
- `pnpm test:example` — **9 / 9** ✅. The `--named-addresses` hypothesis from #38 holds: real `movement move build`/`publish` succeed without any Move.toml mutation. Confirmed at commit 2 BEFORE building further on the assumption.
- `pnpm test:smoke` — pass ✅ (npm pack → global install → CLI surface).

Mocha teardown lag note: `pnpm test:example`'s wrapper hangs after the suite reports `9 passing` because the example mocha config doesn't pass `--exit` and the local-node handle keeps the event loop alive. Pre-existing behaviour on `develop` HEAD, unrelated to this PR. Worth a tiny follow-up to `examples/counter-example/.mocharc.json`.

## Checklist

- [x] `pnpm test` passes locally (184 / 184)
- [x] `pnpm test:example` (9 / 9)
- [x] `pnpm test:smoke` (pass)
- [x] CHANGELOG — N/A (internal refactor + security fixes; same exemption as M1.x sub-PRs)
- [x] Docs — ROADMAP M1.4 row + rolled-up DoD bullets ticked. Public API unchanged (the test-only `adapter?` parameter already existed since M1.3c).
- [x] Conventional Commits used (3 `fix:`, 1 `refactor:`, 1 `docs:`)
- [x] Self-review per CLAUDE.md §8 — posted as a separate review comment after PR opens

## Out of scope (flagged for follow-up)

- Two parallel deploys with the SAME moduleName still race on `saveDeployment` (a separate JSON write to `deployments/<network>.json`). Distinct bug, opening a follow-up issue is appropriate.
- Mocha `--exit` flag in `examples/counter-example/.mocharc.json` — small follow-up to remove the teardown lag.
- The yaml mutation strategy reformats user's existing `~/.aptos/config.yaml` (loses comments). Same as today's behaviour — accepted as continuity. Worth revisiting at M5 if it surfaces in real consumer feedback.

## Self-review will follow as a separate comment.