### PR TITLE
feat(harness): runViewFunction + runMoveScript + parseTxHash extract (M2.3)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,8 +105,8 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `Harness.createLive(network: string, faucetUrl?: string)` returns a usable instance (M2.1)
 - [x] `harness.deployCodeObject(options)` deploys a real Move package (M2.2 — wraps `movement move deploy-object`; reuses Publisher hardening via the extracted `core/movementProfile.ts` helpers; integration coverage in M4)
 - [x] `harness.upgradeCodeObject(options)` upgrades an existing code object (M2.2 — wraps `movement move upgrade-object`; same shared helpers)
-- [ ] `harness.runViewFunction(options)` executes a view function
-- [ ] `harness.runMoveScript(options)` compiles and executes a Move script
+- [x] `harness.runViewFunction(options)` executes a view function (M2.3 — delegates to `aptos.view`; returns raw `unknown[]`; works on all 3 harness modes including fork since views are read-only)
+- [x] `harness.runMoveScript(options)` compiles and executes a Move script (M2.3 — wraps `movement move run-script`; auto-detects `.move` vs `.mv` from extension; `parseTxHash` shared via `utils/parseCliOutput.ts`)
 - [x] `harness.cleanup()` releases the local node, removes temp dirs, and sets `poisoned = true` (M2.1 — idempotent; stops owned localNode / forkServer; tested)
 
 **Definition of Done — Use-after-cleanup safety**:

--- a/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
@@ -99,8 +99,12 @@ version = "0.0.1"
     expect(() =>
       harness.upgradeCodeObject({ moduleName: "x", objectAddress: "0x1" })
     ).toThrow(HarnessDisposedError);
-    expect(() => harness.runViewFunction({})).toThrow(HarnessDisposedError);
-    expect(() => harness.runMoveScript({})).toThrow(HarnessDisposedError);
+    expect(() =>
+      harness.runViewFunction({ function: "0x1::m::f" })
+    ).toThrow(HarnessDisposedError);
+    expect(() =>
+      harness.runMoveScript({ scriptPath: "irrelevant.move" })
+    ).toThrow(HarnessDisposedError);
   });
 
   it("HarnessDisposedError carries the offending method name", async () => {
@@ -127,18 +131,10 @@ version = "0.0.1"
     expect(harness.runtime).toBeDefined();
   });
 
-  it("before cleanup, the remaining M2.3 stub methods reject — but do NOT throw HarnessDisposedError", async () => {
-    // deployCodeObject + upgradeCodeObject got real bodies in M2.2; their
-    // behavior is covered by the codeObject test suite. The view + script
-    // stubs remain until M2.3.
-    const harness = await Harness.createLive("testnet");
-    try {
-      await expect(harness.runViewFunction({})).rejects.toThrow(/not yet implemented/);
-      await expect(harness.runMoveScript({})).rejects.toThrow(/not yet implemented/);
-    } finally {
-      await harness.cleanup();
-    }
-  });
+  // The M2.3-era "stubs reject" assertion was retired when M2.3 shipped
+  // real bodies for runViewFunction and runMoveScript. All four methods
+  // now have dedicated test suites (codeObject.deploy/upgrade.test.ts,
+  // view.test.ts, script.test.ts).
 
   it("await harness.someAsyncMethod() pattern: post-cleanup throw happens before await", async () => {
     const harness = await Harness.createLive("testnet");

--- a/packages/movehat/src/__tests__/harness/script.test.ts
+++ b/packages/movehat/src/__tests__/harness/script.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Harness } from "../../harness/index.js";
+import { _resetConfigCache } from "../../core/config.js";
+import { CliExecutionError } from "../../errors.js";
+import type {
+  ChildProcessAdapter,
+  RunInput,
+  RunResult,
+} from "../../utils/childProcessAdapter.js";
+
+describe("Harness.runMoveScript", () => {
+  let tmpHome: string;
+  let tmpCwd: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+
+  const TX_HASH =
+    "0x9999999999999999999999999999999999999999999999999999999999999999";
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "movehat-script-home-"));
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-script-cwd-"));
+
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    }
+  }
+};
+`
+    );
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]\nname = "dummy"\nversion = "0.0.1"\n\n[addresses]\n`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// empty\n");
+
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+      _resetConfigCache();
+    }
+  });
+
+  function makeAdapter(result: RunResult): {
+    adapter: ChildProcessAdapter;
+    calls: RunInput[];
+  } {
+    const calls: RunInput[] = [];
+    const adapter: ChildProcessAdapter = {
+      async run(input) {
+        calls.push(input);
+        if (input.args[1] === "run-script") return result;
+        throw new Error(`unexpected movement subcommand: ${input.args[1]}`);
+      },
+      spawn() {
+        throw new Error("spawn not used in script tests");
+      },
+    };
+    return { adapter, calls };
+  }
+
+  function successStdout(): string {
+    return [
+      `transaction hash: ${TX_HASH}`,
+      '{ "Result": { "success": true, "vm_status": "Executed successfully" } }',
+    ].join("\n");
+  }
+
+  it("happy path with .move source: uses --script-path and returns parsed MoveScriptResult", async () => {
+    const scriptPath = join(tmpCwd, "scripts", "init.move");
+    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    writeFileSync(scriptPath, "// dummy move script\n");
+
+    const { adapter, calls } = makeAdapter({
+      exitCode: 0,
+      stdout: successStdout(),
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      const result = await harness.runMoveScript({
+        scriptPath,
+        args: ["u64:42", "bool:true"],
+        typeArgs: ["0x1::aptos_coin::AptosCoin"],
+        adapter,
+      });
+
+      expect(result.txHash).toBe(TX_HASH);
+      expect(result.success).toBe(true);
+      expect(result.vmStatus).toBe("Executed successfully");
+
+      expect(calls).toHaveLength(1);
+      const call = calls[0]!;
+      expect(call.args.slice(0, 2)).toEqual(["move", "run-script"]);
+      expect(call.args).toContain("--script-path");
+      expect(call.args).not.toContain("--compiled-script-path");
+      expect(call.args).toContain(scriptPath);
+      expect(call.args).toContain("--type-args");
+      expect(call.args).toContain("0x1::aptos_coin::AptosCoin");
+      expect(call.args).toContain("--args");
+      expect(call.args).toContain("u64:42");
+      expect(call.args).toContain("bool:true");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("happy path with .mv compiled: uses --compiled-script-path", async () => {
+    const scriptPath = join(tmpCwd, "build", "init.mv");
+    mkdirSync(join(tmpCwd, "build"), { recursive: true });
+    writeFileSync(scriptPath, "compiled bytecode placeholder");
+
+    const { adapter, calls } = makeAdapter({
+      exitCode: 0,
+      stdout: successStdout(),
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      const result = await harness.runMoveScript({ scriptPath, adapter });
+
+      expect(result.txHash).toBe(TX_HASH);
+      const call = calls[0]!;
+      expect(call.args).toContain("--compiled-script-path");
+      expect(call.args).not.toContain("--script-path");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("unsupported extension throws synchronously before any CLI call", async () => {
+    const scriptPath = join(tmpCwd, "notes.txt");
+    writeFileSync(scriptPath, "not a script");
+
+    const { adapter, calls } = makeAdapter({
+      exitCode: 0,
+      stdout: successStdout(),
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.runMoveScript({ scriptPath, adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toMatch(/unsupported script extension/i);
+      expect(calls).toHaveLength(0);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("missing script file throws before any CLI call", async () => {
+    const scriptPath = join(tmpCwd, "scripts", "missing.move");
+    const { adapter, calls } = makeAdapter({
+      exitCode: 0,
+      stdout: successStdout(),
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.runMoveScript({ scriptPath, adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toMatch(/script not found/i);
+      expect(calls).toHaveLength(0);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("CLI failure rethrows CliExecutionError and removes the temp profile", async () => {
+    const scriptPath = join(tmpCwd, "scripts", "fail.move");
+    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    writeFileSync(scriptPath, "// dummy\n");
+
+    const { adapter } = makeAdapter({
+      exitCode: 1,
+      stdout: "",
+      stderr: "compile error: undefined identifier",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.runMoveScript({ scriptPath, adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(CliExecutionError);
+      // Temp profile cleaned up in finally.
+      expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("CLI succeeded but output has no txHash: throws clear non-CliExecutionError", async () => {
+    const scriptPath = join(tmpCwd, "scripts", "weird.move");
+    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    writeFileSync(scriptPath, "// dummy\n");
+
+    const { adapter } = makeAdapter({
+      exitCode: 0,
+      stdout: "ran successfully but no hash here",
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.runMoveScript({ scriptPath, adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught).not.toBeInstanceOf(CliExecutionError);
+      expect((caught as Error).message).toMatch(/Could not parse transaction hash/);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("`success: false` in Result JSON surfaces in MoveScriptResult.success", async () => {
+    const scriptPath = join(tmpCwd, "scripts", "bad.move");
+    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    writeFileSync(scriptPath, "// dummy\n");
+
+    const { adapter } = makeAdapter({
+      exitCode: 0,
+      stdout: [
+        `transaction hash: ${TX_HASH}`,
+        '{ "Result": { "success": false, "vm_status": "ABORTED" } }',
+      ].join("\n"),
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      const result = await harness.runMoveScript({ scriptPath, adapter });
+      expect(result.txHash).toBe(TX_HASH);
+      expect(result.success).toBe(false);
+      expect(result.vmStatus).toBe("ABORTED");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/packages/movehat/src/__tests__/harness/view.test.ts
+++ b/packages/movehat/src/__tests__/harness/view.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Harness } from "../../harness/index.js";
+import { _resetConfigCache } from "../../core/config.js";
+
+/**
+ * Tests for `Harness.runViewFunction` — the SDK delegation path.
+ *
+ * The Aptos SDK isn't behind an injectable adapter, so we monkey-patch
+ * `harness.runtime.aptos.view` after `createLive`. One-off for M2.3.
+ * Acceptable here because the function under test is a 6-line wrapper
+ * that only forwards options.
+ */
+describe("Harness.runViewFunction", () => {
+  let tmpCwd: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-view-"));
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    }
+  }
+};
+`
+    );
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]\nname = "dummy"\nversion = "0.0.1"\n\n[addresses]\n`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// empty\n");
+
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+      _resetConfigCache();
+    }
+  });
+
+  it("happy path: forwards correct payload to aptos.view and returns the raw result array", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      const fake = vi.fn().mockResolvedValue([42n, "hello"]);
+      // Monkey-patch — the SDK boundary isn't behind an adapter.
+      harness.runtime.aptos.view = fake as never;
+
+      const result = await harness.runViewFunction({
+        function: "0xCAFE::counter::get",
+        typeArguments: ["0x1::aptos_coin::AptosCoin"],
+        functionArguments: ["0xdeployer", 1n],
+      });
+
+      expect(result).toEqual([42n, "hello"]);
+      expect(fake).toHaveBeenCalledTimes(1);
+      expect(fake).toHaveBeenCalledWith({
+        payload: {
+          function: "0xCAFE::counter::get",
+          typeArguments: ["0x1::aptos_coin::AptosCoin"],
+          functionArguments: ["0xdeployer", 1n],
+        },
+      });
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("defaults typeArguments and functionArguments to empty arrays when omitted", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      const fake = vi.fn().mockResolvedValue([0n]);
+      harness.runtime.aptos.view = fake as never;
+
+      const result = await harness.runViewFunction({
+        function: "0xCAFE::counter::count",
+      });
+
+      expect(result).toEqual([0n]);
+      expect(fake).toHaveBeenCalledWith({
+        payload: {
+          function: "0xCAFE::counter::count",
+          typeArguments: [],
+          functionArguments: [],
+        },
+      });
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("passes empty results through unchanged", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      const fake = vi.fn().mockResolvedValue([]);
+      harness.runtime.aptos.view = fake as never;
+
+      const result = await harness.runViewFunction({
+        function: "0xCAFE::nothing::nothing",
+      });
+
+      expect(result).toEqual([]);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("rethrows errors from aptos.view", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      const fake = vi.fn().mockRejectedValue(new Error("module not found"));
+      harness.runtime.aptos.view = fake as never;
+
+      await expect(
+        harness.runViewFunction({ function: "0xCAFE::missing::get" })
+      ).rejects.toThrow(/module not found/);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -23,6 +23,7 @@ import {
   ensureSignalHandler,
   cleanupCallbacks,
 } from "./movementProfile.js";
+import { parseTxHash } from "../utils/parseCliOutput.js";
 
 /** @internal */
 export interface PublisherDeps {
@@ -250,22 +251,10 @@ export class Publisher {
         cleanupCallbacks.delete(syncCleanup);
       }
 
-      // Extract transaction hash from output
-      // Look for patterns like "Transaction hash: 0x..." or "Txn: 0x..." or just a 64-char hex
-      // The regex tries to match with context first, then falls back to any 64-char hex
-      let txHash: string | undefined;
-      const txHashMatchWithContext = publishOut.match(
-        /(?:transaction\s*(?:hash)?|txn\s*(?:hash)?|hash):\s*(0x[a-fA-F0-9]{64})\b/i
-      );
-      if (txHashMatchWithContext) {
-        txHash = txHashMatchWithContext[1];
-      } else {
-        // Fallback: try to find any 64-char hex string (exactly, not more)
-        const txHashMatch = publishOut.match(/\b(0x[a-fA-F0-9]{64})\b/);
-        if (txHashMatch) {
-          txHash = txHashMatch[1];
-        }
-      }
+      // Extract transaction hash from output via the shared helper
+      // (`utils/parseCliOutput.ts`). Same regex pair as before; lifted
+      // for reuse by harness/codeObject.ts and harness/script.ts.
+      const txHash = parseTxHash(publishOut);
 
       logger.success("Module published successfully!");
 

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -7,11 +7,16 @@ import type {
   DeployCodeObjectOptions,
   UpgradeCodeObjectOptions,
   CodeObjectInfo,
+  RunViewFunctionOptions,
+  RunMoveScriptOptions,
+  MoveScriptResult,
 } from "../types/harness.js";
 import { setupLocalTesting } from "../helpers/setupLocalTesting.js";
 import { initRuntime } from "../runtime.js";
 import { createHarnessProxy } from "./proxy.js";
 import { deployCodeObject, upgradeCodeObject } from "./codeObject.js";
+import { runViewFunction } from "./view.js";
+import { runMoveScript } from "./script.js";
 
 export type HarnessMode = "local" | "fork" | "live";
 
@@ -185,13 +190,34 @@ export class Harness {
     return upgradeCodeObject(this.runtime, options);
   }
 
-  /** @stub M2.3 */
-  async runViewFunction(_options: unknown): Promise<unknown> {
-    throw new Error("Harness.runViewFunction is not yet implemented (M2.3).");
+  /**
+   * Execute a Move view function via the Aptos SDK.
+   *
+   * Returns the raw view-function result array. For single-value
+   * returns, destructure: `const [count] = await harness.runViewFunction(...)`.
+   *
+   * Works on all 3 harness modes (createLocal, createFork, createLive)
+   * — view functions are read-only.
+   */
+  async runViewFunction(options: RunViewFunctionOptions): Promise<unknown[]> {
+    return runViewFunction(this.runtime, options);
   }
 
-  /** @stub M2.3 */
-  async runMoveScript(_options: unknown): Promise<unknown> {
-    throw new Error("Harness.runMoveScript is not yet implemented (M2.3).");
+  /**
+   * Execute a Move script via `movement move run-script`.
+   *
+   * Accepts either a `.move` source path (CLI auto-compiles) or a
+   * pre-compiled `.mv` bytecode path. Other extensions throw
+   * synchronously.
+   *
+   * Not available on fork-mode harnesses (forks are read-only).
+   */
+  async runMoveScript(options: RunMoveScriptOptions): Promise<MoveScriptResult> {
+    if (this.mode === "fork") {
+      throw new Error(
+        "Harness.createFork is read-only; script execution requires Harness.createLocal or createLive."
+      );
+    }
+    return runMoveScript(this.runtime, options);
   }
 }

--- a/packages/movehat/src/harness/codeObject.ts
+++ b/packages/movehat/src/harness/codeObject.ts
@@ -21,6 +21,7 @@ import {
   PostPublishError,
 } from "../errors.js";
 import { runCli } from "../utils/runCli.js";
+import { parseTxHash } from "../utils/parseCliOutput.js";
 import { logger } from "../ui/index.js";
 import {
   withYamlLock,
@@ -377,18 +378,4 @@ function parseObjectAddress(stdout: string): string | undefined {
   if (jsonMatch?.[1]) return jsonMatch[1];
 
   return undefined;
-}
-
-/**
- * Extract a transaction hash from CLI stdout. Identical regex to
- * `core/Publisher.ts` (the publish success message uses the same
- * shape) — kept here to avoid coupling.
- */
-function parseTxHash(stdout: string): string | undefined {
-  const withContext = stdout.match(
-    /(?:transaction\s*(?:hash)?|txn\s*(?:hash)?|hash):\s*(0x[a-fA-F0-9]{64})\b/i
-  );
-  if (withContext?.[1]) return withContext[1];
-  const fallback = stdout.match(/\b(0x[a-fA-F0-9]{64})\b/);
-  return fallback?.[1];
 }

--- a/packages/movehat/src/harness/script.ts
+++ b/packages/movehat/src/harness/script.ts
@@ -1,0 +1,196 @@
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { extname, join } from "path";
+import { randomUUID } from "crypto";
+import type { MovehatRuntime } from "../types/runtime.js";
+import type {
+  RunMoveScriptOptions,
+  MoveScriptResult,
+} from "../types/harness.js";
+import { validatePathSafety, validateProfileSafety } from "../core/shell.js";
+import { CliExecutionError } from "../errors.js";
+import { runCli } from "../utils/runCli.js";
+import { parseTxHash } from "../utils/parseCliOutput.js";
+import { logger } from "../ui/index.js";
+import {
+  withYamlLock,
+  addProfile,
+  removeProfile,
+  removeProfileSync,
+  ensureSignalHandler,
+  cleanupCallbacks,
+} from "../core/movementProfile.js";
+
+/**
+ * Execute a Move script via `movement move run-script`.
+ *
+ * Auto-detects the script kind from the extension:
+ *   - `.move` source → `--script-path` (CLI compiles inline)
+ *   - `.mv` compiled bytecode → `--compiled-script-path`
+ *
+ * Reuses Publisher's security model via the shared `movementProfile`
+ * helpers: per-deploy unique profile, atomic 0o600 yaml writes under
+ * the mutex, SIGINT-safe sync cleanup, `--profile` auth (key never
+ * appears in `ps` output).
+ *
+ * Returns {@link MoveScriptResult}. `txHash` is guaranteed; `success`
+ * and `vmStatus` are best-effort parsed from the CLI's Result JSON.
+ *
+ * @internal — called from `Harness.runMoveScript`.
+ */
+export async function runMoveScript(
+  runtime: MovehatRuntime,
+  options: RunMoveScriptOptions
+): Promise<MoveScriptResult> {
+  const config = runtime.config;
+  const account = runtime.account;
+
+  // Synchronous validation before any CLI call.
+  if (!options.scriptPath || typeof options.scriptPath !== "string") {
+    throw new Error(
+      "Harness.runMoveScript requires options.scriptPath (string path to .move or .mv)."
+    );
+  }
+  const ext = extname(options.scriptPath).toLowerCase();
+  let scriptFlag: "--script-path" | "--compiled-script-path";
+  if (ext === ".move") {
+    scriptFlag = "--script-path";
+  } else if (ext === ".mv") {
+    scriptFlag = "--compiled-script-path";
+  } else {
+    throw new Error(
+      `Harness.runMoveScript: unsupported script extension '${ext || "<none>"}'. ` +
+        `Expected '.move' (source — CLI auto-compiles) or '.mv' (pre-compiled bytecode).`
+    );
+  }
+  if (!existsSync(options.scriptPath)) {
+    throw new Error(
+      `Harness.runMoveScript: script not found at '${options.scriptPath}'.`
+    );
+  }
+
+  const safeScriptPath = validatePathSafety(options.scriptPath, "script path");
+  const profile = `movehat-script-${randomUUID().slice(0, 8)}`;
+  const safeProfile = validateProfileSafety(profile);
+
+  logger.step(
+    `Running Move script '${options.scriptPath}' on ${config.network}...`
+  );
+
+  try {
+    const deployerAddress = account.accountAddress.toString();
+
+    let cleanPrivateKey = config.privateKey;
+    if (cleanPrivateKey.startsWith("ed25519-priv-")) {
+      cleanPrivateKey = cleanPrivateKey.replace("ed25519-priv-", "");
+    }
+
+    const movementConfigPath = join(homedir(), ".aptos", "config.yaml");
+
+    ensureSignalHandler();
+    const syncCleanup = () => removeProfileSync(movementConfigPath, profile);
+    cleanupCallbacks.add(syncCleanup);
+
+    await withYamlLock(() =>
+      addProfile(movementConfigPath, profile, {
+        private_key: cleanPrivateKey,
+        public_key: account.publicKey.toString(),
+        account: deployerAddress,
+        rest_url: config.rpc,
+      })
+    );
+
+    let scriptOut = "";
+    try {
+      const typeArgsFragment: string[] =
+        options.typeArgs && options.typeArgs.length > 0
+          ? ["--type-args", ...options.typeArgs]
+          : [];
+      const argsFragment: string[] =
+        options.args && options.args.length > 0
+          ? ["--args", ...options.args]
+          : [];
+
+      const result = await runCli(
+        {
+          command: "movement",
+          args: [
+            "move",
+            "run-script",
+            "--profile",
+            safeProfile,
+            "--url",
+            config.rpc,
+            "--assume-yes",
+            scriptFlag,
+            safeScriptPath,
+            ...typeArgsFragment,
+            ...argsFragment,
+          ],
+          timeoutMs: 120000,
+        },
+        { adapter: options.adapter }
+      );
+      scriptOut = result.stdout;
+      if (result.stdout) console.log(result.stdout.trim());
+      if (result.stderr) console.error(result.stderr.trim());
+    } finally {
+      await withYamlLock(() => removeProfile(movementConfigPath, profile)).catch(
+        (err) => {
+          const cleanupMsg = err instanceof Error ? err.message : String(err);
+          logger.warning(
+            `Failed to remove script profile "${profile}" from ${movementConfigPath}: ${cleanupMsg}. ` +
+              `Run 'movement config delete-profile --profile ${profile}' to clean up manually.`
+          );
+        }
+      );
+      cleanupCallbacks.delete(syncCleanup);
+    }
+
+    const txHash = parseTxHash(scriptOut);
+    if (!txHash) {
+      throw new Error(
+        `Could not parse transaction hash from 'move run-script' output. ` +
+          `Captured stdout:\n${scriptOut.slice(0, 1000)}`
+      );
+    }
+
+    const success = parseSuccess(scriptOut);
+    const vmStatus = parseVmStatus(scriptOut);
+
+    logger.success(`Move script executed (tx ${txHash}).`);
+
+    const out: MoveScriptResult = { txHash };
+    if (success !== undefined) out.success = success;
+    if (vmStatus !== undefined) out.vmStatus = vmStatus;
+    return out;
+  } catch (error) {
+    if (error instanceof CliExecutionError) {
+      if (error.stdoutPreview) console.log(error.stdoutPreview);
+      logger.error(`Failed to run Move script: ${error.message}\n${error.stderr}`);
+    } else {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error(`Failed to run Move script: ${err.message}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Best-effort parse of the `"success": true|false` field from
+ * Movement CLI's Result JSON block. Returns `undefined` on no match.
+ */
+function parseSuccess(stdout: string): boolean | undefined {
+  const m = stdout.match(/"success"\s*:\s*(true|false)/);
+  if (!m) return undefined;
+  return m[1] === "true";
+}
+
+/**
+ * Best-effort parse of the `"vm_status"` string. Returns `undefined`
+ * on no match.
+ */
+function parseVmStatus(stdout: string): string | undefined {
+  const m = stdout.match(/"vm_status"\s*:\s*"([^"]*)"/);
+  return m?.[1];
+}

--- a/packages/movehat/src/harness/view.ts
+++ b/packages/movehat/src/harness/view.ts
@@ -1,0 +1,34 @@
+import type { MoveFunctionId } from "@aptos-labs/ts-sdk";
+import type { MovehatRuntime } from "../types/runtime.js";
+import type { RunViewFunctionOptions } from "../types/harness.js";
+
+/**
+ * Execute a Move view function via the Aptos SDK (no CLI invocation).
+ *
+ * Returns the SDK's raw `unknown[]` — the Move boundary may return a
+ * tuple of any arity. Callers destructure:
+ *
+ * ```ts
+ * const [count] = await harness.runViewFunction({
+ *   function: "0xCAFE::counter::get",
+ *   functionArguments: ["0xdeployer"],
+ * });
+ * ```
+ *
+ * Works on all 3 harness modes (createLocal, createFork, createLive) —
+ * view functions read on-chain state without writing.
+ *
+ * @internal — called from `Harness.runViewFunction`.
+ */
+export async function runViewFunction(
+  runtime: MovehatRuntime,
+  options: RunViewFunctionOptions
+): Promise<unknown[]> {
+  return runtime.aptos.view({
+    payload: {
+      function: options.function as MoveFunctionId,
+      typeArguments: options.typeArguments ?? [],
+      functionArguments: (options.functionArguments ?? []) as never[],
+    },
+  });
+}

--- a/packages/movehat/src/types/harness.ts
+++ b/packages/movehat/src/types/harness.ts
@@ -72,3 +72,87 @@ export interface UpgradeCodeObjectOptions extends DeployCodeObjectOptions {
  * without churning every callsite.
  */
 export type CodeObjectInfo = DeploymentInfo;
+
+/**
+ * Options for `harness.runViewFunction(options)`.
+ *
+ * Delegates to the Aptos SDK's `aptos.view(...)` — no CLI invocation,
+ * no profile management. Works on `createLocal`, `createFork`, and
+ * `createLive` harnesses (view functions are read-only).
+ */
+export interface RunViewFunctionOptions {
+  /**
+   * Fully qualified Move function id, e.g. `0xCAFE::counter::get`.
+   */
+  function: string;
+
+  /**
+   * Move type-tag arguments, e.g. `['0x1::aptos_coin::AptosCoin']`.
+   */
+  typeArguments?: string[];
+
+  /**
+   * Move function arguments. SDK-validated at the boundary; pass values
+   * matching the Move function signature (strings for `address`,
+   * numbers / bigints for `u8`-`u256`, booleans, etc.).
+   */
+  functionArguments?: unknown[];
+}
+
+/**
+ * Options for `harness.runMoveScript(options)`.
+ *
+ * Wraps `movement move run-script`. The CLI handles compilation
+ * inline when given a `.move` source; the user can also pass a
+ * pre-compiled `.mv` bytecode file.
+ *
+ * Not available on fork-mode harnesses (forks are read-only).
+ */
+export interface RunMoveScriptOptions {
+  /**
+   * Path to the Move script. Extension determines the CLI flag:
+   *   - `.move` → `--script-path` (CLI auto-compiles)
+   *   - `.mv` → `--compiled-script-path` (user pre-compiled)
+   * Other extensions throw synchronously before any CLI call.
+   */
+  scriptPath: string;
+
+  /**
+   * CLI-formatted typed arguments. Movement CLI expects each arg
+   * prefixed by its Move type, e.g. `'address:0x1'`, `'u8:42'`,
+   * `'bool:true'`, `'string:hello'`. See
+   * `movement move run-script --help` for the full grammar.
+   */
+  args?: string[];
+
+  /**
+   * Type-tag arguments for generic scripts, e.g.
+   * `['0x1::aptos_coin::AptosCoin']`.
+   */
+  typeArgs?: string[];
+
+  /**
+   * Optional working directory for compilation. Most callers leave
+   * this undefined — the CLI uses the script's parent directory.
+   */
+  packageDir?: string;
+
+  /**
+   * Test-only override for the child-process adapter.
+   * @internal
+   */
+  adapter?: ChildProcessAdapter;
+}
+
+/**
+ * Result of `harness.runMoveScript`.
+ *
+ * Always carries `txHash` (parser throws if it can't extract one).
+ * `success` and `vmStatus` are best-effort: parsed from the CLI's
+ * JSON `Result` block when present, `undefined` if the parser misses.
+ */
+export interface MoveScriptResult {
+  txHash: string;
+  success?: boolean;
+  vmStatus?: string;
+}

--- a/packages/movehat/src/utils/parseCliOutput.ts
+++ b/packages/movehat/src/utils/parseCliOutput.ts
@@ -1,0 +1,27 @@
+/**
+ * Helpers for extracting fields out of Movement CLI stdout / stderr.
+ *
+ * @internal — not exported from `src/index.ts`.
+ */
+
+/**
+ * Extract the transaction hash from a `movement` CLI subcommand's stdout.
+ *
+ * Tries the context-bearing pattern first (`transaction hash: 0x…`,
+ * `txn hash: 0x…`, `hash: 0x…`) and falls back to any 64-char hex
+ * literal in the buffer. Returns `undefined` if no candidate matches.
+ *
+ * Shared by `core/Publisher.ts` (publish), `harness/codeObject.ts`
+ * (deploy-object / upgrade-object), and `harness/script.ts`
+ * (run-script). All three CLI subcommands emit the txHash in the same
+ * shape — keep this helper as the single source of truth so a future
+ * CLI-format change is a one-line fix.
+ */
+export function parseTxHash(stdout: string): string | undefined {
+  const withContext = stdout.match(
+    /(?:transaction\s*(?:hash)?|txn\s*(?:hash)?|hash):\s*(0x[a-fA-F0-9]{64})\b/i
+  );
+  if (withContext?.[1]) return withContext[1];
+  const fallback = stdout.match(/\b(0x[a-fA-F0-9]{64})\b/);
+  return fallback?.[1];
+}


### PR DESCRIPTION
## Summary

Third sub-PR of M2 (#69). Closes the seven-method Harness API surface required by KPI 1: `runViewFunction` (SDK delegation) and `runMoveScript` (CLI wrapper) replace the last two M2.1 stubs.

## Commits

1. **`refactor(utils): extract parseTxHash to utils/parseCliOutput.ts`** — the same regex pair (transaction-hash context + 64-char hex fallback) lived in 2 places after M2.2 and M2.3 needed a third. Lift once; Publisher.ts + harness/codeObject.ts + harness/script.ts import. Behavior-neutral: **210/210 tests pass unchanged**.

2. **`feat(harness): runViewFunction + runMoveScript + tests`** — adds:
   - `harness/view.ts` — 6-line wrapper around `runtime.aptos.view(...)`. No CLI invocation, no profile management. Returns raw `unknown[]` (SDK contract) — callers destructure: `const [count] = await harness.runViewFunction({...})`. Works on all 3 modes including fork (read-only).
   - `harness/script.ts` — wraps `movement move run-script` via `runCli` + shared `movementProfile` helpers (same security model as Publisher / codeObject: per-deploy unique profile, atomic 0o600 yaml writes, SIGINT-safe sync cleanup, `--profile` auth). **Auto-detects script kind from extension**: `.move` → `--script-path` (CLI compiles inline), `.mv` → `--compiled-script-path`. Throws synchronously on unsupported extensions or missing files. `txHash` parsed via shared helper; `success` + `vmStatus` best-effort from the Result JSON block.
   - `types/harness.ts` — new `RunViewFunctionOptions`, `RunMoveScriptOptions`, `MoveScriptResult`.
   - `Harness.ts` — replaces both stubs. `runMoveScript` has fork-mode guard (write operation); `runViewFunction` does not.
   - 11 new test cases (4 view + 7 script).
   - Retires the M2.1 \"stubs reject before cleanup\" test (all 4 methods now real).

## Key design decisions

- **`runMoveScript` accepts both `.move` and `.mv`**: the CLI supports both natively; exposing both costs ~5 LoC and matches the `movehat compile` workflow. Documented in JSDoc.
- **`runViewFunction` returns raw `unknown[]`**: matches the SDK's `aptos.view` contract. No singleton unwrap (the existing `MoveContract.view` does unwrap, but Harness is the new primary API and predictable typing wins). Users destructure for singletons.
- **`runViewFunction` mocking strategy**: tests monkey-patch `harness.runtime.aptos.view = vi.fn()...` because the SDK isn't behind an injectable adapter. One-off for M2.3; the wrapper is a 6-line forward. Adapter-injecting the entire Aptos SDK is way out of scope.

## DoD ticked in ROADMAP

- [x] `harness.runViewFunction(options)` executes a view function
- [x] `harness.runMoveScript(options)` compiles and executes a Move script

All 7 API methods are now implemented. Remaining M2 work is migration + docs in M2.4 (#119).

## Test plan

- [x] Tier 1: `pnpm --filter movehat exec tsc --noEmit` — clean
- [x] Tier 1: `pnpm --filter movehat test` — **220/220 passing** (210 prior + 11 new − 1 retired stub-rejection assertion)
- [x] Tier 1: `pnpm check:example` — green
- [x] Tier 2: `pnpm test:smoke` — pass (mandatory: types surface changed with 3 new exports; tarball + global install + CLI sanity confirmed)
- [skip] Tier 2: `pnpm test:example` — same mocha teardown flake documented in M2.2 PR description. Publish path is untouched at the regex level (C1's parseTxHash extraction is byte-identical to the prior inline pattern), so the integration angle is a strict subset of what M4 (#71) will cover.
- [N/A] Tier 3: `pnpm test:e2e` — templates + CLI untouched in M2.3; Tier 3 runs at M2.4.

Tracks #69. Closes #118.