### PR TITLE
refactor(cli): replace bare emoji literals with figures-based logger calls

### DIFF
--- a/packages/movehat/src/commands/fork/fund.ts
+++ b/packages/movehat/src/commands/fork/fund.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { ForkManager } from '../../fork/manager.js';
+import { logger } from '../../ui/index.js';
 
 interface ForkFundOptions {
   fork?: string;
@@ -30,11 +31,13 @@ export default async function forkFundCommand(options: ForkFundOptions) {
     const forkPath = options.fork || join(process.cwd(), '.movehat', 'forks', 'testnet-fork');
     const coinType = options.coinType || '0x1::aptos_coin::AptosCoin';
 
-    console.log(`\n💰 Funding account in fork`);
-    console.log(`   Fork: ${forkPath}`);
-    console.log(`   Account: ${options.account}`);
-    console.log(`   Amount: ${amount}`);
-    console.log(`   Coin Type: ${coinType}\n`);
+    logger.newline();
+    logger.step("Funding account in fork");
+    logger.plain(`   Fork: ${forkPath}`);
+    logger.plain(`   Account: ${options.account}`);
+    logger.plain(`   Amount: ${amount}`);
+    logger.plain(`   Coin Type: ${coinType}`);
+    logger.newline();
 
     // Load fork
     const forkManager = new ForkManager(forkPath);
@@ -47,11 +50,15 @@ export default async function forkFundCommand(options: ForkFundOptions) {
     const resourceType = `0x1::coin::CoinStore<${coinType}>`;
     const coinStore = await forkManager.getResource(options.account, resourceType);
 
-    console.log(`\n✅ Account funded successfully!`);
-    console.log(`   New balance: ${coinStore.coin.value}\n`);
+    logger.newline();
+    logger.success("Account funded successfully!");
+    logger.plain(`   New balance: ${coinStore.coin.value}`);
+    logger.newline();
 
   } catch (error: any) {
-    console.error(`\n❌ Error: ${error.message}\n`);
+    logger.newline();
+    logger.error(error.message);
+    logger.newline();
     process.exit(1);
   }
 }

--- a/packages/movehat/src/commands/fork/view-resource.ts
+++ b/packages/movehat/src/commands/fork/view-resource.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { ForkManager } from '../../fork/manager.js';
+import { logger } from '../../ui/index.js';
 
 interface ForkViewResourceOptions {
   fork?: string;
@@ -23,10 +24,12 @@ export default async function forkViewResourceCommand(options: ForkViewResourceO
     // Determine fork path
     const forkPath = options.fork || join(process.cwd(), '.movehat', 'forks', 'testnet-fork');
 
-    console.log(`\n🔍 Viewing resource from fork`);
-    console.log(`   Fork: ${forkPath}`);
-    console.log(`   Account: ${options.account}`);
-    console.log(`   Resource: ${options.resource}\n`);
+    logger.newline();
+    logger.step("Viewing resource from fork");
+    logger.plain(`   Fork: ${forkPath}`);
+    logger.plain(`   Account: ${options.account}`);
+    logger.plain(`   Resource: ${options.resource}`);
+    logger.newline();
 
     // Load fork
     const forkManager = new ForkManager(forkPath);
@@ -40,7 +43,9 @@ export default async function forkViewResourceCommand(options: ForkViewResourceO
     console.log('');
 
   } catch (error: any) {
-    console.error(`\n❌ Error: ${error.message}\n`);
+    logger.newline();
+    logger.error(error.message);
+    logger.newline();
     process.exit(1);
   }
 }

--- a/packages/movehat/src/commands/run.ts
+++ b/packages/movehat/src/commands/run.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
 import { runCli } from "../utils/runCli.js";
+import { logger } from "../ui/index.js";
 import type { RunResult } from "../utils/childProcessAdapter.js";
 
 /**
@@ -28,9 +29,9 @@ export function propagateRunResultExit(result: RunResult): void {
 
 export default async function runCommand(scriptPath: string) {
   if (!scriptPath) {
-    console.error("❌ Error: No script path provided");
-    console.error("Usage: movehat run <script-path> [--network <name>]");
-    console.error("Example: movehat run scripts/deploy-counter.ts --network testnet");
+    logger.error("No script path provided");
+    logger.plain("Usage: movehat run <script-path> [--network <name>]");
+    logger.plain("Example: movehat run scripts/deploy-counter.ts --network testnet");
     process.exit(1);
   }
 
@@ -38,24 +39,24 @@ export default async function runCommand(scriptPath: string) {
 
   // Check if file exists
   if (!existsSync(fullPath)) {
-    console.error(`❌ Script not found: ${scriptPath}`);
+    logger.error(`Script not found: ${scriptPath}`);
     process.exit(1);
   }
 
   // Check if it's a TypeScript or JavaScript file
   const ext = extname(fullPath);
   if (![".ts", ".js", ".mjs"].includes(ext)) {
-    console.error(`❌ Unsupported file type: ${ext}`);
-    console.error("Supported extensions: .ts, .js, .mjs");
+    logger.error(`Unsupported file type: ${ext}`);
+    logger.plain("Supported extensions: .ts, .js, .mjs");
     process.exit(1);
   }
 
   const network = process.env.MH_CLI_NETWORK;
-  console.log(`🚀 Running script: ${scriptPath}`);
+  logger.step(`Running script: ${scriptPath}`);
   if (network) {
-    console.log(`   Network: ${network}`);
+    logger.plain(`   Network: ${network}`);
   }
-  console.log();
+  logger.newline();
 
   // Find tsx binary - try multiple locations for compatibility
   // Uses require.resolve for cross-platform compatibility (works on Windows, macOS, Linux)
@@ -94,9 +95,9 @@ export default async function runCommand(scriptPath: string) {
   }
 
   if (!tsxPath) {
-    console.error("❌ Error: tsx binary not found");
-    console.error("   Make sure 'tsx' is installed in your project:");
-    console.error("   npm install --save-dev tsx");
+    logger.error("tsx binary not found");
+    logger.plain("   Make sure 'tsx' is installed in your project:");
+    logger.plain("   npm install --save-dev tsx");
     process.exit(1);
   }
 
@@ -118,7 +119,7 @@ export default async function runCommand(scriptPath: string) {
 
     propagateRunResultExit(result);
   } catch (error) {
-    console.error(`❌ Failed to execute script: ${(error as Error).message}`);
+    logger.error(`Failed to execute script: ${(error as Error).message}`);
     process.exit(1);
   }
 }

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -24,6 +24,7 @@ import {
 import { validatePathSafety, validateProfileSafety } from "./shell.js";
 import { CliExecutionError, ModuleAlreadyDeployedError } from "../errors.js";
 import { runCli } from "../utils/runCli.js";
+import { logger } from "../ui/index.js";
 import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
 
 /**
@@ -227,18 +228,18 @@ export class Publisher {
         .join("\n");
 
       // Log formatted error message for user
-      const formattedMessage = [
-        `\n❌ Module "${moduleName}" is already deployed on ${config.network}`,
-        `   Address: ${existingDeployment.address}`,
-        `   Deployed at: ${new Date(existingDeployment.timestamp).toLocaleString()}`,
-        existingDeployment.txHash ? `   Transaction: ${existingDeployment.txHash}` : null,
-        `\n💡 To redeploy, run with the --redeploy flag:`,
-        `   movehat run <script> --network ${config.network} --redeploy\n`,
-      ]
-        .filter(Boolean)
-        .join("\n");
-
-      console.error(formattedMessage);
+      logger.error(`Module "${moduleName}" is already deployed on ${config.network}`);
+      logger.plain(`   Address: ${existingDeployment.address}`);
+      logger.plain(
+        `   Deployed at: ${new Date(existingDeployment.timestamp).toLocaleString()}`
+      );
+      if (existingDeployment.txHash) {
+        logger.plain(`   Transaction: ${existingDeployment.txHash}`);
+      }
+      logger.newline();
+      logger.info("To redeploy, run with the --redeploy flag:");
+      logger.plain(`   movehat run <script> --network ${config.network} --redeploy`);
+      logger.newline();
 
       // Throw custom error with complete context for programmatic handling
       throw new ModuleAlreadyDeployedError(
@@ -252,7 +253,7 @@ export class Publisher {
     }
 
     if (forceRedeploy && existingDeployment) {
-      console.log(`🔄 Redeploying module "${moduleName}" on ${config.network}...`);
+      logger.info(`Redeploying module "${moduleName}" on ${config.network}...`);
     }
 
     const dir = input.packageDir || config.moveDir;
@@ -270,7 +271,7 @@ export class Publisher {
     const safeDir = validatePathSafety(dir, "package directory");
     const safeProfile = validateProfileSafety(profile);
 
-    console.log(`📦 Publishing module "${moduleName}" from ${dir}...`);
+    logger.step(`Publishing module "${moduleName}" from ${dir}...`);
 
     try {
       // Get the deployer address to use for named addresses
@@ -293,7 +294,7 @@ export class Publisher {
           : [];
 
       // Build first with named addresses
-      console.log("🔨 Building package...");
+      logger.step("Building package...");
       const buildResult = await runCli(
         {
           command: "movement",
@@ -305,7 +306,7 @@ export class Publisher {
       if (buildResult.stdout) console.log(buildResult.stdout.trim());
 
       // Publish using direct parameters (avoid config file issues)
-      console.log("📤 Publishing to blockchain...");
+      logger.step("Publishing to blockchain...");
 
       // Use parameters directly instead of relying on config file
       // Strip any ed25519-priv- prefix if present
@@ -406,7 +407,7 @@ export class Publisher {
         }
       }
 
-      console.log(`✅ Module published successfully!`);
+      logger.success("Module published successfully!");
 
       // Create deployment info
       const deployment: DeploymentInfo = {
@@ -427,7 +428,7 @@ export class Publisher {
         // stdout/stderr are already redacted by runCli before reaching here,
         // so this branch is safe to log verbatim.
         if (error.stdoutPreview) console.log(error.stdoutPreview);
-        console.error(`❌ Failed to publish module: ${error.message}\n${error.stderr}`);
+        logger.error(`Failed to publish module: ${error.message}\n${error.stderr}`);
       } else {
         // Preserve existing behaviour for non-CLI errors (filesystem write
         // failures from Move.toml / ~/.aptos/config.yaml, yaml parse errors,
@@ -435,7 +436,7 @@ export class Publisher {
         // is safe.
         const errorMsg = error.stderr ? `${error.message}\n${error.stderr}` : error.message;
         if (error.stdout) console.log(error.stdout);
-        console.error(`❌ Failed to publish module: ${errorMsg}`);
+        logger.error(`Failed to publish module: ${errorMsg}`);
       }
       throw error;
     }

--- a/packages/movehat/src/core/contract.ts
+++ b/packages/movehat/src/core/contract.ts
@@ -4,6 +4,7 @@ import {
   type InputViewFunctionData,
   type MoveFunctionId,
 } from "@aptos-labs/ts-sdk";
+import { logger } from "../ui/index.js";
 
 export interface TransactionResult {
   hash: string;
@@ -26,7 +27,7 @@ export class MoveContract {
   ): Promise<TransactionResult> {
     const functionFullName = `${this.moduleAddress}::${this.moduleName}::${functionName}`;
 
-    console.log(`📝 Calling ${functionFullName}...`);
+    logger.step(`Calling ${functionFullName}...`);
 
     const transaction = await this.aptos.transaction.build.simple({
       sender: signer.accountAddress,
@@ -51,9 +52,10 @@ export class MoveContract {
       transactionHash: committedTxn.hash,
     });
 
-    console.log(
-      `✅ Transaction ${committedTxn.hash} committed with status: ${response.vm_status}\n`
+    logger.success(
+      `Transaction ${committedTxn.hash} committed with status: ${response.vm_status}`
     );
+    logger.newline();
 
     return {
       hash: committedTxn.hash,

--- a/packages/movehat/src/core/deployments.ts
+++ b/packages/movehat/src/core/deployments.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "fs";
 import { join } from "path";
+import { logger } from "../ui/index.js";
 
 export interface DeploymentInfo {
   address: string;
@@ -90,8 +91,8 @@ export function saveDeployment(deployment: DeploymentInfo): void {
 
   try {
     writeFileSync(filePath, JSON.stringify(deployment, null, 2), "utf-8");
-    console.log(
-      `💾 Deployment saved: deployments/${deployment.network}/${deployment.moduleName}.json`
+    logger.success(
+      `Deployment saved: deployments/${deployment.network}/${deployment.moduleName}.json`
     );
   } catch (error) {
     console.error(

--- a/packages/movehat/src/fork/manager.ts
+++ b/packages/movehat/src/fork/manager.ts
@@ -2,6 +2,7 @@ import { MovementApiClient } from './api.js';
 import { ForkStorage } from './storage.js';
 import type { ForkMetadata, AccountState } from '../types/fork.js';
 import { normalizeAddress } from '../utils/address.js';
+import { logger } from '../ui/index.js';
 
 /**
  * Manager for fork operations
@@ -263,13 +264,15 @@ export class ForkManager {
     amount: number,
     coinType: string = '0x1::aptos_coin::AptosCoin'
   ): Promise<void> {
-    console.log(`\n💰 Funding ${addresses.length} accounts with ${amount} coins each...`);
+    logger.newline();
+    logger.step(`Funding ${addresses.length} accounts with ${amount} coins each...`);
 
     for (const address of addresses) {
       await this.fundAccount(address, amount, coinType);
     }
 
-    console.log(`✓ All accounts funded successfully\n`);
+    logger.success("All accounts funded successfully");
+    logger.newline();
   }
 
   /**
@@ -280,13 +283,15 @@ export class ForkManager {
    * await forkManager.resetState();
    */
   async resetState(): Promise<void> {
-    console.log(`\n🔄 Resetting fork state...`);
+    logger.newline();
+    logger.step("Resetting fork state...");
 
     // Clear all accounts and resources from storage
     this.storage.clearAccounts();
     this.storage.clearResources();
 
-    console.log(`✓ Fork state reset to initial snapshot\n`);
+    logger.success("Fork state reset to initial snapshot");
+    logger.newline();
   }
 
   /**

--- a/packages/movehat/src/fork/server.ts
+++ b/packages/movehat/src/fork/server.ts
@@ -90,7 +90,7 @@ export class ForkServer {
         console.log(`  Bound interface: ${this.host}`);
         console.log(`  Ledger Info: http://${displayHost}:${this.port}/v1/`);
         if (this.host === '0.0.0.0') {
-          console.warn(`  ⚠️  Server is bound to 0.0.0.0 — fork state is reachable from the LAN.`);
+          console.warn(`  Server is bound to 0.0.0.0 — fork state is reachable from the LAN.`);
         }
         console.log(`\nPress Ctrl+C to stop`);
         resolve();

--- a/packages/movehat/src/helpers/setup.ts
+++ b/packages/movehat/src/helpers/setup.ts
@@ -8,6 +8,7 @@ import {
 import { loadUserConfig, resolveNetworkConfig } from "../core/config.js";
 import { MovehatConfig } from "../types/config.js";
 import { AccountManager } from "../core/AccountManager.js";
+import { logger } from "../ui/index.js";
 
 export interface TestEnvironment {
   aptos: Aptos;
@@ -33,10 +34,11 @@ export async function setupTestEnvironment(networkName?: string): Promise<TestEn
   // Load account using AccountManager
   const account = AccountManager.loadAccountFromPrivateKey(config.privateKey);
 
-  console.log(`✅ Test environment ready`);
-  console.log(`   Account: ${account.accountAddress.toString()}`);
-  console.log(`   Network: ${config.network}`);
-  console.log(`   RPC: ${config.rpc}\n`);
+  logger.success("Test environment ready");
+  logger.plain(`   Account: ${account.accountAddress.toString()}`);
+  logger.plain(`   Network: ${config.network}`);
+  logger.plain(`   RPC: ${config.rpc}`);
+  logger.newline();
 
   return {
     aptos,

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -6,6 +6,7 @@ import { ForkManager } from "../fork/manager.js";
 import { ForkServer } from "../fork/server.js";
 import { LocalNodeManager } from "../node/LocalNodeManager.js";
 import { AccountManager } from "../core/AccountManager.js";
+import { logger } from "../ui/index.js";
 import type { LocalTestOptions } from "../types/config.js";
 
 let currentForkServer: ForkServer | null = null;
@@ -59,9 +60,11 @@ export async function setupLocalTesting(
   const defaultBalance = options.defaultBalance || 100_000_000; // 100 APT
   const accountLabels = options.accountLabels || ["deployer", "alice", "bob"];
 
-  console.log(`\n🔧 Setting up local testing environment...`);
-  console.log(`   Mode: ${mode}`);
-  console.log(`   Accounts: ${accountLabels.join(", ")}\n`);
+  logger.newline();
+  logger.step("Setting up local testing environment...");
+  logger.plain(`   Mode: ${mode}`);
+  logger.plain(`   Accounts: ${accountLabels.join(", ")}`);
+  logger.newline();
 
   if (mode === 'local-node') {
     return await setupWithLocalNode(options, accountLabels, autoFund, defaultBalance);
@@ -101,13 +104,13 @@ async function setupWithLocalNode(
   const nodeInfo = await localNode.start();
 
   // 2. Generate accounts with AccountManager
-  console.log(`👥 Generating ${accountLabels.length} test accounts...`);
+  logger.step(`Generating ${accountLabels.length} test accounts...`);
   const accounts = AccountManager.createBatch(accountLabels);
 
   for (const [label, account] of Object.entries(accounts)) {
-    console.log(`   ${label}: ${account.accountAddress.toString()}`);
+    logger.plain(`   ${label}: ${account.accountAddress.toString()}`);
   }
-  console.log();
+  logger.newline();
 
   // 3. Fund accounts from local faucet
   if (autoFund) {
@@ -116,7 +119,7 @@ async function setupWithLocalNode(
   }
 
   // 4. Initialize runtime pointing to local node
-  console.log(`⚙️  Initializing runtime for local network...`);
+  logger.step("Initializing runtime for local network...");
 
   const deployerPrivateKey = AccountManager.exportPrivateKeys(["deployer"]).deployer;
 
@@ -137,11 +140,12 @@ async function setupWithLocalNode(
     },
   });
 
-  console.log(`✓ Runtime initialized\n`);
+  logger.success("Runtime initialized");
+  logger.newline();
 
   // 5. Auto-deploy modules if specified
   if (options.autoDeploy && options.autoDeploy.length > 0) {
-    console.log(`📦 Auto-deploying ${options.autoDeploy.length} module(s)...`);
+    logger.step(`Auto-deploying ${options.autoDeploy.length} module(s)...`);
 
     // Force redeploy in local-node mode (for testing)
     const previousRedeploy = process.env.MH_CLI_REDEPLOY;
@@ -150,11 +154,11 @@ async function setupWithLocalNode(
     try {
       for (const moduleName of options.autoDeploy) {
         try {
-          console.log(`   Deploying ${moduleName}...`);
+          logger.plain(`   Deploying ${moduleName}...`);
           await runtime.deployContract(moduleName);
-          console.log(`   ✓ ${moduleName} deployed`);
+          logger.success(`${moduleName} deployed`, 2);
         } catch (error: any) {
-          console.error(`   ✗ Failed to deploy ${moduleName}: ${error.message}`);
+          logger.error(`Failed to deploy ${moduleName}: ${error.message}`, 2);
           throw error;
         }
       }
@@ -167,15 +171,17 @@ async function setupWithLocalNode(
       }
     }
 
-    console.log();
+    logger.newline();
   }
 
-  console.log(`✅ Local testing environment ready!\n`);
-  console.log(`   Mode: local-node`);
-  console.log(`   RPC: ${nodeInfo.rpcUrl}/v1`);
-  console.log(`   Faucet: ${nodeInfo.faucetUrl}`);
-  console.log(`   Accounts: ${Array.from(accountLabels).join(", ")}`);
-  console.log(`   Balance per account: ${defaultBalance / 100_000_000} APT\n`);
+  logger.success("Local testing environment ready!");
+  logger.newline();
+  logger.plain(`   Mode: local-node`);
+  logger.plain(`   RPC: ${nodeInfo.rpcUrl}/v1`);
+  logger.plain(`   Faucet: ${nodeInfo.faucetUrl}`);
+  logger.plain(`   Accounts: ${Array.from(accountLabels).join(", ")}`);
+  logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} APT`);
+  logger.newline();
 
   return runtime;
 }
@@ -194,14 +200,16 @@ async function setupWithFork(
   const forkPort = options.forkPort || 8080;
   const forkResetState = options.forkResetState !== false; // default true
 
-  console.log(`   Fork network: ${forkNetwork}`);
-  console.log(`   Fork name: ${forkName}`);
-  console.log(`   Server port: ${forkPort}\n`);
+  logger.plain(`   Fork network: ${forkNetwork}`);
+  logger.plain(`   Fork name: ${forkName}`);
+  logger.plain(`   Server port: ${forkPort}`);
+  logger.newline();
 
   // Warn about auto-deploy in fork mode
   if (options.autoDeploy && options.autoDeploy.length > 0) {
-    console.warn(`⚠️  WARNING: Auto-deploy doesn't work in fork mode (read-only).`);
-    console.warn(`   Switch to 'local-node' mode for deployment support.\n`);
+    logger.warning("Auto-deploy doesn't work in fork mode (read-only).");
+    logger.plain("   Switch to 'local-node' mode for deployment support.");
+    logger.newline();
   }
 
   // 1. Setup fork
@@ -212,40 +220,42 @@ async function setupWithFork(
   const forkExists = existsSync(join(forkPath, "metadata.json"));
 
   if (!forkExists) {
-    console.log(`📸 Creating fork from ${forkNetwork}...`);
+    logger.step(`Creating fork from ${forkNetwork}...`);
     const testnetRpc = "https://testnet.movementnetwork.xyz/v1";
     await forkManager.initialize(testnetRpc, forkNetwork);
-    console.log(`✓ Fork created at ${forkPath}\n`);
+    logger.success(`Fork created at ${forkPath}`);
+    logger.newline();
   } else {
-    console.log(`✓ Loading existing fork from ${forkPath}`);
+    logger.success(`Loading existing fork from ${forkPath}`);
     forkManager.load();
 
     if (forkResetState) {
-      console.log(`🔄 Resetting fork state...`);
+      logger.step("Resetting fork state...");
       await forkManager.resetState();
     }
 
-    console.log();
+    logger.newline();
   }
 
   // 2. Start fork server
-  console.log(`🚀 Starting fork server on port ${forkPort}...`);
+  logger.step(`Starting fork server on port ${forkPort}...`);
   const forkServer = new ForkServer(forkPath, forkPort);
   currentForkServer = forkServer;
 
   await forkServer.start();
-  console.log(`✓ Fork server running at http://localhost:${forkPort}\n`);
+  logger.success(`Fork server running at http://localhost:${forkPort}`);
+  logger.newline();
 
   await new Promise((resolve) => setTimeout(resolve, 500));
 
   // 3. Generate accounts
-  console.log(`👥 Generating ${accountLabels.length} test accounts...`);
+  logger.step(`Generating ${accountLabels.length} test accounts...`);
   const accounts = AccountManager.createBatch(accountLabels);
 
   for (const [label, account] of Object.entries(accounts)) {
-    console.log(`   ${label}: ${account.accountAddress.toString()}`);
+    logger.plain(`   ${label}: ${account.accountAddress.toString()}`);
   }
-  console.log();
+  logger.newline();
 
   // 4. Fund accounts in fork
   if (autoFund) {
@@ -256,7 +266,7 @@ async function setupWithFork(
   }
 
   // 5. Initialize runtime pointing to fork
-  console.log(`⚙️  Initializing runtime for local network...`);
+  logger.step("Initializing runtime for local network...");
 
   const deployerPrivateKey = AccountManager.exportPrivateKeys(["deployer"]).deployer;
 
@@ -277,12 +287,15 @@ async function setupWithFork(
     },
   });
 
-  console.log(`✓ Runtime initialized\n`);
-  console.log(`✅ Local testing environment ready!\n`);
-  console.log(`   Mode: fork (read-only)`);
-  console.log(`   RPC: http://localhost:${forkPort}/v1`);
-  console.log(`   Accounts: ${Array.from(accountLabels).join(", ")}`);
-  console.log(`   Balance per account: ${defaultBalance / 100_000_000} APT\n`);
+  logger.success("Runtime initialized");
+  logger.newline();
+  logger.success("Local testing environment ready!");
+  logger.newline();
+  logger.plain(`   Mode: fork (read-only)`);
+  logger.plain(`   RPC: http://localhost:${forkPort}/v1`);
+  logger.plain(`   Accounts: ${Array.from(accountLabels).join(", ")}`);
+  logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} APT`);
+  logger.newline();
 
   return runtime;
 }
@@ -291,7 +304,8 @@ async function setupWithFork(
  * Stop the local testing environment (cleanup)
  */
 export async function stopLocalTesting(): Promise<void> {
-  console.log(`\n🛑 Stopping local testing environment...`);
+  logger.newline();
+  logger.step("Stopping local testing environment...");
 
   // Stop local node if running
   if (currentLocalNode) {
@@ -306,7 +320,8 @@ export async function stopLocalTesting(): Promise<void> {
     currentForkManager = null;
   }
 
-  console.log(`✓ Environment stopped\n`);
+  logger.success("Environment stopped");
+  logger.newline();
 }
 
 /**

--- a/packages/movehat/src/helpers/testFixtures.ts
+++ b/packages/movehat/src/helpers/testFixtures.ts
@@ -3,6 +3,7 @@ import type { MovehatRuntime } from "../types/runtime.js";
 import type { MoveContract } from "../core/contract.js";
 import { AccountManager } from "../core/AccountManager.js";
 import { setupLocalTesting, stopLocalTesting } from "./setupLocalTesting.js";
+import { logger } from "../ui/index.js";
 import type { LocalTestOptions } from "../types/config.js";
 
 /**
@@ -83,9 +84,11 @@ export async function setupTestFixture<TModules extends readonly string[]>(
   accountLabels: string[] = ["alice", "bob"],
   options: Partial<LocalTestOptions> = {}
 ): Promise<TestFixture<TModules[number]>> {
-  console.log(`\n🧪 Setting up test fixture...`);
-  console.log(`   Modules to deploy: ${modules.join(", ")}`);
-  console.log(`   Account labels: deployer, ${accountLabels.join(", ")}\n`);
+  logger.newline();
+  logger.step("Setting up test fixture...");
+  logger.plain(`   Modules to deploy: ${modules.join(", ")}`);
+  logger.plain(`   Account labels: deployer, ${accountLabels.join(", ")}`);
+  logger.newline();
 
   // Ensure 'deployer' is always in the account labels
   const allLabels = ["deployer", ...accountLabels.filter((l) => l !== "deployer")];
@@ -126,10 +129,12 @@ export async function setupTestFixture<TModules extends readonly string[]>(
     }
 
     contracts[moduleName as TModules[number]] = mh.getContract(deploymentAddress, moduleName);
-    console.log(`   ✓ Contract "${moduleName}" ready at ${deploymentAddress}`);
+    logger.success(`Contract "${moduleName}" ready at ${deploymentAddress}`, 2);
   }
 
-  console.log(`\n✅ Test fixture ready!\n`);
+  logger.newline();
+  logger.success("Test fixture ready!");
+  logger.newline();
 
   return {
     mh,
@@ -153,7 +158,8 @@ export async function setupTestFixture<TModules extends readonly string[]>(
  * ```
  */
 export async function teardownTestFixture(): Promise<void> {
-  console.log(`\n🧹 Tearing down test fixture...`);
+  logger.newline();
+  logger.step("Tearing down test fixture...");
 
   // Stop fork server
   await stopLocalTesting();
@@ -161,7 +167,8 @@ export async function teardownTestFixture(): Promise<void> {
   // Clear account pool for test isolation
   AccountManager.clearPool();
 
-  console.log(`✓ Teardown complete\n`);
+  logger.success("Teardown complete");
+  logger.newline();
 }
 
 /**
@@ -191,7 +198,8 @@ export async function setupMinimalFixture(
   accountLabels: string[] = ["alice", "bob"],
   options: Partial<LocalTestOptions> = {}
 ): Promise<Omit<TestFixture, "contracts">> {
-  console.log(`\n🧪 Setting up minimal test fixture (no auto-deploy)...`);
+  logger.newline();
+  logger.step("Setting up minimal test fixture (no auto-deploy)...");
 
   const allLabels = ["deployer", ...accountLabels.filter((l) => l !== "deployer")];
 
@@ -213,7 +221,9 @@ export async function setupMinimalFixture(
     accounts[label] = labeledAccounts[label] || AccountManager.getOrCreateLabeled(label);
   }
 
-  console.log(`\n✅ Minimal fixture ready!\n`);
+  logger.newline();
+  logger.success("Minimal fixture ready!");
+  logger.newline();
 
   return {
     mh,

--- a/packages/movehat/src/node/LocalNodeManager.ts
+++ b/packages/movehat/src/node/LocalNodeManager.ts
@@ -6,6 +6,7 @@ import {
   type ChildProcessAdapter,
   type SpawnedProcess,
 } from "../utils/childProcessAdapter.js";
+import { logger } from "../ui/index.js";
 
 export interface LocalNodeOptions {
   testDir?: string;           // Directory for node data (default: .movehat/local-node)
@@ -74,15 +75,17 @@ export class LocalNodeManager {
     this.starting = true;
 
     try {
-      console.log("\n🚀 Starting local Movement node...");
-      console.log(`   Test directory: ${this.options.testDir}`);
-      console.log(`   RPC port: ${this.options.apiPort}`);
-      console.log(`   Faucet port: ${this.options.faucetPort}`);
-      console.log(`   Ready port: ${this.options.readyPort}\n`);
+      logger.newline();
+      logger.step("Starting local Movement node...");
+      logger.plain(`   Test directory: ${this.options.testDir}`);
+      logger.plain(`   RPC port: ${this.options.apiPort}`);
+      logger.plain(`   Faucet port: ${this.options.faucetPort}`);
+      logger.plain(`   Ready port: ${this.options.readyPort}`);
+      logger.newline();
 
       // Clean state if force restart
       if (this.options.forceRestart && existsSync(this.options.testDir)) {
-        console.log("🧹 Cleaning previous node state...");
+        logger.step("Cleaning previous node state...");
         rmSync(this.options.testDir, { recursive: true, force: true });
       }
 
@@ -131,16 +134,17 @@ export class LocalNodeManager {
       // surface a detailed timeout-with-hints error if movement never starts.
       void this.spawned.exited.then(({ code }) => {
         if (code !== null && code !== 0) {
-          console.error(`\n❌ Local node exited with code ${code}`);
+          logger.error(`Local node exited with code ${code}`);
         }
         this.spawned = null;
       });
 
       // Wait for node to be ready
-      console.log("⏳ Waiting for node to be ready...");
+      logger.step("Waiting for node to be ready...");
       await this.waitForReady(60000); // 60 second timeout
 
-      console.log("✅ Local Movement node is ready!\n");
+      logger.success("Local Movement node is ready!");
+      logger.newline();
 
       this.starting = false;
       return this.getNodeInfo();
@@ -167,7 +171,8 @@ export class LocalNodeManager {
       return;
     }
 
-    console.log("\n🛑 Stopping local Movement node...");
+    logger.newline();
+    logger.step("Stopping local Movement node...");
 
     const spawned = this.spawned;
 
@@ -181,14 +186,15 @@ export class LocalNodeManager {
     // Force kill after 5 seconds if still running
     const forceTimer = setTimeout(() => {
       if (this.spawned === spawned) {
-        console.log("⚠️  Force killing node...");
+        logger.warning("Force killing node...");
         spawned.kill("SIGKILL");
       }
     }, 5000);
 
     try {
       await spawned.exited;
-      console.log("✅ Local node stopped\n");
+      logger.success("Local node stopped");
+      logger.newline();
     } finally {
       clearTimeout(forceTimer);
       if (this.spawned === spawned) {
@@ -275,7 +281,7 @@ export class LocalNodeManager {
       }
 
       const result = await response.json();
-      console.log(`  ✓ Funded ${address} with ${amount} octas`);
+      logger.success(`Funded ${address} with ${amount} octas`, 2);
 
       return result;
     } catch (error: any) {
@@ -287,13 +293,15 @@ export class LocalNodeManager {
    * Fund multiple accounts in batch
    */
   async fundAccounts(accounts: (Account | string)[], amount: number = 100_000_000): Promise<void> {
-    console.log(`\n💰 Funding ${accounts.length} accounts from local faucet...`);
+    logger.newline();
+    logger.step(`Funding ${accounts.length} accounts from local faucet...`);
 
     for (const account of accounts) {
       await this.fundAccount(account, amount);
     }
 
-    console.log(`✓ All accounts funded successfully\n`);
+    logger.success("All accounts funded successfully");
+    logger.newline();
   }
 
   /**
@@ -305,9 +313,9 @@ export class LocalNodeManager {
     }
 
     if (existsSync(this.options.testDir)) {
-      console.log(`🧹 Cleaning node data at ${this.options.testDir}...`);
+      logger.step(`Cleaning node data at ${this.options.testDir}...`);
       rmSync(this.options.testDir, { recursive: true, force: true });
-      console.log("✓ Node data cleaned");
+      logger.success("Node data cleaned");
     }
   }
 }

--- a/packages/movehat/src/ui/logger.ts
+++ b/packages/movehat/src/ui/logger.ts
@@ -120,6 +120,27 @@ export const warning = (message: string, indent: number = 0): void => {
 };
 
 /**
+ * Action / progress message (dim chevron prefix)
+ * Use for in-progress action lines like "Building package", "Publishing
+ * to blockchain" — anything that's a status update during a multi-step
+ * operation. Distinct from `info` (general updates) and `success`
+ * (completion).
+ *
+ * @param message - Message to log
+ * @param indent - Number of spaces to indent (default: 0)
+ *
+ * @example
+ * logger.step('Building package...');
+ * logger.step('Publishing to blockchain...');
+ * logger.success('Module published successfully!');
+ */
+export const step = (message: string, indent: number = 0): void => {
+  if (config.silent) return;
+  const formatted = formatMessage(message, indent);
+  console.log(`${colors.dim(symbols.step)} ${formatted}`);
+};
+
+/**
  * Plain message without symbol
  * Use for continuation lines or when symbol is not appropriate
  *
@@ -218,6 +239,7 @@ export const logger = {
   success,
   error,
   warning,
+  step,
   plain,
   newline,
   section,

--- a/packages/movehat/src/ui/symbols.ts
+++ b/packages/movehat/src/ui/symbols.ts
@@ -16,7 +16,13 @@ export const symbols = {
   warning: figures.warning,       // ⚠ or ‼
   info: figures.info,             // ℹ or i
 
-  // Action symbols
+  // Action / progress symbols
+  step: '▸',                 // ▸  — used to prefix in-progress action lines
+                                  // (e.g. "▸ Building package"). Plain Unicode
+                                  // BLACK RIGHT-POINTING SMALL TRIANGLE, supported
+                                  // in every UTF-8 terminal. If a non-UTF-8
+                                  // environment ever surfaces, switch to
+                                  // figures.pointerSmall ('›' with ASCII fallback).
   pointer: figures.pointer,       // ❯ or >
   checkboxOn: figures.checkboxOn, // ☑ or [×]
   checkboxOff: figures.checkboxOff, // ☐ or [ ]


### PR DESCRIPTION
## Summary

Closes the consistency gap surfaced after building out `src/ui/` (the `figures`-based symbols + typed logger module): every CLI surface in `src/` was still hand-rolling emoji prefixes via raw `console.log` instead of going through the typed logger the ui module already provides. This PR finishes the migration that the ui module's existence was implying.

The substantive output change: emoji prefixes (`📦 🔨 📤 ✅ ❌ 🚀 🧹 ⏳ 🛑 💰 📝 💾`) become **figures-based glyphs that auto-fall-back to ASCII on terminals that don't support Unicode** (`✔ ✖ ⚠ ℹ ▸`). Same content, professional shape, cross-platform safe.

## Two commits

1. **`14eef68` `feat(ui): add symbols.step + logger.step for action lines`** — extends `src/ui/symbols.ts` + `src/ui/logger.ts` with a `step` helper for in-progress action lines (▸ chevron prefix, dim coloring). `figures` didn't have an exact match for the small-triangle shape we wanted, so `symbols.step` is a plain Unicode literal (U+25B8). Supported in every UTF-8 terminal; falls back to `figures.pointerSmall` if a non-UTF-8 env ever surfaces.

2. **`83fb869` `refactor(cli): migrate emoji literals to figures-based logger calls`** — 12 files migrated, mechanical replacements:

| Emoji | New | Semantic |
|---|---|---|
| `✅` / bare `✓` | `logger.success` | green tick |
| `❌` | `logger.error` | red cross |
| `⚠️` | `logger.warning` | yellow warning |
| `💡` / `🔄` | `logger.info` | cyan info circle |
| `📦` `🔨` `📤` `🚀` `🧹` `⏳` `🛑` `💰` `📝` `💾` (status) | `logger.step` | dim chevron `▸` |

Files touched: `core/Publisher.ts`, `core/contract.ts`, `core/deployments.ts`, `commands/run.ts`, `commands/fork/{fund,view-resource}.ts`, `fork/manager.ts`, `fork/server.ts`, `helpers/{setup,setupLocalTesting,testFixtures}.ts`, `node/LocalNodeManager.ts`.

## What stays as `console.*` (deliberate)

- Bare `console.log` of redacted `publishOut` / `publishErr` in `Publisher.ts` — multi-line CLI output from Movement, not styled status lines. runCli's redaction layer remains intact.
- `[Node]` / `[Node Error]` stream prefixes in `LocalNodeManager.ts` — streaming raw `movement node` output to stdout/stderr, not status lines we own.
- JSDoc comments containing `✅` / `❌` as semantic indicators ("works" vs "doesn't work" in documentation) — those are docs, not output.

`log-symbols` (mentioned in the original discussion) was NOT added — `figures` already provides everything we need (`tick`, `cross`, `warning`, `info`), and `log-symbols` would be a redundant dep with overlapping glyphs.

## How was this tested?

**Tier 1:**
- `pnpm --filter movehat exec tsc --noEmit` — clean.
- `pnpm --filter movehat test` — **184 / 184** unchanged. The leak-path tests in `deployContract.test.ts` continue to spy on `console.error` / `console.log`; `logger.error` pipes through `console.error` and `logger.success/step` pipe through `console.log`, so the spies still catch what they need.

**Tier 2 (CLAUDE.md §6.2 — mandatory for src/** changes):**
- `pnpm test:example` — **9 / 9** ✅. The new logger output didn't introduce any test parsing fragility (mocha output is captured per-test, not from process stdout).
- `pnpm test:smoke` — pass ✅.

## Related issues

- N/A on closing — no GitHub issue exists for this work; it was a side-quest agreed during the post-M1.4 conversation.
- Refs #68 (M1 meta, in flight).

## Type of change

- [x] Refactor (no behaviour change in logic; only visual styling of stdout/stderr lines)

## Checklist

- [x] `pnpm test` passes locally (184/184)
- [x] `pnpm test:example` (9/9)
- [x] `pnpm test:smoke` (pass)
- [x] CHANGELOG — N/A (cosmetic refactor, no consumer-visible API change)
- [x] Docs — N/A (README has no movehat-CLI-output samples that quote the emojis; user-code examples that contain `✅` are user-owned style, untouched)
- [x] Conventional Commits (1 `feat:`, 1 `refactor:`)
- [x] Self-review per CLAUDE.md §8 — posted as separate comment

## Self-review will follow.