### PR TITLE
feat(M1.6): cache loadUserConfig by mtime; fix #62 module leak (#81)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,7 +63,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 | ✅ | M1.3c | [#78](https://github.com/gilbertsahumada/movehat/issues/78) (shipped in PR #97) | Migrate `runtime.ts` publish + `node/LocalNodeManager.ts` daemon + stderr-redaction unit test | completes [#58](https://github.com/gilbertsahumada/movehat/issues/58), completes [#43](https://github.com/gilbertsahumada/movehat/issues/43) |
 | ✅ | M1.4 | [#79](https://github.com/gilbertsahumada/movehat/issues/79) | Extract `core/Publisher.ts` + per-deploy unique profile + signal handler | [#19](https://github.com/gilbertsahumada/movehat/issues/19), [#36](https://github.com/gilbertsahumada/movehat/issues/36), [#37](https://github.com/gilbertsahumada/movehat/issues/37), [#38](https://github.com/gilbertsahumada/movehat/issues/38), [#53](https://github.com/gilbertsahumada/movehat/issues/53) |
 | ✅ | M1.5 | [#80](https://github.com/gilbertsahumada/movehat/issues/80) | Remove `cachedRuntime` and the three `setupLocalTesting` singletons; `switchNetwork` returns runtime (folded in from M1.6) | [#21](https://github.com/gilbertsahumada/movehat/issues/21), [#55](https://github.com/gilbertsahumada/movehat/issues/55) |
-| ⏳ | M1.6 | [#81](https://github.com/gilbertsahumada/movehat/issues/81) | `loadUserConfig` mtime cache (the `switchNetwork`-returns-runtime piece shipped with M1.5) | [#46](https://github.com/gilbertsahumada/movehat/issues/46), [#62](https://github.com/gilbertsahumada/movehat/issues/62) |
+| ✅ | M1.6 | [#81](https://github.com/gilbertsahumada/movehat/issues/81) | `loadUserConfig` mtime cache (the `switchNetwork`-returns-runtime piece shipped with M1.5) | [#46](https://github.com/gilbertsahumada/movehat/issues/46), [#62](https://github.com/gilbertsahumada/movehat/issues/62) |
 | ⏳ | M1.7 | [#82](https://github.com/gilbertsahumada/movehat/issues/82) | Strict types audit (`any`, `!`, `noUncheckedIndexedAccess`) | [#57](https://github.com/gilbertsahumada/movehat/issues/57) |
 
 **Definition of Done** (rolled up from the sub-issues):
@@ -72,10 +72,10 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `packages/movehat/src/utils/address.ts` exists; replaces ad-hoc normalization in `fork/manager.ts`, `fork/storage.ts`, `fork/api.ts` (M1.2, #87)
 - [x] `packages/movehat/src/core/Publisher.ts` exists; `runtime.deployContract` is a thin orchestrator over it (17 lines on develop, M1.4)
 - [x] `grep -R "cachedRuntime\|currentForkServer\|currentForkManager\|currentLocalNode" packages/movehat/src` returns **no matches** (M1.5: 4 module-scoped singletons replaced with `LocalTestingContext` + `fixture.teardown()`; `switchNetwork` returns the new runtime; `mh` proxy + `getRuntime()` removed from public barrel)
-- [ ] `loadUserConfig` cache by `path + mtimeMs` (no per-call module loader churn) — pending M1.6 (#81)
+- [x] `loadUserConfig` cache by `path + mtimeMs` (no per-call module loader churn) (M1.6: module-level `Map<absPath, {mtimeMs, config}>`; `?t=Date.now()` cache-bust replaced with `?mtime=${mtimeMs}` so Node's loader cache grows by edit count, not call count — closes #62)
 - [x] Two parallel `deployContract` calls do **not** corrupt `~/.aptos/config.yaml` or `Move.toml` (M1.4: unique profile per deploy + Move.toml never mutated)
 - [x] SIGINT during deploy leaves no private key on disk (M1.4: process-level signal handler + sync profile cleanup)
-- [x] All previously passing 119 tests still green; new unit tests for `runCli`, `address`, `deployContract` stderr redaction, Move.toml integrity, parallel-deploy, and signal-handler cleanup (currently **184/184** on develop)
+- [x] All previously passing 119 tests still green; new unit tests for `runCli`, `address`, `deployContract` stderr redaction, Move.toml integrity, parallel-deploy, signal-handler cleanup, and config-mtime cache (currently **189/189** on develop)
 - [x] `examples/counter-example/` keeps passing through every sub-PR (per Decision 6) — mechanical typecheck gate enforced by pre-push since PR #84; runtime gate **9/9 passing** as of PR closing #86 (`message.test.ts` rewritten to local-node, broken-scaffold `greeting-fork.test.ts` removed)
 
 ### M2 — Hardhat-style Harness API (~6 days, issue #69)

--- a/packages/movehat/src/core/__tests__/config.test.ts
+++ b/packages/movehat/src/core/__tests__/config.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadUserConfig, _resetConfigCache } from "../config.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const CONFIG_A = `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: { url: "https://testnet.movementnetwork.xyz/v1", chainId: "testnet" }
+  }
+};
+`;
+
+const CONFIG_B = `export default {
+  defaultNetwork: "mainnet",
+  networks: {
+    mainnet: { url: "https://mainnet.movementnetwork.xyz/v1", chainId: "mainnet" }
+  }
+};
+`;
+
+describe("loadUserConfig — mtime cache (#81, #62)", () => {
+  let tmpCwd: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    _resetConfigCache();
+    origCwd = process.cwd();
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-config-test-"));
+    process.chdir(tmpCwd);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    rmSync(tmpCwd, { recursive: true, force: true });
+  });
+
+  it("first call reads from disk", async () => {
+    writeFileSync(join(tmpCwd, "movehat.config.js"), CONFIG_A);
+
+    const config = await loadUserConfig();
+
+    expect(config.defaultNetwork).toBe("testnet");
+    expect(config.networks).toHaveProperty("testnet");
+  });
+
+  it("second call returns the same parsed object (cache hit)", async () => {
+    writeFileSync(join(tmpCwd, "movehat.config.js"), CONFIG_A);
+
+    const first = await loadUserConfig();
+    const second = await loadUserConfig();
+
+    // Reference equality proves we returned the cached object rather
+    // than re-importing and getting a structurally-equal copy.
+    expect(second).toBe(first);
+  });
+
+  it("mtime change invalidates the cache", async () => {
+    const path = join(tmpCwd, "movehat.config.js");
+    writeFileSync(path, CONFIG_A);
+
+    const first = await loadUserConfig();
+    expect(first.defaultNetwork).toBe("testnet");
+
+    // Rewrite + force an mtime far in the future so we don't depend on
+    // filesystem mtime resolution.
+    writeFileSync(path, CONFIG_B);
+    const future = new Date(Date.now() + 60_000);
+    utimesSync(path, future, future);
+
+    const second = await loadUserConfig();
+
+    expect(second).not.toBe(first);
+    expect(second.defaultNetwork).toBe("mainnet");
+    expect(second.networks).toHaveProperty("mainnet");
+  });
+
+  it("different cwds keep separate cache entries", async () => {
+    writeFileSync(join(tmpCwd, "movehat.config.js"), CONFIG_A);
+    const fromA = await loadUserConfig();
+    expect(fromA.defaultNetwork).toBe("testnet");
+
+    const tmpCwdB = mkdtempSync(join(tmpdir(), "movehat-config-test-b-"));
+    try {
+      process.chdir(tmpCwdB);
+      writeFileSync(join(tmpCwdB, "movehat.config.js"), CONFIG_B);
+      const fromB = await loadUserConfig();
+      expect(fromB.defaultNetwork).toBe("mainnet");
+
+      // Switching back to A returns A's cached entry, not B's — proves
+      // the cache is keyed by absolute path, not by something process-
+      // scoped like "the last value loaded".
+      process.chdir(tmpCwd);
+      const fromAagain = await loadUserConfig();
+      expect(fromAagain).toBe(fromA);
+      expect(fromAagain.defaultNetwork).toBe("testnet");
+    } finally {
+      process.chdir(tmpCwd);
+      rmSync(tmpCwdB, { recursive: true, force: true });
+    }
+  });
+
+  it("source file no longer contains the `?t=` cache-bust (#62 regression guard)", () => {
+    const configSrc = readFileSync(join(__dirname, "..", "config.ts"), "utf-8");
+
+    expect(configSrc).not.toMatch(/\?t=['"]\s*\+\s*Date\.now/);
+  });
+
+  // Note: there's no direct behavioral test for `_resetConfigCache()`.
+  // The function is exercised in `beforeEach` above — if it didn't
+  // actually clear the in-memory map, tests 3 and 4 would leak state
+  // between each other and start failing. Its "test" is therefore the
+  // rest of this suite continuing to pass.
+});

--- a/packages/movehat/src/core/config.ts
+++ b/packages/movehat/src/core/config.ts
@@ -1,12 +1,33 @@
 import { pathToFileURL } from "url";
 import { join } from "path";
-import { existsSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { Account, Ed25519PrivateKey } from "@aptos-labs/ts-sdk";
 import { MovehatConfig, MovehatUserConfig } from "../types/config.js";
 
+interface ConfigCacheEntry {
+  mtimeMs: number;
+  config: MovehatUserConfig;
+}
+
+// Keyed by resolved absolute path. One entry per config file the process
+// has loaded. Closes #62 — the previous `?t=Date.now()` cache-bust
+// created a fresh Node loader module per call.
+//
+// Note on concurrency: two `loadUserConfig()` calls racing on a cold
+// cache may both invoke `import()`. Node's loader cache deduplicates by
+// URL so both resolve to the same module, and both writers store the
+// same value here. No corruption, no in-flight-promise memoization
+// needed.
+const configCache = new Map<string, ConfigCacheEntry>();
+
 /**
- * Loads the user's movehat.config.js from the current working directory.
- * 
+ * Loads the user's movehat.config.{ts,js} from the current working directory.
+ *
+ * Cached by `{ absPath, mtimeMs }`: a second call with no edit returns
+ * the parsed object directly and skips both the tsx loader register
+ * dance and the dynamic `import()`. Edits invalidate via the file's
+ * mtime.
+ *
  * @throws {Error} If the configuration file is not found or fails to load
  * @security This function loads and executes code from the current working directory.
  *           It should only be called from trusted project directories.
@@ -14,7 +35,6 @@ import { MovehatConfig, MovehatUserConfig } from "../types/config.js";
 export async function loadUserConfig(): Promise<MovehatUserConfig> {
   const cwd = process.cwd();
 
-  // Try to find config file (.ts first, then .js)
   const possiblePaths = [
     join(cwd, "movehat.config.ts"),
     join(cwd, "movehat.config.js"),
@@ -35,39 +55,54 @@ export async function loadUserConfig(): Promise<MovehatUserConfig> {
   }
 
   try {
+    const { mtimeMs } = statSync(configPath);
+
+    const cached = configCache.get(configPath);
+    if (cached && cached.mtimeMs === mtimeMs) {
+      return cached.config;
+    }
+
     let configModule;
 
     if (configPath.endsWith('.ts')) {
-      // For TypeScript files, we need to use tsx's import system
-      // Register tsx loader for .ts files
       const { register } = await import('tsx/esm/api');
       const unregister = register();
 
       try {
         const configUrl = pathToFileURL(configPath).href;
-        configModule = await import(configUrl + '?t=' + Date.now());
+        configModule = await import(configUrl + '?mtime=' + mtimeMs);
       } finally {
         unregister();
       }
     } else {
-      // For .js files, use standard import
       const configUrl = pathToFileURL(configPath).href;
-      configModule = await import(configUrl + '?t=' + Date.now());
+      configModule = await import(configUrl + '?mtime=' + mtimeMs);
     }
 
     const userConfig = configModule.default as MovehatUserConfig;
 
-    // Validate that networks are defined
     if (!userConfig.networks || Object.keys(userConfig.networks).length === 0) {
       throw new Error(
         "No networks defined in configuration. Add at least one network in the 'networks' field."
       );
     }
 
+    configCache.set(configPath, { mtimeMs, config: userConfig });
+
     return userConfig;
   } catch (error) {
     throw new Error(`Failed to load configuration file '${configPath}': ${error}`);
   }
+}
+
+/**
+ * Clear the in-memory config cache. Test-only escape hatch.
+ *
+ * @internal Not part of the public API surface. Imported via relative
+ *           path from `core/__tests__/config.test.ts` only.
+ */
+export function _resetConfigCache(): void {
+  configCache.clear();
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the per-call `?t=${Date.now()}` cache-bust in `loadUserConfig` with an in-memory map keyed by `{ absPath, mtimeMs }`. The parsed config is returned directly on subsequent calls when the file hasn't changed; the tsx loader register/unregister and the dynamic `import()` are skipped entirely on cache hits.

Closes **#62** (module-leak: every `loadUserConfig` call created a new module in Node's loader cache, which has no eviction).
Closes **#81** (M1.6).
Retroactively closes **#46** — the `switchNetwork`-returns-runtime piece already shipped in M1.5 (PR #107). Closing here as housekeeping; see comment posted on the issue after merge.

## DoD verification (issues #81 + #62)

| DoD bullet | Status |
|---|---|
| Cache by `{ absPath, mtimeMs }` | ✅ `Map<absPath, {mtimeMs, config}>` |
| No `?t=` query string remains | ✅ behavioral grep test in `config.test.ts:106` |
| Two consecutive `loadUserConfig(samePath)` hit disk **once** (logical-load) | ✅ ref-equality test in `config.test.ts:60` |
| Mtime modification invalidates the cache | ✅ `utimesSync`-based test in `config.test.ts:67` |
| No new module created when config file unchanged | ✅ cache hit skips `import()` entirely |
| Watch-mode picks up edits (mtime changes) | ✅ `?mtime=${mtimeMs}` makes Node see a new specifier when (and only when) mtime changes |

```bash
$ grep -nE "\\?t=['\"]\\s*\\+\\s*Date\\.now" packages/movehat/src/core/config.ts
(empty — and the behavioral test asserts this stays empty)

$ grep -nE "configCache|mtimeMs" packages/movehat/src/core/config.ts
(11 matches: declaration, lookup, comparison, miss-path import, write-back, reset)
```

## Why `?mtime=${mtimeMs}` instead of just dropping the query

Node's ESM loader caches modules by URL. With no query at all, `import(fileURL)` would return the same module forever per Node process — edits to the user's config would not be picked up at all (regression of the watch-mode use case in #62).

`?mtime=${mtimeMs}` makes Node treat each *distinct mtime* as a new specifier. The loader cache grows by the number of distinct edits (bounded), not by the number of `loadUserConfig` calls (unbounded under the old `?t=Date.now()`). And our own in-memory map short-circuits before `import()` is even invoked when mtime matches the cached entry — so on the common hot path, Node's loader is never re-consulted.

## Concurrency note

Two parallel `loadUserConfig()` calls on a cold cache may both invoke `import()`. Node's loader deduplicates by URL, so both resolve to the same module, and both writers race to store the same value into the Map. No corruption. An in-flight-promise memoization was considered and rejected as out-of-DoD-scope per CLAUDE.md §2 (no speculative complexity).

## Commits

- `0efa85c` feat(config): cache loadUserConfig by mtime, drop ?t= cache-bust
- `4176ef5` test(config): cover loadUserConfig mtime cache behavior + tick M1.6

## Test plan

- [x] `pnpm --filter movehat exec tsc --noEmit` — clean
- [x] `pnpm --filter movehat test` — **189/189 passing** (184 + 5 new)
- [x] `pnpm check:example` — clean (Tier 1 strict typecheck)
- [x] `pnpm test:example` — **9/9 passing** (Tier 2; pre-existing mocha teardown lag)
- [x] `pnpm test:smoke` — pass (Tier 2 install verification)
- [N/A] `pnpm test:e2e` — Tier 3, runs pre-publish or on the `develop → main` batch PR per CLAUDE.md §6.3

## Remaining for M1 batch to `main`

Only **M1.7** (#82, strict types audit) left. Then `develop → main` batch with `test:e2e` gate + README sync.