### PR TITLE
docs(readme): sync code samples with M1 public API + Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 Before installing Movehat, make sure you have:
 
-- **Node.js** (v18 or later) - [Download](https://nodejs.org/)
+- **Node.js** (v20 or later) - [Download](https://nodejs.org/)
 - **Movement CLI** - **REQUIRED** for compiling and deploying Move contracts
 
   Install Movement CLI by following the official guide:
@@ -514,7 +514,7 @@ Write tests in TypeScript that run on a **real local Movement blockchain** (just
 // tests/Counter.test.ts
 import { describe, it, before, after } from "mocha";
 import { expect } from "chai";
-import { setupTestFixture, teardownTestFixture, type TestFixture } from "movehat/helpers";
+import { setupTestFixture, type TestFixture } from "movehat/helpers";
 
 describe("Counter Contract", () => {
   let fixture: TestFixture<'counter'>;
@@ -599,8 +599,8 @@ describe("Counter Contract", () => {
   });
 
   after(async () => {
-    // Cleanup: Stop local node and clear account pool
-    await teardownTestFixture();
+    // Cleanup: Stop local node
+    await fixture.teardown();
   });
 });
 ```
@@ -863,7 +863,7 @@ main().catch(console.error);
 ### System Requirements
 
 **Required:**
-- Node.js v18+
+- Node.js v20+
 - Movement CLI (install from [Movement docs](https://docs.movementnetwork.xyz/devs/movementcli))
 - npm or pnpm
 


### PR DESCRIPTION
## Summary

Fixes 5 sites in \`README.md\` where the documentation lagged the post-M1 public API:

- **L37 + L866** — Node version: \`v18+\` → \`v20+\` (matches \`packages/movehat/package.json\` \`engines.node: ">=20.0.0"\`).
- **L517** — Drop \`teardownTestFixture\` from the example import. The export was removed in M1.5 (PR #107).
- **L602** — Drop "\`and clear account pool\`" from the cleanup comment. M1.5 deliberately does NOT clear the shared AccountManager pool from \`fixture.teardown()\` — clearing it would poison parallel \`setupTestFixture\` calls.
- **L603** — \`await teardownTestFixture()\` → \`await fixture.teardown()\` (the new M1.5 API).

## Why now

PR #106 (\`develop → main\` for M1 batch) flagged this as a merge-blocker. Without the sync, a new user copy-pasting the README would hit \`TypeError: undefined is not a function\` on the \`teardownTestFixture\` import — a hard-to-diagnose paper cut directly attributable to the docs.

## Verification

\`\`\`bash
$ grep -nE "teardownTestFixture|v18|clear account pool" README.md
(empty)
\`\`\`

No structural changes; 5 exact-string edits in one commit.

## Test plan

- [x] Tier 1 not required (docs-only change; no \`*.ts\` touched).
- [N/A] Tier 2 install verification — README sync doesn't touch \`packages/movehat/src/**\`, \`bin/**\`, or templates.
- [x] Manual: \`grep\` returns empty for all stale patterns.