### PR TITLE
feat(harness): skeleton + factories + Proxy poisoning + cleanup (M2.1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,20 +89,29 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 
 **Goal**: Provide a Hardhat-style testing harness with explicit lifecycle and use-after-cleanup safety.
 
+**Sub-issues** (each is a separate PR. Execution order: M2.1 → M2.2 → M2.3 → M2.4 in serial — M2.2/M2.3 replace M2.1's method stubs and M2.4 migrates consumers, so each depends on the previous):
+
+| Status | Sub-PR | Issue | Focus | Closes |
+|---|---|---|---|---|
+|   | M2.1 | [#116](https://github.com/gilbertsahumada/movehat/issues/116) | Harness skeleton + 3 factories + Proxy poisoning + cleanup + HarnessDisposedError (4 methods stubbed) | foundations |
+|   | M2.2 | [#117](https://github.com/gilbertsahumada/movehat/issues/117) | `deployCodeObject` + `upgradeCodeObject` via `movement move deploy-object` / `upgrade-object` | (partial of #69) |
+|   | M2.3 | [#118](https://github.com/gilbertsahumada/movehat/issues/118) | `runViewFunction` + `runMoveScript` | (partial of #69) |
+|   | M2.4 | [#119](https://github.com/gilbertsahumada/movehat/issues/119) | Migrate `examples/counter-example/` + templates + 8 docs MDX; `@deprecated` JSDoc on `mh()` / `getMovehat` | closes #69 |
+
 **Definition of Done — API surface**:
 - [ ] `import { Harness } from 'movehat'` works from the built package
 - [ ] `Harness.createLocal()` returns a usable instance
 - [ ] `Harness.createFork(network: string, apiKey?: string)` returns a usable instance
-- [ ] `Harness.createLive(network: string, faucetUrl?: string)` returns a usable instance
+- [x] `Harness.createLive(network: string, faucetUrl?: string)` returns a usable instance (M2.1)
 - [ ] `harness.deployCodeObject(options)` deploys a real Move package
 - [ ] `harness.upgradeCodeObject(options)` upgrades an existing code object
 - [ ] `harness.runViewFunction(options)` executes a view function
 - [ ] `harness.runMoveScript(options)` compiles and executes a Move script
-- [ ] `harness.cleanup()` releases the local node, removes temp dirs, and sets `poisoned = true`
+- [x] `harness.cleanup()` releases the local node, removes temp dirs, and sets `poisoned = true` (M2.1 — idempotent; stops owned localNode / forkServer; tested)
 
 **Definition of Done — Use-after-cleanup safety**:
-- [ ] Calling **any** method on a disposed harness (other than `cleanup`) throws `HarnessDisposedError` synchronously
-- [ ] `HarnessDisposedError` exported from the package
+- [x] Calling **any** method on a disposed harness (other than `cleanup`) throws `HarnessDisposedError` synchronously (M2.1 — Proxy `get` trap fires on property access before the awaited body)
+- [x] `HarnessDisposedError` exported from the package (M2.1)
 
 **Definition of Done — Migration**:
 - [ ] `examples/counter-example/` uses `Harness.createLocal()`

--- a/packages/movehat/src/__tests__/harness/Harness.createLive.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.createLive.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Harness } from "../../harness/index.js";
+import { _resetConfigCache } from "../../core/config.js";
+
+describe("Harness.createLive", () => {
+  let tmpCwd: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-harness-live-"));
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    },
+    custom: {
+      url: "https://custom.example.com/v1",
+      chainId: "custom",
+      accounts: ["0x${"a".repeat(64)}"]
+    }
+  }
+};
+`
+    );
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]
+name = "dummy"
+version = "0.0.1"
+
+[addresses]
+`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// intentionally empty\n");
+
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+      _resetConfigCache();
+    }
+  });
+
+  it("returns a Harness bound to the requested network with mode='live'", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      expect(harness.mode).toBe("live");
+      expect(harness.runtime).toBeDefined();
+      expect(harness.runtime.network.name).toBe("testnet");
+      expect(harness.runtime.network.rpc).toContain("testnet.movementnetwork.xyz");
+      // createLive does not own a local node or fork server.
+      expect(harness.localNode).toBeUndefined();
+      expect(harness.forkServer).toBeUndefined();
+      expect(harness.forkManager).toBeUndefined();
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("can switch networks via the first argument", async () => {
+    const harness = await Harness.createLive("custom");
+    try {
+      expect(harness.runtime.network.name).toBe("custom");
+      expect(harness.runtime.network.rpc).toContain("custom.example.com");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("cleanup() is a no-op for createLive (no owned services) but still poisons", async () => {
+    const harness = await Harness.createLive("testnet");
+    expect(harness.poisoned).toBe(false);
+    await harness.cleanup();
+    expect(harness.poisoned).toBe(true);
+  });
+});

--- a/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Harness, HarnessDisposedError } from "../../harness/index.js";
+import { _resetConfigCache } from "../../core/config.js";
+
+/**
+ * Proxy poisoning is the load-bearing safety guarantee of M2: once a
+ * Harness has been cleaned up, any further deploy / view / script /
+ * upgrade call must throw `HarnessDisposedError` synchronously on
+ * property access — not after the awaited method body. These tests
+ * lock that contract.
+ *
+ * Uses `Harness.createLive(network)` because it does not spawn a real
+ * Movement node — `initRuntime` only constructs the SDK client (no RPC
+ * round-trip) from the fixture config. `createLocal` / `createFork`
+ * runtime tests live in the M4 integration suite where spinning a real
+ * node is acceptable.
+ */
+describe("Harness — proxy poisoning", () => {
+  let tmpCwd: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-harness-test-"));
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    }
+  }
+};
+`
+    );
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]
+name = "dummy"
+version = "0.0.1"
+
+[addresses]
+`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// intentionally empty\n");
+
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+      _resetConfigCache();
+    }
+  });
+
+  it("cleanup() flips poisoned to true", async () => {
+    const harness = await Harness.createLive("testnet");
+    expect(harness.poisoned).toBe(false);
+    await harness.cleanup();
+    expect(harness.poisoned).toBe(true);
+  });
+
+  it("cleanup() is idempotent", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+    // Second call must not throw and must leave the harness poisoned.
+    await expect(harness.cleanup()).resolves.toBeUndefined();
+    expect(harness.poisoned).toBe(true);
+  });
+
+  it("post-cleanup, deployCodeObject throws HarnessDisposedError synchronously on property access", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+
+    // Property access itself throws — the call site never gets a Promise back.
+    expect(() => harness.deployCodeObject({})).toThrow(HarnessDisposedError);
+  });
+
+  it("post-cleanup, upgradeCodeObject / runViewFunction / runMoveScript all throw HarnessDisposedError synchronously", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+
+    expect(() => harness.upgradeCodeObject({})).toThrow(HarnessDisposedError);
+    expect(() => harness.runViewFunction({})).toThrow(HarnessDisposedError);
+    expect(() => harness.runMoveScript({})).toThrow(HarnessDisposedError);
+  });
+
+  it("HarnessDisposedError carries the offending method name", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+
+    let captured: unknown;
+    try {
+      harness.deployCodeObject({});
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(HarnessDisposedError);
+    expect((captured as HarnessDisposedError).methodName).toBe("deployCodeObject");
+  });
+
+  it("post-cleanup, metadata accessors (mode, poisoned, runtime) still work", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+
+    // None of these should throw — only the 4 poisoned methods do.
+    expect(harness.mode).toBe("live");
+    expect(harness.poisoned).toBe(true);
+    expect(harness.runtime).toBeDefined();
+  });
+
+  it("before cleanup, the 4 stub methods reject (real impls in M2.2/M2.3) — but do NOT throw HarnessDisposedError", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      await expect(harness.deployCodeObject({})).rejects.toThrow(/not yet implemented/);
+      await expect(harness.upgradeCodeObject({})).rejects.toThrow(/not yet implemented/);
+      await expect(harness.runViewFunction({})).rejects.toThrow(/not yet implemented/);
+      await expect(harness.runMoveScript({})).rejects.toThrow(/not yet implemented/);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("await harness.someAsyncMethod() pattern: post-cleanup throw happens before await", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+
+    // The error is synchronous (property access), but the typical caller
+    // shape uses await. Confirm that pattern surfaces the error too.
+    let captured: unknown;
+    try {
+      await harness.deployCodeObject({});
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(HarnessDisposedError);
+  });
+});

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -1,0 +1,163 @@
+import type { MovehatRuntime } from "../types/runtime.js";
+import type { LocalNodeManager } from "../node/LocalNodeManager.js";
+import type { ForkServer } from "../fork/server.js";
+import type { ForkManager } from "../fork/manager.js";
+import type { LocalTestOptions } from "../types/config.js";
+import { setupLocalTesting } from "../helpers/setupLocalTesting.js";
+import { initRuntime } from "../runtime.js";
+import { createHarnessProxy } from "./proxy.js";
+
+export type HarnessMode = "local" | "fork" | "live";
+
+interface HarnessInit {
+  mode: HarnessMode;
+  runtime: MovehatRuntime;
+  localNode?: LocalNodeManager;
+  forkServer?: ForkServer;
+  forkManager?: ForkManager;
+}
+
+/**
+ * Hardhat-style testing harness for Movehat.
+ *
+ * Construct via the static factories — `createLocal`, `createFork`,
+ * `createLive` — never via `new Harness(...)`. The returned instance is
+ * a Proxy that synchronously throws {@link HarnessDisposedError} on any
+ * post-`cleanup()` call to one of the deployment / script / view methods.
+ *
+ * Methods `deployCodeObject`, `upgradeCodeObject`, `runViewFunction`,
+ * and `runMoveScript` are stubbed in M2.1 — they throw at runtime until
+ * M2.2/M2.3 lands. The type surface is complete so callers and docs can
+ * be written against it ahead of time.
+ *
+ * AccountManager note: as of M2.1 the underlying account pool is a
+ * process-wide static (see `core/AccountManager.ts`). Two Harness
+ * instances in the same process share account labels; this is the same
+ * constraint that already governs `setupTestFixture`. A per-Harness pool
+ * is a future change.
+ */
+export class Harness {
+  public readonly mode: HarnessMode;
+  public readonly runtime: MovehatRuntime;
+
+  /** @internal */
+  public readonly localNode?: LocalNodeManager;
+  /** @internal */
+  public readonly forkServer?: ForkServer;
+  /** @internal */
+  public readonly forkManager?: ForkManager;
+
+  private _poisoned = false;
+
+  private constructor(init: HarnessInit) {
+    this.mode = init.mode;
+    this.runtime = init.runtime;
+    if (init.localNode) this.localNode = init.localNode;
+    if (init.forkServer) this.forkServer = init.forkServer;
+    if (init.forkManager) this.forkManager = init.forkManager;
+  }
+
+  /** True once `cleanup()` has been awaited at least once. */
+  public get poisoned(): boolean {
+    return this._poisoned;
+  }
+
+  /**
+   * Spin up a local Movement node and return a Harness bound to it.
+   *
+   * Forwards to `setupLocalTesting({ mode: 'local-node', ... })` so all
+   * existing options (`nodeApiPort`, `accountLabels`, `autoDeploy`, ...)
+   * apply unchanged.
+   */
+  static async createLocal(options: LocalTestOptions = {}): Promise<Harness> {
+    const ctx = await setupLocalTesting({ ...options, mode: "local-node" });
+    const init: HarnessInit = {
+      mode: "local",
+      runtime: ctx.runtime,
+    };
+    if (ctx.localNode) init.localNode = ctx.localNode;
+    const instance = new Harness(init);
+    return createHarnessProxy(instance, () => instance._poisoned);
+  }
+
+  /**
+   * Create a fork-mode Harness reading from a snapshot of `network`.
+   *
+   * Fork mode is read-only: `deployCodeObject`, `upgradeCodeObject`, and
+   * `runMoveScript` will throw with a message pointing at `createLocal`
+   * once their real bodies land in M2.2/M2.3. `runViewFunction` works.
+   *
+   * @param network - Network to fork (e.g. `"testnet"`).
+   * @param _apiKey - Reserved for M2.2; if non-undefined a TODO will fire.
+   */
+  static async createFork(network: string, _apiKey?: string): Promise<Harness> {
+    if (_apiKey !== undefined) {
+      // TODO(M2.2): plumb into MovementApiClient headers when the
+      // fork manager needs authenticated upstream reads.
+    }
+    const ctx = await setupLocalTesting({ mode: "fork", forkNetwork: network });
+    const init: HarnessInit = {
+      mode: "fork",
+      runtime: ctx.runtime,
+    };
+    if (ctx.forkServer) init.forkServer = ctx.forkServer;
+    if (ctx.forkManager) init.forkManager = ctx.forkManager;
+    const instance = new Harness(init);
+    return createHarnessProxy(instance, () => instance._poisoned);
+  }
+
+  /**
+   * Bind a Harness to a real running network (testnet, mainnet, or any
+   * custom network defined in `movehat.config.ts`). No local process is
+   * spawned; transactions are submitted to the configured RPC.
+   *
+   * @param network - Named network from movehat.config.ts.
+   * @param _faucetUrl - Reserved for M2.2 (auto-fund on networks with a faucet).
+   */
+  static async createLive(network: string, _faucetUrl?: string): Promise<Harness> {
+    const runtime = await initRuntime({ network });
+    const instance = new Harness({ mode: "live", runtime });
+    return createHarnessProxy(instance, () => instance._poisoned);
+  }
+
+  /**
+   * Release resources owned by this harness (local node or fork server)
+   * and poison it. Idempotent: subsequent calls are no-ops.
+   *
+   * After `cleanup()` resolves, any call to `deployCodeObject`,
+   * `upgradeCodeObject`, `runViewFunction`, or `runMoveScript` throws
+   * `HarnessDisposedError` synchronously on property access.
+   */
+  async cleanup(): Promise<void> {
+    if (this._poisoned) return;
+    this._poisoned = true;
+    if (this.localNode) {
+      await this.localNode.stop().catch(() => {});
+    }
+    if (this.forkServer) {
+      await this.forkServer.stop().catch(() => {});
+    }
+  }
+
+  // ---- Stubbed methods (real bodies land in M2.2 / M2.3) ----
+
+  /** @stub M2.2 */
+  async deployCodeObject(_options: unknown): Promise<unknown> {
+    throw new Error("Harness.deployCodeObject is not yet implemented (M2.2).");
+  }
+
+  /** @stub M2.2 */
+  async upgradeCodeObject(_options: unknown): Promise<unknown> {
+    throw new Error("Harness.upgradeCodeObject is not yet implemented (M2.2).");
+  }
+
+  /** @stub M2.3 */
+  async runViewFunction(_options: unknown): Promise<unknown> {
+    throw new Error("Harness.runViewFunction is not yet implemented (M2.3).");
+  }
+
+  /** @stub M2.3 */
+  async runMoveScript(_options: unknown): Promise<unknown> {
+    throw new Error("Harness.runMoveScript is not yet implemented (M2.3).");
+  }
+}

--- a/packages/movehat/src/harness/errors.ts
+++ b/packages/movehat/src/harness/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Thrown synchronously when any method other than `cleanup` is invoked
+ * on a Harness instance whose `cleanup()` has already run.
+ *
+ * The throw happens on property access (Proxy `get` trap), not after the
+ * async method body. That means `await harness.deployCodeObject(...)`
+ * throws *before* the call site awaits — callers can use a plain
+ * `try`/`catch` or rely on the rejected promise; either form will fire.
+ */
+export class HarnessDisposedError extends Error {
+  constructor(public readonly methodName: string) {
+    super(
+      `Harness is disposed; call to '${methodName}' is not allowed. ` +
+        `Create a new Harness via Harness.createLocal/createFork/createLive instead.`
+    );
+    this.name = "HarnessDisposedError";
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, HarnessDisposedError);
+    }
+  }
+}

--- a/packages/movehat/src/harness/index.ts
+++ b/packages/movehat/src/harness/index.ts
@@ -1,0 +1,3 @@
+export { Harness } from "./Harness.js";
+export type { HarnessMode } from "./Harness.js";
+export { HarnessDisposedError } from "./errors.js";

--- a/packages/movehat/src/harness/proxy.ts
+++ b/packages/movehat/src/harness/proxy.ts
@@ -1,0 +1,40 @@
+import { HarnessDisposedError } from "./errors.js";
+
+/**
+ * Names of Harness methods that must throw `HarnessDisposedError`
+ * synchronously once the harness has been disposed (via `cleanup()`).
+ *
+ * Properties NOT in this set — `cleanup`, `mode`, `poisoned`, the runtime
+ * accessors, well-known Symbols, and the promise-protocol hooks
+ * (`then`/`catch`/`finally`) — always pass through. That keeps:
+ *  - `await harness` from breaking on `.then` access
+ *  - debug tools (`console.log`, `util.inspect`) from throwing
+ *  - idempotent `cleanup()` callable post-poisoning
+ *
+ * New Harness methods that should fail post-cleanup MUST be added here.
+ */
+const POISONED_METHODS: ReadonlySet<string> = new Set([
+  "deployCodeObject",
+  "upgradeCodeObject",
+  "runViewFunction",
+  "runMoveScript",
+]);
+
+/**
+ * Wrap a Harness instance in a Proxy that throws `HarnessDisposedError`
+ * synchronously on access to any method in {@link POISONED_METHODS} once
+ * `isPoisoned()` returns true.
+ */
+export function createHarnessProxy<T extends object>(
+  target: T,
+  isPoisoned: () => boolean
+): T {
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      if (typeof prop === "string" && POISONED_METHODS.has(prop) && isPoisoned()) {
+        throw new HarnessDisposedError(prop);
+      }
+      return Reflect.get(obj, prop, receiver);
+    },
+  });
+}

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -15,3 +15,7 @@ export type { ForkMetadata, AccountState, LedgerInfo, AccountData, AccountResour
 
 // Export custom errors
 export { ModuleAlreadyDeployedError, PostPublishError } from "./errors.js";
+
+// Export Harness (Hardhat-style API — primary public surface from M2 onward)
+export { Harness, HarnessDisposedError } from "./harness/index.js";
+export type { HarnessMode } from "./harness/index.js";


### PR DESCRIPTION
## Summary

First sub-PR of M2 (#69). Lands the `Harness` scaffolding — class shell, three static factories (`createLocal`, `createFork`, `createLive`), Proxy-based use-after-cleanup poisoning, idempotent `cleanup()`, and `HarnessDisposedError`. The four method bodies (`deployCodeObject`, `upgradeCodeObject`, `runViewFunction`, `runMoveScript`) are intentional stubs — real implementations land in M2.2 (#117) and M2.3 (#118).

## Key design decisions

- **Why Proxy** — `HarnessDisposedError` must throw synchronously on **property access**, before any awaited body. A class-method guard (`if (this.poisoned) throw`) only fires after dispatch, which violates the M2 DoD ("Calling any method on a disposed harness throws `HarnessDisposedError` synchronously"). The Proxy `get` trap throws on lookup of any of the 4 poisoned method names; `cleanup`, `poisoned`, `mode`, `runtime`, `then`/`catch`, and Symbol properties pass through (so `await harness.x()` surfaces the error, `console.log(harness)` doesn't break, and `cleanup()` stays idempotent).

- **Why `createLive` is the only factory with full runtime tests** — `createLocal` / `createFork` go through `setupLocalTesting`, which spawns a real Movement node / fork server. Adapter injection at that depth is out of scope for M2.1; integration coverage for those paths lands in M4 (#71). `createLive` only constructs the SDK client (no spawn), so it's testable with a fixture `movehat.config.js` in a tmpdir — same pattern as `deployContract.test.ts`.

- **AccountManager stays static** — Two `Harness` instances in the same process share the account pool (same as today's `setupTestFixture`). Documented in `Harness.ts` JSDoc. Per-Harness pool is a future change, not M2 scope.

- **`mh()` / helpers unchanged** — `setupTestFixture` / `setupLocalTesting` / `getMovehat` remain exported as-is. `@deprecated` JSDoc on `mh()` lands in M2.4 (#119); actual removal is M6 (#73).

## Files

```
packages/movehat/src/harness/
├── Harness.ts          # class with private ctor, 3 factories, 4 stubbed methods, cleanup
├── errors.ts           # HarnessDisposedError extends Error (carries methodName)
├── proxy.ts            # createHarnessProxy(target, isPoisoned) — narrow allowlist
└── index.ts            # re-exports

packages/movehat/src/__tests__/harness/
├── Harness.proxy.test.ts        # poisoning semantics (7 cases)
└── Harness.createLive.test.ts   # factory smoke (3 cases)

packages/movehat/src/index.ts    # 2 new exports (Harness, HarnessDisposedError)
ROADMAP.md                       # M2 sub-PR table added; 4 DoD bullets ticked
```

## DoD ticked in ROADMAP

- [x] `Harness.createLive(network, faucetUrl?)` returns a usable instance
- [x] `harness.cleanup()` releases owned services + sets `poisoned = true` (idempotent)
- [x] Any method on a disposed harness throws `HarnessDisposedError` synchronously
- [x] `HarnessDisposedError` exported

Remaining M2 bullets land in M2.2/M2.3/M2.4.

## Test plan

- [x] Tier 1: `pnpm --filter movehat exec tsc --noEmit` — clean
- [x] Tier 1: `pnpm --filter movehat test` — **200/200 passing** (189 prior + 11 new in `__tests__/harness/`)
- [x] Tier 1: `pnpm check:example` — green (example typechecks against the new Harness surface; no breaking changes since the surface is purely additive)
- [N/A] Tier 2 (`test:example`, `test:smoke`) — skipped per plan: M2.1 is a purely additive public surface; helpers + runtime + templates are untouched, so the example runtime path is unchanged. Tier 2 mandatory from M2.2 onward (publisher surface touched).
- [N/A] Tier 3 — skipped (not an install-experience change; templates/CLI surface untouched).

Tracks #69. Closes #116.