### PR TITLE
fix: address high-priority CodeRabbit findings on PR #106 (TP1-TP4 + TP7)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `examples/counter-example/` keeps passing through every sub-PR (per Decision 6) — mechanical typecheck gate enforced by pre-push since PR #84; runtime gate **9/9 passing** as of PR closing #86 (`message.test.ts` rewritten to local-node, broken-scaffold `greeting-fork.test.ts` removed)
 - [x] M1.7 (#82): `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` enabled in `packages/movehat/tsconfig.json`; all 16 `catch (error: any)` sites migrated to `unknown`-typed catches; `fork/*` `any` audit closes the corresponding bullet of #57 — boundary validation (zod or guards for `fork/api.ts` parsed JSON) deferred to follow-up; `verbatimModuleSyntax` deliberately omitted (low-benefit/high-churn)
 
-**M1 status: ✅ shipped via PRs #76, #87, #89, #92, #97, #99 (M1.4), #107 (M1.5), #109 (M1.6), and #N (M1.7). Ready for `develop → main` batch.**
+**M1 status: ✅ shipped via PRs #76, #87, #89, #92, #97, #99 (M1.4), #107 (M1.5), #109 (M1.6), and #110 (M1.7). Tier 3 verification `pnpm test:e2e` 32/32 passing (captured on the `develop → main` batch PR #106). Ready for `develop → main` batch.**
 
 ### M2 — Hardhat-style Harness API (~6 days, issue #69)
 

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -22,7 +22,7 @@ import {
   validateSafeName,
 } from "./deployments.js";
 import { validatePathSafety, validateProfileSafety } from "./shell.js";
-import { CliExecutionError, ModuleAlreadyDeployedError } from "../errors.js";
+import { CliExecutionError, ModuleAlreadyDeployedError, PostPublishError } from "../errors.js";
 import { runCli } from "../utils/runCli.js";
 import { logger } from "../ui/index.js";
 import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
@@ -389,7 +389,20 @@ export class Publisher {
         // a "snapshot" of the whole file (that's what the old code did,
         // and that's the bug #37 race). Removing only our key leaves
         // other concurrent deploys' profiles intact.
-        await withYamlLock(() => removeProfile(movementConfigPath, profile));
+        //
+        // CRITICAL: catch + log instead of throwing. `await` in a finally
+        // block that throws will clobber both the try block's successful
+        // return value AND any error already propagating. Without this
+        // catch, a yaml-write failure here would mask a successful
+        // publish (making the deploy look failed and inviting a redeploy)
+        // or mask the real publish error.
+        await withYamlLock(() => removeProfile(movementConfigPath, profile)).catch((err) => {
+          const cleanupMsg = err instanceof Error ? err.message : String(err);
+          logger.warning(
+            `Failed to remove deploy profile "${profile}" from ${movementConfigPath}: ${cleanupMsg}. ` +
+            `Run 'movement config delete-profile --profile ${profile}' to clean up manually.`
+          );
+        });
         // Unregister the sync cleanup hook — normal path. (The signal
         // handler stays installed for the process lifetime; cheap.)
         cleanupCallbacks.delete(syncCleanup);
@@ -414,7 +427,12 @@ export class Publisher {
 
       logger.success("Module published successfully!");
 
-      // Create deployment info
+      // ←← "Publish succeeded" boundary. Anything thrown below this
+      // point did NOT cause the publish to fail — the module is on
+      // chain. We surface those failures as PostPublishError so callers
+      // can distinguish a genuine publish failure from a local
+      // bookkeeping failure (and avoid a wasteful redeploy).
+
       const deployment: DeploymentInfo = {
         address: account.accountAddress.toString(),
         moduleName,
@@ -424,11 +442,36 @@ export class Publisher {
         txHash,
       };
 
-      // Save deployment
-      saveDeployment(deployment);
+      try {
+        saveDeployment(deployment);
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        throw new PostPublishError(
+          `Module "${moduleName}" published to ${deployment.address} ` +
+          `but local deployment record could not be written: ${err.message}`,
+          deployment,
+          err
+        );
+      }
 
       return deployment;
     } catch (error) {
+      if (error instanceof PostPublishError) {
+        // Publish DID succeed; only local persistence failed. Log as
+        // warning (not error) so the user knows the deploy is real on
+        // chain. Re-throw so programmatic callers can react.
+        logger.warning(
+          `Module published successfully to ${error.deployment.address} ` +
+          `(tx=${error.deployment.txHash ?? "unknown"}) ` +
+          `but local deployment record could not be written.`
+        );
+        logger.warning(`   Cause: ${error.cause.message}`);
+        logger.warning(
+          `   To recover, manually write the deployment to ` +
+          `deployments/${error.deployment.network}/${error.deployment.moduleName}.json.`
+        );
+        throw error;
+      }
       if (error instanceof CliExecutionError) {
         // stdout/stderr are already redacted by runCli before reaching here,
         // so this branch is safe to log verbatim.

--- a/packages/movehat/src/errors.ts
+++ b/packages/movehat/src/errors.ts
@@ -21,6 +21,35 @@ export class ModuleAlreadyDeployedError extends Error {
 }
 
 import { redactSecrets } from './utils/redact.js';
+import type { DeploymentInfo } from './core/deployments.js';
+
+/**
+ * Thrown when the on-chain publish succeeded but a subsequent local
+ * step (saveDeployment, profile cleanup, etc.) failed.
+ *
+ * Distinct from `CliExecutionError`: by the time this error fires, the
+ * module IS deployed on-chain. Callers that want to recover can read
+ * `deployment` and re-attempt the local-side persistence manually
+ * (e.g. write the JSON to `deployments/{network}/{moduleName}.json`).
+ *
+ * Without this distinction, the same outer catch would surface a
+ * post-publish filesystem failure as "Failed to publish module",
+ * inviting an accidental redeploy that wastes gas.
+ */
+export class PostPublishError extends Error {
+  constructor(
+    message: string,
+    public readonly deployment: DeploymentInfo,
+    public readonly cause: Error
+  ) {
+    super(message);
+    this.name = 'PostPublishError';
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, PostPublishError);
+    }
+  }
+}
 
 /**
  * Thrown by runCli when a spawned process exits with a non-zero status.

--- a/packages/movehat/src/fork/manager.ts
+++ b/packages/movehat/src/fork/manager.ts
@@ -126,7 +126,7 @@ export class ForkManager {
         this.storage.saveResource(normalizedAddress, resourceType, resource);
         console.log(`  ✓ Cached resource ${resourceType}`);
       } catch (error) {
-        const msg = error instanceof Error ? error.message : "";
+        const msg = error instanceof Error ? error.message : String(error);
         if (msg.includes('404')) {
           throw new Error(`Resource ${resourceType} not found for account ${normalizedAddress}`);
         }
@@ -194,7 +194,7 @@ export class ForkManager {
       coinStore = await this.getResource(normalizedAddress, resourceType);
     } catch (error) {
       // Only catch "not found" errors, rethrow others (network, API, etc.)
-      const msg = error instanceof Error ? error.message : "";
+      const msg = error instanceof Error ? error.message : String(error);
       if (!msg.includes('not found')) {
         throw error;
       }

--- a/packages/movehat/src/fork/server.ts
+++ b/packages/movehat/src/fork/server.ts
@@ -238,7 +238,7 @@ export class ForkServer {
         authentication_key: account.authenticationKey
       });
     } catch (error) {
-      const msg = error instanceof Error ? error.message : "";
+      const msg = error instanceof Error ? error.message : String(error);
       if (msg.includes('not found')) {
         this.send404(res, `Account not found: ${address}`);
       } else {
@@ -263,7 +263,7 @@ export class ForkServer {
         data: resource
       });
     } catch (error) {
-      const msg = error instanceof Error ? error.message : "";
+      const msg = error instanceof Error ? error.message : String(error);
       if (msg.includes('not found')) {
         this.send404(res, `Resource not found: ${resourceType}`, 'resource_not_found');
       } else {
@@ -290,7 +290,7 @@ export class ForkServer {
 
       this.sendJSON(res, 200, resourcesArray);
     } catch (error) {
-      const msg = error instanceof Error ? error.message : "";
+      const msg = error instanceof Error ? error.message : String(error);
       if (msg.includes('not found')) {
         this.send404(res, `Account not found: ${address}`);
       } else {

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -143,82 +143,94 @@ async function setupWithLocalNode(
 
   const nodeInfo = await localNode.start();
 
-  logger.step(`Generating ${accountLabels.length} test accounts...`);
-  const accounts = AccountManager.createBatch(accountLabels);
+  // Once the node is up, every later step (account creation, funding,
+  // runtime init, autoDeploy) is fallible. If any of them throws we
+  // must stop the node we just started — otherwise the child process
+  // leaks and port 8080 stays bound until the OS reaps it (manifests as
+  // "Movement command failed" on the next test:example run).
+  try {
+    logger.step(`Generating ${accountLabels.length} test accounts...`);
+    const accounts = AccountManager.createBatch(accountLabels);
 
-  for (const [label, account] of Object.entries(accounts)) {
-    logger.plain(`   ${label}: ${account.accountAddress.toString()}`);
-  }
-  logger.newline();
+    for (const [label, account] of Object.entries(accounts)) {
+      logger.plain(`   ${label}: ${account.accountAddress.toString()}`);
+    }
+    logger.newline();
 
-  if (autoFund) {
-    const accountsList = Object.values(accounts);
-    await localNode.fundAccounts(accountsList, defaultBalance);
-  }
-
-  logger.step("Initializing runtime for local network...");
-
-  const deployerPrivateKey = AccountManager.exportPrivateKeys(["deployer"]).deployer;
-
-  if (!deployerPrivateKey) {
-    throw new Error("Failed to get deployer private key");
-  }
-
-  const runtime = await initRuntime({
-    network: "local",
-    configOverride: {
-      networks: {
-        local: {
-          url: `${nodeInfo.rpcUrl}/v1`,
-          chainId: "local",
-        },
-      },
-      accounts: [deployerPrivateKey],
-    },
-  });
-
-  logger.success("Runtime initialized");
-  logger.newline();
-
-  if (options.autoDeploy && options.autoDeploy.length > 0) {
-    logger.step(`Auto-deploying ${options.autoDeploy.length} module(s)...`);
-
-    const previousRedeploy = process.env.MH_CLI_REDEPLOY;
-    process.env.MH_CLI_REDEPLOY = 'true';
-
-    try {
-      for (const moduleName of options.autoDeploy) {
-        try {
-          logger.plain(`   Deploying ${moduleName}...`);
-          await runtime.deployContract(moduleName);
-          logger.success(`${moduleName} deployed`, 2);
-        } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
-          logger.error(`Failed to deploy ${moduleName}: ${msg}`, 2);
-          throw error;
-        }
-      }
-    } finally {
-      if (previousRedeploy === undefined) {
-        delete process.env.MH_CLI_REDEPLOY;
-      } else {
-        process.env.MH_CLI_REDEPLOY = previousRedeploy;
-      }
+    if (autoFund) {
+      const accountsList = Object.values(accounts);
+      await localNode.fundAccounts(accountsList, defaultBalance);
     }
 
+    logger.step("Initializing runtime for local network...");
+
+    const deployerPrivateKey = AccountManager.exportPrivateKeys(["deployer"]).deployer;
+
+    if (!deployerPrivateKey) {
+      throw new Error("Failed to get deployer private key");
+    }
+
+    const runtime = await initRuntime({
+      network: "local",
+      configOverride: {
+        networks: {
+          local: {
+            url: `${nodeInfo.rpcUrl}/v1`,
+            chainId: "local",
+          },
+        },
+        accounts: [deployerPrivateKey],
+      },
+    });
+
+    logger.success("Runtime initialized");
     logger.newline();
+
+    if (options.autoDeploy && options.autoDeploy.length > 0) {
+      logger.step(`Auto-deploying ${options.autoDeploy.length} module(s)...`);
+
+      const previousRedeploy = process.env.MH_CLI_REDEPLOY;
+      process.env.MH_CLI_REDEPLOY = 'true';
+
+      try {
+        for (const moduleName of options.autoDeploy) {
+          try {
+            logger.plain(`   Deploying ${moduleName}...`);
+            await runtime.deployContract(moduleName);
+            logger.success(`${moduleName} deployed`, 2);
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.error(`Failed to deploy ${moduleName}: ${msg}`, 2);
+            throw error;
+          }
+        }
+      } finally {
+        if (previousRedeploy === undefined) {
+          delete process.env.MH_CLI_REDEPLOY;
+        } else {
+          process.env.MH_CLI_REDEPLOY = previousRedeploy;
+        }
+      }
+
+      logger.newline();
+    }
+
+    logger.success("Local testing environment ready!");
+    logger.newline();
+    logger.plain(`   Mode: local-node`);
+    logger.plain(`   RPC: ${nodeInfo.rpcUrl}/v1`);
+    logger.plain(`   Faucet: ${nodeInfo.faucetUrl}`);
+    logger.plain(`   Accounts: ${Array.from(accountLabels).join(", ")}`);
+    logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} APT`);
+    logger.newline();
+
+    return { runtime, localNode };
+  } catch (error) {
+    // Best-effort cleanup. Swallow the stop() error so the original
+    // setup failure surfaces unchanged.
+    await localNode.stop().catch(() => {});
+    throw error;
   }
-
-  logger.success("Local testing environment ready!");
-  logger.newline();
-  logger.plain(`   Mode: local-node`);
-  logger.plain(`   RPC: ${nodeInfo.rpcUrl}/v1`);
-  logger.plain(`   Faucet: ${nodeInfo.faucetUrl}`);
-  logger.plain(`   Accounts: ${Array.from(accountLabels).join(", ")}`);
-  logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} APT`);
-  logger.newline();
-
-  return { runtime, localNode };
 }
 
 /**
@@ -276,53 +288,61 @@ async function setupWithFork(
   logger.success(`Fork server running at http://localhost:${forkPort}`);
   logger.newline();
 
-  await new Promise((resolve) => setTimeout(resolve, 500));
+  // Same cleanup-on-failure pattern as setupWithLocalNode: once the
+  // fork server is listening, any later throw must stop the server or
+  // we leak the listener.
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 500));
 
-  logger.step(`Generating ${accountLabels.length} test accounts...`);
-  const accounts = AccountManager.createBatch(accountLabels);
+    logger.step(`Generating ${accountLabels.length} test accounts...`);
+    const accounts = AccountManager.createBatch(accountLabels);
 
-  for (const [label, account] of Object.entries(accounts)) {
-    logger.plain(`   ${label}: ${account.accountAddress.toString()}`);
-  }
-  logger.newline();
+    for (const [label, account] of Object.entries(accounts)) {
+      logger.plain(`   ${label}: ${account.accountAddress.toString()}`);
+    }
+    logger.newline();
 
-  if (autoFund) {
-    const addresses = Object.values(accounts).map((acc) =>
-      acc.accountAddress.toString()
-    );
-    await forkManager.fundMultipleAccounts(addresses, defaultBalance);
-  }
+    if (autoFund) {
+      const addresses = Object.values(accounts).map((acc) =>
+        acc.accountAddress.toString()
+      );
+      await forkManager.fundMultipleAccounts(addresses, defaultBalance);
+    }
 
-  logger.step("Initializing runtime for local network...");
+    logger.step("Initializing runtime for local network...");
 
-  const deployerPrivateKey = AccountManager.exportPrivateKeys(["deployer"]).deployer;
+    const deployerPrivateKey = AccountManager.exportPrivateKeys(["deployer"]).deployer;
 
-  if (!deployerPrivateKey) {
-    throw new Error("Failed to get deployer private key");
-  }
+    if (!deployerPrivateKey) {
+      throw new Error("Failed to get deployer private key");
+    }
 
-  const runtime = await initRuntime({
-    network: "local",
-    configOverride: {
-      networks: {
-        local: {
-          url: `http://localhost:${forkPort}/v1`,
-          chainId: "local",
+    const runtime = await initRuntime({
+      network: "local",
+      configOverride: {
+        networks: {
+          local: {
+            url: `http://localhost:${forkPort}/v1`,
+            chainId: "local",
+          },
         },
+        accounts: [deployerPrivateKey],
       },
-      accounts: [deployerPrivateKey],
-    },
-  });
+    });
 
-  logger.success("Runtime initialized");
-  logger.newline();
-  logger.success("Local testing environment ready!");
-  logger.newline();
-  logger.plain(`   Mode: fork (read-only)`);
-  logger.plain(`   RPC: http://localhost:${forkPort}/v1`);
-  logger.plain(`   Accounts: ${Array.from(accountLabels).join(", ")}`);
-  logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} APT`);
-  logger.newline();
+    logger.success("Runtime initialized");
+    logger.newline();
+    logger.success("Local testing environment ready!");
+    logger.newline();
+    logger.plain(`   Mode: fork (read-only)`);
+    logger.plain(`   RPC: http://localhost:${forkPort}/v1`);
+    logger.plain(`   Accounts: ${Array.from(accountLabels).join(", ")}`);
+    logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} APT`);
+    logger.newline();
 
-  return { runtime, forkServer, forkManager };
+    return { runtime, forkServer, forkManager };
+  } catch (error) {
+    await forkServer.stop().catch(() => {});
+    throw error;
+  }
 }

--- a/packages/movehat/src/helpers/testFixtures.ts
+++ b/packages/movehat/src/helpers/testFixtures.ts
@@ -96,51 +96,61 @@ export async function setupTestFixture<TModules extends readonly string[]>(
   };
 
   const ctx = await setupLocalTesting(setupOptions);
-  const mh = ctx.runtime;
 
-  const labeledAccounts = AccountManager.getLabeledAccounts();
+  // Assembly is fallible — a missing deployment address (autoDeploy
+  // silently failed) or any unexpected throw would leak the started
+  // infrastructure. Tear down ctx on failure; the outer caller sees
+  // the original assembly error unchanged.
+  try {
+    const mh = ctx.runtime;
 
-  // any: TestFixture.accounts has a structural shape with required
-  // `deployer/alice/bob` plus a `[key: string]: Account` index. The
-  // builder fills the index dynamically; typing this as the exact
-  // intersection would require a generic over `accountLabels` and
-  // produce noisy errors for the dynamic key assignment below.
-  const accounts: any = {
-    // non-null: setupLocalTesting → setupWithLocalNode/Fork unconditionally
-    // funds the deployer account via accountLabels[0]; deployer is always
-    // first by construction at L93 above.
-    deployer: labeledAccounts.deployer!,
-  };
+    const labeledAccounts = AccountManager.getLabeledAccounts();
 
-  for (const label of accountLabels) {
-    accounts[label] = labeledAccounts[label] || AccountManager.getOrCreateLabeled(label);
-  }
+    // any: TestFixture.accounts has a structural shape with required
+    // `deployer/alice/bob` plus a `[key: string]: Account` index. The
+    // builder fills the index dynamically; typing this as the exact
+    // intersection would require a generic over `accountLabels` and
+    // produce noisy errors for the dynamic key assignment below.
+    const accounts: any = {
+      // non-null: setupLocalTesting → setupWithLocalNode/Fork unconditionally
+      // funds the deployer account via accountLabels[0]; deployer is always
+      // first by construction at L93 above.
+      deployer: labeledAccounts.deployer!,
+    };
 
-  const contracts = {} as Record<TModules[number], MoveContract>;
-
-  for (const moduleName of modules) {
-    const deploymentAddress = mh.getDeploymentAddress(moduleName);
-
-    if (!deploymentAddress) {
-      throw new Error(
-        `Module "${moduleName}" was not deployed. Check auto-deploy logs.`
-      );
+    for (const label of accountLabels) {
+      accounts[label] = labeledAccounts[label] || AccountManager.getOrCreateLabeled(label);
     }
 
-    contracts[moduleName as TModules[number]] = mh.getContract(deploymentAddress, moduleName);
-    logger.success(`Contract "${moduleName}" ready at ${deploymentAddress}`, 2);
+    const contracts = {} as Record<TModules[number], MoveContract>;
+
+    for (const moduleName of modules) {
+      const deploymentAddress = mh.getDeploymentAddress(moduleName);
+
+      if (!deploymentAddress) {
+        throw new Error(
+          `Module "${moduleName}" was not deployed. Check auto-deploy logs.`
+        );
+      }
+
+      contracts[moduleName as TModules[number]] = mh.getContract(deploymentAddress, moduleName);
+      logger.success(`Contract "${moduleName}" ready at ${deploymentAddress}`, 2);
+    }
+
+    logger.newline();
+    logger.success("Test fixture ready!");
+    logger.newline();
+
+    return {
+      mh,
+      accounts,
+      contracts,
+      teardown: ctx.teardown,
+    } as TestFixture<TModules[number]>;
+  } catch (error) {
+    await ctx.teardown().catch(() => {});
+    throw error;
   }
-
-  logger.newline();
-  logger.success("Test fixture ready!");
-  logger.newline();
-
-  return {
-    mh,
-    accounts,
-    contracts,
-    teardown: ctx.teardown,
-  } as TestFixture<TModules[number]>;
 }
 
 /**
@@ -167,27 +177,34 @@ export async function setupMinimalFixture(
   };
 
   const ctx = await setupLocalTesting(setupOptions);
-  const mh = ctx.runtime;
 
-  const labeledAccounts = AccountManager.getLabeledAccounts();
+  // Same teardown-on-assembly-failure pattern as setupTestFixture.
+  try {
+    const mh = ctx.runtime;
 
-  // any: see setupTestFixture above — same dynamic-key builder pattern.
-  const accounts: any = {
-    // non-null: deployer is unconditionally added to allLabels at L156 above.
-    deployer: labeledAccounts.deployer!,
-  };
+    const labeledAccounts = AccountManager.getLabeledAccounts();
 
-  for (const label of accountLabels) {
-    accounts[label] = labeledAccounts[label] || AccountManager.getOrCreateLabeled(label);
+    // any: see setupTestFixture above — same dynamic-key builder pattern.
+    const accounts: any = {
+      // non-null: deployer is unconditionally added to allLabels at L156 above.
+      deployer: labeledAccounts.deployer!,
+    };
+
+    for (const label of accountLabels) {
+      accounts[label] = labeledAccounts[label] || AccountManager.getOrCreateLabeled(label);
+    }
+
+    logger.newline();
+    logger.success("Minimal fixture ready!");
+    logger.newline();
+
+    return {
+      mh,
+      accounts,
+      teardown: ctx.teardown,
+    };
+  } catch (error) {
+    await ctx.teardown().catch(() => {});
+    throw error;
   }
-
-  logger.newline();
-  logger.success("Minimal fixture ready!");
-  logger.newline();
-
-  return {
-    mh,
-    accounts,
-    teardown: ctx.teardown,
-  };
 }

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -14,4 +14,4 @@ export { ForkServer } from "./fork/server.js";
 export type { ForkMetadata, AccountState, LedgerInfo, AccountData, AccountResource } from "./types/fork.js";
 
 // Export custom errors
-export { ModuleAlreadyDeployedError } from "./errors.js";
+export { ModuleAlreadyDeployedError, PostPublishError } from "./errors.js";


### PR DESCRIPTION
## Summary

Addresses the **high-priority** CodeRabbit findings from PR #106 (the M1 \`develop → main\` batch). Pulls in 5 actionable bug fixes + a ROADMAP cleanup. The 3 false-positive CodeRabbit comments get inline responses on PR #106 (not on this PR — the comments live on #106).

## Commits

| Commit | TP | Issue |
|---|---|---|
| \`0d12173\` | **TP1** 🟠 | \`setupWithLocalNode\` / \`setupWithFork\` leak the started child if post-start steps throw. Wrap in try/catch; \`stop()\` on error. |
| \`a868f00\` | **TP2** 🟠 | Same leak at fixture-assembly level (\`setupTestFixture\` / \`setupMinimalFixture\`). Call \`ctx.teardown()\` on error. |
| \`0cdcef1\` | **TP3** 🟠 | Post-publish errors (\`saveDeployment\`, inner-finally \`removeProfile\`) misreported as publish failures. New \`PostPublishError\` class carries the successful \`DeploymentInfo\`; inner-finally now \`.catch(...)\` instead of throwing. |
| \`993f7dc\` | **TP7** 🟡 | \`fork/manager.ts\` + \`fork/server.ts\` (5 sites): \`: ""\` fallback for non-Error throws → \`: String(error)\`. |
| \`5d81248\` | **TP4** 🟡 | \`ROADMAP.md\` placeholder \`#N\` → \`#110\` + add test:e2e evidence reference. |

## Why TP1 + TP2 matter

We've hit the orphan-process bug repeatedly during Tier-2 runs across M1.5, M1.6, and M1.7 — manifests as "Movement command failed" on a second \`test:example\` invocation, because the first run's leaked node still owns port 8080. Today the workaround is \`pkill -f movement && lsof -ti:8080 | xargs -r kill -9\` between runs. After TP1+TP2, a fixture-assembly failure stops the node automatically; no leak, no port conflict on the next run.

## Why TP3 matters

The publish flow had two latent bugs:

1. **\`await\` in finally clobbering the publish result.** If \`removeProfile\` failed in the inner \`finally\`, the throw replaced both successful returns and outer errors. Successful deploys could look failed; real publish errors could be masked.
2. **Post-publish bookkeeping misreported as publish failure.** Once the on-chain transaction succeeded, any later throw (saveDeployment write, etc.) bubbled out as "Failed to publish module" — inviting the user to redeploy and burn gas on a duplicate transaction.

The fix introduces a clear "publish succeeded" boundary (the existing \`logger.success("Module published successfully!")\` line). Anything thrown below that line is now a \`PostPublishError\` carrying the \`DeploymentInfo\` so callers can recover (write the JSON manually, or trust the on-chain state).

## False positives — inline responses on PR #106

Three of CodeRabbit's findings were verified as false positives and will get inline replies on PR #106 explaining why:

- **FP1** \`setupLocalTesting.ts:307-325\` (resetForkState uses console.warn) — function was deleted in M1.5 (PR #107). CodeRabbit reviewed an older base.
- **FP2** \`deployContract.test.ts:15\` 🔴 (raw spawn import) — test code spawning its own SIGINT harness; adapter pattern is for production code.
- **FP3** \`ui/symbols.ts:20-25\` (\`step\` hardcoded \`'▸'\`) — intentional design choice documented in adjacent comment.

## Deferred to follow-up sub-PR C (out of scope here)

7 low-priority CodeRabbit findings deferred to a post-batch polish sub-PR:
- TP5: Signal handler unregister (Publisher.ts:183) — embedded-library concern; movehat is CLI today.
- TP6: \`fixture.teardown()\` undefined guard in tests — already covered if TP1/TP2 ship (root cause is the setup throw).
- TP8: Empty palette guard in \`ui/colors.ts\`.
- TP9: \`console.log\` → \`logger.plain\` in \`LocalNodeManager.ts:67\` + \`view-resource.ts:42-43\`.
- TP10: \`structuredClone\` defensive copy in config cache (debatable — defeats cache speedup).
- TP11: \`fetch\` / \`fs.readFile\` error handling in docs site routes.

## Test plan

- [x] \`pnpm --filter movehat exec tsc --noEmit\` — clean
- [x] \`pnpm --filter movehat test\` — **189/189 passing** after every commit
- [x] \`pnpm check:example\` — clean
- [x] \`pnpm test:example\` — **9/9** (Tier 2; pre-existing mocha teardown lag)
- [x] \`pnpm test:smoke\` — pass
- [N/A] \`pnpm test:e2e\` — Tier 3 runs on PR #106 (the batch PR); this sub-PR auto-updates it.

## Public-API note

New exported class \`PostPublishError\` joins the existing \`ModuleAlreadyDeployedError\` in \`movehat\`'s public barrel. Pre-1.0; goes into M6 release notes when 0.1.0 ships.