### PR TITLE
feat(harness): migrate example + templates + docs; deprecate getMovehat (M2.4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,15 +93,15 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 
 | Status | Sub-PR | Issue | Focus | Closes |
 |---|---|---|---|---|
-|   | M2.1 | [#116](https://github.com/gilbertsahumada/movehat/issues/116) | Harness skeleton + 3 factories + Proxy poisoning + cleanup + HarnessDisposedError (4 methods stubbed) | foundations |
-|   | M2.2 | [#117](https://github.com/gilbertsahumada/movehat/issues/117) | `deployCodeObject` + `upgradeCodeObject` via `movement move deploy-object` / `upgrade-object` | (partial of #69) |
-|   | M2.3 | [#118](https://github.com/gilbertsahumada/movehat/issues/118) | `runViewFunction` + `runMoveScript` | (partial of #69) |
-|   | M2.4 | [#119](https://github.com/gilbertsahumada/movehat/issues/119) | Migrate `examples/counter-example/` + templates + 8 docs MDX; `@deprecated` JSDoc on `mh()` / `getMovehat` | closes #69 |
+| ✅ | M2.1 | [#116](https://github.com/gilbertsahumada/movehat/issues/116) (shipped in PR #120 @ `c44f9cb`) | Harness skeleton + 3 factories + Proxy poisoning + cleanup + HarnessDisposedError (4 methods stubbed) | foundations |
+| ✅ | M2.2 | [#117](https://github.com/gilbertsahumada/movehat/issues/117) (shipped in PR #121 @ `c336077`) | `deployCodeObject` + `upgradeCodeObject` via `movement move deploy-object` / `upgrade-object` + extract `core/movementProfile.ts` | (partial of #69) |
+| ✅ | M2.3 | [#118](https://github.com/gilbertsahumada/movehat/issues/118) (shipped in PR #122 @ `a334991`) | `runViewFunction` + `runMoveScript` + extract `utils/parseCliOutput.ts` | (partial of #69) |
+| ✅ | M2.4 | [#119](https://github.com/gilbertsahumada/movehat/issues/119) | Migrate `examples/counter-example/` + templates + 8 docs MDX + new `api/harness.mdx`; `@deprecated` JSDoc on `getMovehat`; fix M2.2 `addressName` bug | closes #69 |
 
 **Definition of Done — API surface**:
-- [ ] `import { Harness } from 'movehat'` works from the built package
-- [ ] `Harness.createLocal()` returns a usable instance
-- [ ] `Harness.createFork(network: string, apiKey?: string)` returns a usable instance
+- [x] `import { Harness } from 'movehat'` works from the built package (M2.4 — verified by Tier 2 smoke + Tier 3 e2e on the dev→main batch)
+- [x] `Harness.createLocal()` returns a usable instance (M2.4 — exercised end-to-end by the migrated `examples/counter-example/tests/Counter.test.ts`)
+- [x] `Harness.createFork(network: string, apiKey?: string)` returns a usable instance (M2.1 factory + documented in `api/harness.mdx`; integration coverage in M4)
 - [x] `Harness.createLive(network: string, faucetUrl?: string)` returns a usable instance (M2.1)
 - [x] `harness.deployCodeObject(options)` deploys a real Move package (M2.2 — wraps `movement move deploy-object`; reuses Publisher hardening via the extracted `core/movementProfile.ts` helpers; integration coverage in M4)
 - [x] `harness.upgradeCodeObject(options)` upgrades an existing code object (M2.2 — wraps `movement move upgrade-object`; same shared helpers)
@@ -114,12 +114,14 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `HarnessDisposedError` exported from the package (M2.1)
 
 **Definition of Done — Migration**:
-- [ ] `examples/counter-example/` uses `Harness.createLocal()`
-- [ ] `packages/movehat/src/templates/scripts/deploy-counter.ts` uses the new API
-- [ ] All MDX code snippets in `packages/docs/content/docs/` updated
-- [ ] `packages/docs/content/docs/api/harness.mdx` covers the 7 methods + cleanup
-- [ ] `mh()` still exported with `@deprecated` JSDoc tag
-- [ ] `pnpm test` green
+- [x] `examples/counter-example/` uses `Harness.createLocal()` (M2.4 — `tests/Counter.test.ts` + `scripts/deploy-counter.ts`; `greeting.test.ts` + `message.test.ts` + `scripts/deploy-greeting.ts` stay on `setupTestFixture` / `getMovehat` as the coexistence demo)
+- [x] `packages/movehat/src/templates/scripts/deploy-counter.ts` uses the new API (M2.4 — plus `templates/tests/Counter.test.ts`)
+- [x] All MDX code snippets in `packages/docs/content/docs/` updated (M2.4 — 8 MDX files: index, getting-started/{quickstart,configuration}, guides/{testing,scripts,deployment}, cli/{init,run})
+- [x] `packages/docs/content/docs/api/harness.mdx` covers the 7 methods + cleanup (M2.4 — ~200 lines: factory matrix, options reference, fork-mode guard, HarnessDisposedError, AccountManager shared-pool quirk)
+- [x] `getMovehat()` still exported with `@deprecated` JSDoc tag (M2.4 — full migration snippet inline; `initRuntime` stays public as a low-level utility used by `Harness.createLive`)
+- [x] `pnpm test` green (M2.4 — 222/222 unit tests; Tier 2 `test:example` 9/9 passing in ~1 min)
+
+**M2 status: ✅ ready for `develop → main` batch — all 4 sub-PRs (M2.1 PR #120, M2.2 PR #121, M2.3 PR #122, M2.4 PR #N) merged to develop. Tier 3 `pnpm test:e2e` to be run on the batch PR per CLAUDE.md §6.3.**
 
 ### M3 — 80% unit coverage + Movement CLI cache (~5 days, issue #70) — (KPI 1)
 

--- a/examples/counter-example/scripts/deploy-counter.ts
+++ b/examples/counter-example/scripts/deploy-counter.ts
@@ -1,48 +1,55 @@
-import { getMovehat, ModuleAlreadyDeployedError } from "movehat";
+import { Harness } from "movehat";
 
+/**
+ * Canonical example of `harness.deployCodeObject` against a Move
+ * package where the Move.toml's named address differs from the
+ * module identifier:
+ *
+ *   move/Move.toml:    [addresses] hello_blockchain = "_"
+ *   move/sources/...:  module hello_blockchain::counter { ... }
+ *
+ * `--address-name` must be `hello_blockchain` (the Move.toml slot),
+ * but `moduleName` stays `counter` (the on-chain module identifier
+ * + the persistence key + the `runtime.getContract(addr, "counter")`
+ * argument). The `addressName` option carries that distinction.
+ */
 async function main() {
   console.log("🚀 Deploying Counter contract...\n");
 
-  // Get the Movehat Runtime Environment
-  const mh = await getMovehat();
+  const network = process.env.MOVEHAT_NETWORK ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    console.log(`✅ Runtime initialized on ${harness.runtime.network.name}`);
+    console.log(`   Account: ${harness.runtime.account.accountAddress.toString()}`);
+    console.log(`   RPC: ${harness.runtime.network.rpc}\n`);
 
-  console.log(`✅ Runtime initialized`);
-  console.log(`   Account: ${mh.account.accountAddress.toString()}`);
-  console.log(`   Network: ${mh.network.name}`);
-  console.log(`   RPC: ${mh.network.rpc}\n`);
+    const deployment = await harness.deployCodeObject({
+      moduleName: "counter",
+      addressName: "hello_blockchain",
+    });
 
-  // Deploy (publish) the module
-  // Automatically checks if already deployed and suggests --redeploy if needed
-  const deployment = await mh.deployContract("counter");
+    console.log(`\n✅ Module deployed at: ${deployment.address}::counter`);
+    if (deployment.txHash) {
+      console.log(`   Transaction: ${deployment.txHash}`);
+    }
 
-  console.log(`\n✅ Module deployed at: ${deployment.address}::counter`);
-  if (deployment.txHash) {
-    console.log(`   Transaction: ${deployment.txHash}`);
+    const counter = harness.runtime.getContract(deployment.address, "counter");
+
+    console.log("\n📝 Incrementing counter...");
+    const txResult = await counter.call(harness.runtime.account, "increment", []);
+    console.log(`✅ Transaction hash: ${txResult.hash}`);
+
+    const [value] = await harness.runViewFunction({
+      function: `${deployment.address}::counter::get`,
+      functionArguments: [harness.runtime.account.accountAddress.toString()],
+    });
+    console.log(`\n📊 Counter value: ${value}`);
+  } finally {
+    await harness.cleanup();
   }
-
-  // Get contract instance
-  const counter = mh.getContract(deployment.address, "counter");
-
-  // Increment the counter (this also initializes it if not exists)
-  console.log("\n📝 Incrementing counter...");
-  const txResult = await counter.call(mh.account, "increment", []);
-
-  console.log(`✅ Transaction hash: ${txResult.hash}`);
-  console.log(`✅ Counter incremented successfully!`);
-
-  // Verify
-  const value = await counter.view<number>("get", [
-    mh.account.accountAddress.toString()
-  ]);
-
-  console.log(`\n📊 Counter value: ${value}`);
 }
 
 main().catch((error) => {
-  // ModuleAlreadyDeployedError is already logged with full details by deployContract()
-  // For other errors, show the message
-  if (!(error instanceof ModuleAlreadyDeployedError)) {
-    console.error("❌ Deployment failed:", error?.message || error);
-  }
+  console.error("❌ Deployment failed:", error?.message || error);
   process.exit(1);
 });

--- a/examples/counter-example/tests/Counter.test.ts
+++ b/examples/counter-example/tests/Counter.test.ts
@@ -1,70 +1,77 @@
-import { setupTestFixture, type TestFixture } from "movehat/helpers";
+import { Harness, AccountManager } from "movehat";
+import type { MoveContract } from "movehat/helpers";
+import type { Account } from "@aptos-labs/ts-sdk";
 import { expect } from "chai";
 
+/**
+ * Migrated to the M2 Harness API. Uses Harness.createLocal with
+ * autoDeploy — same Publisher-based publish path the previous
+ * setupTestFixture flow used. The sibling tests (greeting.test.ts,
+ * message.test.ts) stay on setupTestFixture to demonstrate that the
+ * older API continues to work side-by-side.
+ *
+ * For the new code-object deploy path (`harness.deployCodeObject`),
+ * see scripts/deploy-counter.ts in this directory.
+ */
 describe("Counter Contract", () => {
-  let fixture: TestFixture<'counter'>;
+  let harness: Harness;
+  let counter: MoveContract;
+  let counterAddr: string;
+  let deployer: Account, alice: Account;
 
   before(async function () {
-    this.timeout(60000); // Allow time for fork creation + deployment
+    this.timeout(60000); // Allow time for local node startup + autoDeploy
 
-    // Setup local testing environment with auto-deployment
-    // TypeScript will infer that fixture.contracts.counter exists!
-    fixture = await setupTestFixture(['counter'] as const, ['alice', 'bob']);
+    harness = await Harness.createLocal({
+      accountLabels: ["deployer", "alice", "bob"],
+      autoDeploy: ["counter"],
+    });
+
+    const labeled = AccountManager.getLabeledAccounts();
+    deployer = labeled.deployer!;
+    alice = labeled.alice!;
+
+    counterAddr = harness.runtime.getDeploymentAddress("counter")!;
+    counter = harness.runtime.getContract(counterAddr, "counter");
   });
 
-  it("should initialize with value 0", async () => {
-    const counter = fixture.contracts.counter; // ✅ No need for `!` anymore
-    const deployer = fixture.accounts.deployer;
-
-    // Read counter value (returns string from view function)
-    const value = await counter.view<string>("get", [
-      deployer.accountAddress.toString()
-    ]);
+  it("should initialize with value 0 (via harness.runViewFunction)", async () => {
+    // Demonstrate the new SDK-backed view path. Returns the raw
+    // unknown[] tuple from aptos.view — destructure for singletons.
+    const [value] = await harness.runViewFunction({
+      function: `${counterAddr}::counter::get`,
+      functionArguments: [deployer.accountAddress.toString()],
+    });
 
     console.log(`   Counter value: ${value}`);
-
-    // Assert the counter is 0 (note: values from view are strings)
-    expect(parseInt(value)).to.equal(0);
+    expect(parseInt(value as string)).to.equal(0);
   });
 
   it("should increment counter", async () => {
-    const counter = fixture.contracts.counter;
-    const deployer = fixture.accounts.deployer;
-
-    // Increment the counter
     const tx = await counter.call(deployer, "increment", []);
     console.log(`   Transaction: ${tx.hash}`);
 
-    // Read new value
     const value = await counter.view<string>("get", [
-      deployer.accountAddress.toString()
+      deployer.accountAddress.toString(),
     ]);
 
     console.log(`   New counter value: ${value}`);
-
-    // Should be 1 now
     expect(parseInt(value)).to.equal(1);
   });
 
   it("alice can also increment counter", async () => {
-    const counter = fixture.contracts.counter;
-    const alice = fixture.accounts.alice;
-
-    // Alice increments her own counter
     const tx = await counter.call(alice, "increment", []);
     console.log(`   Alice's transaction: ${tx.hash}`);
 
-    // Read counter value for Alice (each user has their own counter)
     const aliceValue = await counter.view<string>("get", [
-      alice.accountAddress.toString()
+      alice.accountAddress.toString(),
     ]);
 
     console.log(`   Alice's counter value: ${aliceValue}`);
     expect(parseInt(aliceValue)).to.equal(1);
 
-    // Deployer's counter should still be 1 (unchanged)
     const deployerValue = await counter.view<string>("get", [
-      fixture.accounts.deployer.accountAddress.toString()
+      deployer.accountAddress.toString(),
     ]);
 
     console.log(`   Deployer's counter value: ${deployerValue}`);
@@ -72,6 +79,6 @@ describe("Counter Contract", () => {
   });
 
   after(async () => {
-    await fixture.teardown();
+    await harness.cleanup();
   });
 });

--- a/packages/docs/content/docs/api/harness.mdx
+++ b/packages/docs/content/docs/api/harness.mdx
@@ -1,0 +1,209 @@
+---
+title: Harness
+description: Hardhat-style harness API — factories, deployment, view + script execution, cleanup
+icon: Wrench
+---
+
+The `Harness` class is the primary public API of Movehat since M2 (KPI 1). It wraps the Movement TypeScript SDK + Movement CLI behind a Hardhat-style lifecycle: a static factory constructs the instance, methods do the work, and `cleanup()` releases resources + poisons the instance so any further method call throws `HarnessDisposedError` synchronously.
+
+## Quick Start
+
+```typescript
+import { Harness } from "movehat";
+
+const harness = await Harness.createLocal({
+  accountLabels: ["deployer", "alice", "bob"],
+  autoDeploy: ["counter"],
+});
+try {
+  const addr = harness.runtime.getDeploymentAddress("counter");
+  const counter = harness.runtime.getContract(addr, "counter");
+  await counter.call(harness.runtime.account, "increment", []);
+  const [value] = await harness.runViewFunction({
+    function: `${addr}::counter::get`,
+    functionArguments: [harness.runtime.account.accountAddress.toString()],
+  });
+  console.log("counter:", value);
+} finally {
+  await harness.cleanup();
+}
+```
+
+## Factory Methods
+
+Three static factories cover the three execution modes. Each returns a `Harness` instance whose `mode` field reflects the chosen path.
+
+| Factory | Mode | What it spawns | When to use |
+|---|---|---|---|
+| `Harness.createLocal(options?)` | `'local'` | Movement local node (real blockchain on `localhost:8080`) | Unit + integration tests that need real transaction flow |
+| `Harness.createFork(network, apiKey?)` | `'fork'` | Movement fork server (read-only snapshot of `network`) | View-only tests against real network state, no writes |
+| `Harness.createLive(network, faucetUrl?)` | `'live'` | Nothing — binds to a real RPC (testnet / mainnet / custom) | Deployment scripts, real-network interactions |
+
+### `Harness.createLocal(options?: LocalTestOptions)`
+
+Spins up a Movement local node (`movement node run-localnet`), generates and funds the named accounts from the local faucet, and (when `autoDeploy` is set) publishes the named modules via the existing Publisher path.
+
+```typescript
+const harness = await Harness.createLocal({
+  accountLabels: ["deployer", "alice", "bob"],
+  autoDeploy: ["counter"],
+  // mode is forced to 'local-node'; other LocalTestOptions pass through
+});
+```
+
+`LocalTestOptions` (see `movehat/helpers`) supports `nodeApiPort`, `nodeFaucetPort`, `accountLabels`, `autoDeploy`, `autoFund`, `defaultBalance`, and more.
+
+### `Harness.createFork(network: string, apiKey?: string)`
+
+Read-only path. `network` is `'testnet'`, `'mainnet'`, or any custom name resolvable by `loadUserConfig`. Spawns a `ForkServer` reading from the upstream JSON-RPC endpoint and caching responses on disk.
+
+```typescript
+const harness = await Harness.createFork("testnet");
+// harness.runViewFunction works
+// harness.deployCodeObject / upgradeCodeObject / runMoveScript throw a clear error
+```
+
+> The `apiKey` parameter is reserved — wiring into the `MovementApiClient` Authorization header is a TODO for an upcoming sub-PR. Passing it today is a silent no-op.
+
+### `Harness.createLive(network: string, faucetUrl?: string)`
+
+Binds to a real running network. No local process is spawned; transactions hit the configured RPC. Use for testnet / mainnet deployments and real-network reads/writes.
+
+```typescript
+const harness = await Harness.createLive(process.env.MOVEHAT_NETWORK ?? "testnet");
+```
+
+## Methods
+
+### `harness.deployCodeObject(options)`
+
+Wraps `movement move deploy-object`. The derived object address is bound to a Move.toml named address at compile time and returned as `DeploymentInfo.address`.
+
+```typescript
+const deployment = await harness.deployCodeObject({
+  moduleName: "counter",     // persistence key + getContract argument
+  addressName: "my_pkg",     // optional — Move.toml named address (defaults to moduleName)
+  packageDir: "./move",      // optional — defaults to config.moveDir
+  namedAddresses: { extra: "0x..." }, // optional overrides
+});
+```
+
+| Option | Description |
+|---|---|
+| `moduleName` | The on-chain module identifier (the `name` part of `module addr::name`). Used as the deployments registry key (`deployments/{network}/{moduleName}.json`) and as the `name` argument you pass to `runtime.getContract(addr, name)`. |
+| `addressName` | The Move.toml named address that the derived object address binds to (the `--address-name` CLI flag). Defaults to `moduleName`. Set when they differ — e.g. `module hello_blockchain::counter` with `[addresses] hello_blockchain = "_"` needs `addressName: "hello_blockchain"`, `moduleName: "counter"`. |
+| `packageDir` | Path to the Move package. Defaults to `config.moveDir` (usually `./move`). |
+| `namedAddresses` | Overlay on top of the named addresses auto-detected from `<packageDir>/sources/**.move`. |
+| `includedArtifacts` | One of `'none'` / `'sparse'` / `'all'` — defaults to the CLI default (`'sparse'`). |
+
+**Re-deploying:** the local record at `deployments/{network}/{moduleName}.json` makes a second call refuse with `ModuleAlreadyDeployedError`. Set `MH_CLI_REDEPLOY=true` to force a re-deploy.
+
+**Fork-mode guard:** throws a clear error on a `Harness.createFork(...)` instance (forks are read-only).
+
+### `harness.upgradeCodeObject(options)`
+
+Wraps `movement move upgrade-object`. Requires `objectAddress` — the existing on-chain object's address. The local `DeploymentInfo` record is overwritten with a new `timestamp` + `txHash`; the address stays the same.
+
+```typescript
+const upgraded = await harness.upgradeCodeObject({
+  moduleName: "counter",
+  objectAddress: "0xCAFE...",
+});
+```
+
+Fork-mode guard applies.
+
+### `harness.runViewFunction(options)`
+
+Pure SDK call — no Movement CLI invocation, no profile management. Works on all 3 harness modes (read-only).
+
+```typescript
+const result = await harness.runViewFunction({
+  function: "0xCAFE::counter::get",      // fully qualified function id
+  typeArguments: [],                     // optional Move type tags
+  functionArguments: ["0xdeployer..."],  // optional Move function args
+});
+// result: unknown[] — the raw view-function return tuple
+const [value] = result;
+```
+
+Returns the SDK's raw `unknown[]` (Move view functions can return tuples of any arity). Destructure for singletons.
+
+### `harness.runMoveScript(options)`
+
+Wraps `movement move run-script`. Accepts either a `.move` source path (CLI auto-compiles) or a pre-compiled `.mv` bytecode path — the extension picks the right CLI flag.
+
+```typescript
+const result = await harness.runMoveScript({
+  scriptPath: "scripts/init.move",       // or scripts/init.mv
+  args: ["address:0x1", "u64:42"],       // typed args per Movement CLI grammar
+  typeArgs: ["0x1::aptos_coin::AptosCoin"],
+});
+// result: { txHash, success?, vmStatus? }
+```
+
+`success` and `vmStatus` are best-effort parsed from the CLI's Result JSON block. `txHash` is always present (the parser throws if it can't extract one). Fork-mode guard applies.
+
+### `harness.cleanup()`
+
+Releases owned services and poisons the harness:
+
+- `createLocal`: stops the Movement local node
+- `createFork`: stops the fork server
+- `createLive`: no-op (no spawned process), but still poisons the instance
+
+After `cleanup()`, any call to `deployCodeObject`, `upgradeCodeObject`, `runViewFunction`, or `runMoveScript` throws `HarnessDisposedError` **synchronously on property access** (before the awaited body runs). `cleanup()` is idempotent — calling it twice is a no-op.
+
+```typescript
+const harness = await Harness.createLocal();
+await harness.cleanup();
+harness.deployCodeObject({ moduleName: "x" });
+// throws HarnessDisposedError immediately
+```
+
+## Use-After-Cleanup Safety
+
+`HarnessDisposedError` is exported alongside `Harness`:
+
+```typescript
+import { Harness, HarnessDisposedError } from "movehat";
+
+try {
+  await disposedHarness.runViewFunction({ function: "..." });
+} catch (err) {
+  if (err instanceof HarnessDisposedError) {
+    console.error(`Method '${err.methodName}' rejected — harness is disposed.`);
+  }
+}
+```
+
+The poisoning is implemented via a `Proxy` whose `get` trap throws on access to any of the four mutating/view methods listed above. Properties like `mode`, `poisoned`, `runtime`, and `cleanup` itself stay readable — so `await harness.cleanup()` after a previous `cleanup()` is safe and idempotent, and `console.log(harness)` / promise-protocol checks (`.then`, etc.) don't fire the trap.
+
+## Coexistence with `setupTestFixture` / `mh()`
+
+Both pre-M2 helpers continue to work in M2.4:
+
+- `import { setupTestFixture } from "movehat/helpers"` — still exported, still functional.
+- `import { getMovehat } from "movehat"` — exported with a `@deprecated` JSDoc tag; removed in `0.1.0` (M6 / [#73](https://github.com/gilbertsahumada/movehat/issues/73)).
+
+`Harness.createLocal` actually goes through `setupLocalTesting` (which `setupTestFixture` also uses) under the hood — the test environment is identical. The migration is API-level, not infrastructure-level.
+
+## AccountManager Shared Pool
+
+`AccountManager` is a process-wide static. Two `Harness` instances in the same process share account labels:
+
+```typescript
+const h1 = await Harness.createLocal({ accountLabels: ["alice"] });
+const h2 = await Harness.createLocal({ accountLabels: ["alice"] });
+// h1 and h2 see the SAME alice key — AccountManager doesn't re-derive per harness.
+```
+
+This is the same constraint that already governs `setupTestFixture`. A per-Harness pool is a future change tracked under M3.
+
+## Reference Implementation
+
+The canonical end-to-end migration:
+
+- **Counter test using `Harness.createLocal`:** [`examples/counter-example/tests/Counter.test.ts`](https://github.com/gilbertsahumada/movehat/blob/develop/examples/counter-example/tests/Counter.test.ts)
+- **Deploy script using `Harness.createLive` + `deployCodeObject` + `addressName`:** [`examples/counter-example/scripts/deploy-counter.ts`](https://github.com/gilbertsahumada/movehat/blob/develop/examples/counter-example/scripts/deploy-counter.ts)
+- **Template the `movehat init` CLI ships:** [`packages/movehat/src/templates/scripts/deploy-counter.ts`](https://github.com/gilbertsahumada/movehat/blob/develop/packages/movehat/src/templates/scripts/deploy-counter.ts)

--- a/packages/docs/content/docs/api/meta.json
+++ b/packages/docs/content/docs/api/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "API Reference",
+  "pages": ["harness"]
+}

--- a/packages/docs/content/docs/cli/init.mdx
+++ b/packages/docs/content/docs/cli/init.mdx
@@ -43,8 +43,8 @@ my-project/
 ## What It Creates
 
 - **Counter.move** — A sample Move smart contract with increment/decrement functions and Move unit tests
-- **Counter.test.ts** — TypeScript integration test file using `setupTestFixture`
-- **deploy-counter.ts** — Deployment script using the Movehat Runtime Environment
+- **Counter.test.ts** — TypeScript integration test file using `Harness.createLocal`
+- **deploy-counter.ts** — Deployment script using `Harness.createLive` + `deployCodeObject`
 - **movehat.config.ts** — Network configuration (testnet, mainnet, local)
 - **package.json** — Dependencies including `movehat`
 - **.env.example** — Environment variable template

--- a/packages/docs/content/docs/cli/run.mdx
+++ b/packages/docs/content/docs/cli/run.mdx
@@ -36,11 +36,11 @@ movehat run scripts/deploy-counter.ts --network testnet --redeploy
 
 ## How It Works
 
-1. Parses `--network` and `--redeploy` flags
+1. Parses `--network` and `--redeploy` flags (`--redeploy` sets `MH_CLI_REDEPLOY=true` for the spawned script)
 2. Spawns `tsx` with your script
-3. Your script calls `getMovehat()` to get the runtime
-4. The runtime loads configuration, connects to the network, and sets up accounts
-5. If `deployContract()` is called, deployment tracking checks/saves are performed
+3. Your script constructs a `Harness` via one of the `Harness.create*` factories
+4. The harness loads configuration, connects to the network, and sets up accounts
+5. If `harness.deployCodeObject()` is called, deployment tracking checks/saves are performed
 
 ## Deployment Tracking
 
@@ -53,15 +53,22 @@ When a script deploys a contract:
 ## Script Template
 
 ```typescript
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const harness = await Harness.createLive(process.env.MOVEHAT_NETWORK ?? "testnet");
+  try {
+    console.log("Network:", harness.runtime.network.name);
+    console.log("Account:", harness.runtime.account.accountAddress.toString());
 
-  console.log("Network:", mh.config.network);
-  console.log("Account:", mh.account.accountAddress.toString());
-
-  // Your deployment logic here
+    // Your deployment logic here, e.g.:
+    //   const deployment = await harness.deployCodeObject({ moduleName: "counter" });
+    //   const [value] = await harness.runViewFunction({ function: "..." });
+    //   const result = await harness.runMoveScript({ scriptPath: "scripts/init.move" });
+  } finally {
+    // cleanup() is idempotent and safe to always call.
+    await harness.cleanup();
+  }
 }
 
 main().catch((error) => {

--- a/packages/docs/content/docs/getting-started/configuration.mdx
+++ b/packages/docs/content/docs/getting-started/configuration.mdx
@@ -104,13 +104,20 @@ PRIVATE_KEY=0x<YOUR_PRIVATE_KEY>
 // movehat.config.ts
 export default {
   accounts: [
-    process.env.PRIVATE_KEY,     // Primary (mh.account)
-    process.env.SECONDARY_KEY,   // mh.accounts[1]
+    process.env.PRIVATE_KEY,     // Primary (harness.runtime.account)
+    process.env.SECONDARY_KEY,   // harness.runtime.accounts[1]
   ].filter(Boolean),
 };
 
 // In your script
-const mh = await getMovehat();
-const primaryAccount = mh.account;               // accounts[0]
-const secondaryAccount = mh.getAccountByIndex(1); // accounts[1]
+import { Harness } from "movehat";
+
+const harness = await Harness.createLive("testnet");
+try {
+  const primaryAccount = harness.runtime.account;                  // accounts[0]
+  const secondaryAccount = harness.runtime.getAccountByIndex(1);   // accounts[1]
+  // ...
+} finally {
+  await harness.cleanup();
+}
 ```

--- a/packages/docs/content/docs/getting-started/quickstart.mdx
+++ b/packages/docs/content/docs/getting-started/quickstart.mdx
@@ -75,39 +75,47 @@ Run with: `movehat test --move` (ultra-fast, milliseconds)
 
 ### TypeScript Integration Tests (Local Node)
 
-Tests written in TypeScript that run on a **local Movement blockchain**:
+Tests written in TypeScript that run on a **local Movement blockchain** using the Hardhat-style `Harness` API:
 
 ```typescript
-import { setupTestFixture, teardownTestFixture } from "movehat/helpers";
+import { Harness, AccountManager } from "movehat";
 
 describe("Counter Contract", () => {
-  let fixture;
+  let harness;
+  let counter, deployer;
 
   before(async function () {
     this.timeout(60000);
-    // Starts local node, funds accounts, deploys contracts
-    fixture = await setupTestFixture(['counter'] as const, ['alice', 'bob']);
+    // Starts local node, funds accounts, deploys the named module(s)
+    harness = await Harness.createLocal({
+      accountLabels: ["deployer", "alice", "bob"],
+      autoDeploy: ["counter"],
+    });
+    deployer = AccountManager.getLabeledAccounts().deployer;
+    const addr = harness.runtime.getDeploymentAddress("counter");
+    counter = harness.runtime.getContract(addr, "counter");
   });
 
   it("should increment counter", async () => {
-    const counter = fixture.contracts.counter;
-    const deployer = fixture.accounts.deployer;
-
-    // Real transaction on local blockchain
     await counter.call(deployer, "increment", []);
 
-    const value = await counter.view<string>("get", [
-      deployer.accountAddress.toString()
-    ]);
+    const [value] = await harness.runViewFunction({
+      function: `${counter.moduleAddress}::counter::get`,
+      functionArguments: [deployer.accountAddress.toString()],
+    });
 
     expect(parseInt(value)).to.equal(1);
   });
 
   after(async () => {
-    await teardownTestFixture();
+    // Stops the local node and poisons the harness — any further
+    // method call (other than cleanup) throws HarnessDisposedError.
+    await harness.cleanup();
   });
 });
 ```
+
+> **Looking for the older API?** `setupTestFixture` / `teardownTestFixture` still works (see `movehat/helpers`); use whichever style fits your codebase. `Harness` is the new primary surface since M2.
 
 Run with: `movehat test --ts` (starts local node)
 

--- a/packages/docs/content/docs/guides/deployment.mdx
+++ b/packages/docs/content/docs/guides/deployment.mdx
@@ -6,31 +6,36 @@ icon: CloudUpload
 
 ## Writing Deployment Scripts
 
-Deployment scripts use the **Movehat Runtime Environment (MRE)**:
+Deployment scripts use the **Hardhat-style `Harness` API**, which wraps the Movement SDK + the new code-object publish path (`movement move deploy-object`):
 
 ```typescript
 // scripts/deploy-counter.ts
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const harness = await Harness.createLive(process.env.MOVEHAT_NETWORK ?? "testnet");
+  try {
+    console.log("Deploying from:", harness.runtime.account.accountAddress.toString());
+    console.log("Network:", harness.runtime.network.name);
 
-  console.log("Deploying from:", mh.account.accountAddress.toString());
-  console.log("Network:", mh.config.network);
+    // Deploy as a code object. If your Move.toml's named address
+    // differs from the module identifier (e.g. `module my_pkg::counter`
+    // with `[addresses] my_pkg = "_"`), set `addressName: "my_pkg"`.
+    const deployment = await harness.deployCodeObject({ moduleName: "counter" });
 
-  // Deploy (publish) the module
-  const deployment = await mh.deployContract("counter");
+    console.log("Module deployed at:", deployment.address);
+    console.log("Transaction:", deployment.txHash);
 
-  console.log("Module deployed at:", deployment.address);
-  console.log("Transaction:", deployment.txHash);
+    // Get contract instance
+    const contract = harness.runtime.getContract(deployment.address, "counter");
 
-  // Get contract instance
-  const contract = mh.getContract(deployment.address, "counter");
+    // Initialize the counter
+    await contract.call(harness.runtime.account, "init", []);
 
-  // Initialize the counter
-  await contract.call(mh.account, "init", []);
-
-  console.log("Counter initialized!");
+    console.log("Counter initialized!");
+  } finally {
+    await harness.cleanup();
+  }
 }
 
 main().catch((error) => {
@@ -38,6 +43,8 @@ main().catch((error) => {
   process.exit(1);
 });
 ```
+
+> **Re-deploying:** the local deployment record lives at `deployments/{network}/{moduleName}.json`. A second `deployCodeObject({ moduleName: "counter" })` call refuses with `ModuleAlreadyDeployedError`. To force a re-deploy, set `MH_CLI_REDEPLOY=true` in the environment.
 
 ## Running Deployment Scripts
 
@@ -99,56 +106,60 @@ movehat run scripts/deploy-counter.ts --network testnet
 #    Deployed at: 2025-12-05 23:38:14 UTC
 #    Transaction: 0x59cb0c2df832...
 #
-#    To redeploy, run with the --redeploy flag:
-#    movehat run <script> --network testnet --redeploy
+#    To redeploy, set MH_CLI_REDEPLOY=true:
+#    MH_CLI_REDEPLOY=true movehat run <script> --network testnet
 ```
 
 **Force redeploy:**
 
 ```bash
-movehat run scripts/deploy-counter.ts --network testnet --redeploy
+MH_CLI_REDEPLOY=true movehat run scripts/deploy-counter.ts --network testnet
 # Redeploys and updates deployment info
 ```
 
-## Runtime Environment Properties
+## Harness Properties
 
 ```typescript
-const mh = await getMovehat();
+const harness = await Harness.createLive("testnet");
 
-// Core
-mh.config         // Resolved configuration
-mh.network        // Network info (name, chainId, rpc)
-mh.aptos          // Movement TypeScript SDK client
-mh.account        // Primary account
-mh.accounts       // All configured accounts
+// Harness methods (M2 public API)
+harness.mode               // 'local' | 'fork' | 'live'
+harness.deployCodeObject   // movement move deploy-object
+harness.upgradeCodeObject  // movement move upgrade-object
+harness.runViewFunction    // aptos.view
+harness.runMoveScript      // movement move run-script
+harness.cleanup            // release resources + poison
 
-// Contract helpers
-mh.getContract    // Get contract helper
-
-// Deployment functions
-mh.deployContract       // Deploy and track module
-mh.getDeployment        // Get deployment info for a module
-mh.getDeployments       // Get all deployments for current network
-mh.getDeploymentAddress // Get deployed address for a module
-
-// Network management
-mh.switchNetwork  // Switch to different network
+// Underlying runtime
+harness.runtime.config              // Resolved configuration
+harness.runtime.network             // Network info
+harness.runtime.aptos               // Movement TypeScript SDK client
+harness.runtime.account             // Primary account
+harness.runtime.accounts            // All configured accounts
+harness.runtime.getContract         // Get a MoveContract helper
+harness.runtime.getDeployment       // Get deployment info
+harness.runtime.getDeployments      // Get all deployments
+harness.runtime.getDeploymentAddress // Get deployed address
 ```
 
 ## Multi-Network Deployment
 
 ```typescript
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const network = process.env.MOVEHAT_NETWORK ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    if (harness.runtime.network.name === "mainnet") {
+      console.log("WARNING: Deploying to MAINNET");
+    }
 
-  if (mh.config.network === "mainnet") {
-    console.log("WARNING: Deploying to MAINNET");
+    const deployment = await harness.deployCodeObject({ moduleName: "counter" });
+    console.log(`Deployed on ${harness.runtime.network.name}:`, deployment.address);
+  } finally {
+    await harness.cleanup();
   }
-
-  const deployment = await mh.deployContract("counter");
-  console.log(`Deployed on ${mh.config.network}:`, deployment.address);
 }
 
 main().catch(console.error);

--- a/packages/docs/content/docs/guides/scripts.mdx
+++ b/packages/docs/content/docs/guides/scripts.mdx
@@ -12,30 +12,64 @@ Execute TypeScript/JavaScript scripts with the Movehat Runtime:
 movehat run scripts/deploy-counter.ts --network testnet
 ```
 
-The `movehat run` command provides your script with access to the **Movehat Runtime Environment (MRE)**, which includes the Movement TypeScript SDK client, account management, contract helpers, and more.
+The `movehat run` command provides your script with access to the **Hardhat-style `Harness` API**, which wraps the Movement TypeScript SDK client, account management, contract helpers, and the new code-object deployment path.
 
 ## Writing Scripts
 
 ### Deploy and Initialize
 
 ```typescript
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const harness = await Harness.createLive(process.env.MOVEHAT_NETWORK ?? "testnet");
+  try {
+    // 1. Deploy via `movement move deploy-object` (code object).
+    //    Set `addressName` if Move.toml's named address ≠ moduleName.
+    const deployment = await harness.deployCodeObject({ moduleName: "counter" });
+    console.log("Module deployed at:", deployment.address);
+    console.log("Transaction:", deployment.txHash);
 
-  // 1. Deploy (publish) the module
-  const deployment = await mh.deployContract("counter");
-  console.log("Module deployed at:", deployment.address);
-  console.log("Transaction:", deployment.txHash);
+    // 2. Initialize
+    const contract = harness.runtime.getContract(deployment.address, "counter");
+    await contract.call(harness.runtime.account, "init", []);
 
-  // 2. Initialize
-  const contract = mh.getContract(deployment.address, "counter");
-  await contract.call(mh.account, "init", []);
+    // 3. Verify via the SDK-backed view path
+    const [value] = await harness.runViewFunction({
+      function: `${deployment.address}::counter::getValue`,
+    });
+    console.log("Initial value:", value);
+  } finally {
+    // Always release — cleanup() is idempotent and poisons the harness.
+    await harness.cleanup();
+  }
+}
 
-  // 3. Verify
-  const value = await contract.view("getValue", []);
-  console.log("Initial value:", value);
+main().catch(console.error);
+```
+
+### Running a Move Script
+
+For Move scripts (one-shot transactions, not module publishes), use `harness.runMoveScript`. It accepts either a `.move` source path (CLI auto-compiles) or a pre-compiled `.mv` bytecode path — the extension determines which CLI flag is used.
+
+```typescript
+import { Harness } from "movehat";
+
+async function main() {
+  const harness = await Harness.createLive("testnet");
+  try {
+    const result = await harness.runMoveScript({
+      scriptPath: "scripts/initialize.move",  // or scripts/initialize.mv
+      typeArgs: ["0x1::aptos_coin::AptosCoin"],
+      args: ["address:0xCAFE", "u64:100"],
+    });
+    console.log("Transaction:", result.txHash);
+    if (result.success === false) {
+      throw new Error(`Script failed: ${result.vmStatus}`);
+    }
+  } finally {
+    await harness.cleanup();
+  }
 }
 
 main().catch(console.error);
@@ -44,19 +78,22 @@ main().catch(console.error);
 ### Multi-Network Deployment
 
 ```typescript
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const network = process.env.MOVEHAT_NETWORK ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    if (harness.runtime.config.network === "mainnet") {
+      console.log("WARNING: Deploying to MAINNET");
+      // Add confirmation logic
+    }
 
-  if (mh.config.network === "mainnet") {
-    console.log("WARNING: Deploying to MAINNET");
-    // Add confirmation logic
+    const deployment = await harness.deployCodeObject({ moduleName: "counter" });
+    console.log(`Deployed on ${harness.runtime.network.name}:`, deployment.address);
+  } finally {
+    await harness.cleanup();
   }
-
-  // Deploy module — automatically tracked per network
-  const deployment = await mh.deployContract("counter");
-  console.log(`Deployed on ${mh.config.network}:`, deployment.address);
 }
 
 main().catch(console.error);
@@ -76,30 +113,36 @@ movehat run scripts/deploy-counter.ts --network local
 movehat run scripts/deploy-counter.ts --network testnet --redeploy
 ```
 
-## Available Runtime Properties
+## Available Harness Properties
 
 ```typescript
-const mh = await getMovehat();
+const harness = await Harness.createLive("testnet");
 
-// Core
-mh.config         // Resolved configuration
-mh.network        // Network info (name, chainId, rpc)
-mh.aptos          // Movement TypeScript SDK client
-mh.account        // Primary account
-mh.accounts       // All configured accounts
+// Mode + cleanup state
+harness.mode               // 'local' | 'fork' | 'live'
+harness.poisoned           // true once cleanup() has been called
 
-// Contract helpers
-mh.getContract    // Get contract helper
+// Harness methods (M2 public API)
+harness.deployCodeObject   // movement move deploy-object
+harness.upgradeCodeObject  // movement move upgrade-object
+harness.runViewFunction    // aptos.view (read-only, works in all modes)
+harness.runMoveScript      // movement move run-script
+harness.cleanup            // release resources + poison harness
 
-// Deployment functions
-mh.deployContract       // Deploy and track module
-mh.getDeployment        // Get deployment info
-mh.getDeployments       // Get all deployments
-mh.getDeploymentAddress // Get deployed address
-
-// Network management
-mh.switchNetwork  // Switch to different network
+// Underlying runtime (Movement SDK + account/contract/deployment helpers)
+harness.runtime.config              // Resolved configuration
+harness.runtime.network             // Network info (name, chainId, rpc)
+harness.runtime.aptos               // Movement TypeScript SDK client
+harness.runtime.account             // Primary account
+harness.runtime.accounts            // All configured accounts
+harness.runtime.getContract         // Get a MoveContract helper
+harness.runtime.getDeployment       // Get deployment info
+harness.runtime.getDeployments      // Get all deployments
+harness.runtime.getDeploymentAddress // Get deployed address
+harness.runtime.switchNetwork       // Switch to different network (returns a new runtime)
 ```
+
+> **`harness.runtime.deployContract` (legacy `move publish` path)** is still available for users who prefer it. New code should use `harness.deployCodeObject` (code-object path).
 
 ## Using Multiple Accounts
 
@@ -107,13 +150,20 @@ mh.switchNetwork  // Switch to different network
 // movehat.config.ts
 export default {
   accounts: [
-    process.env.PRIVATE_KEY,     // Primary (mh.account)
-    process.env.SECONDARY_KEY,   // mh.accounts[1]
+    process.env.PRIVATE_KEY,     // Primary (harness.runtime.account)
+    process.env.SECONDARY_KEY,   // harness.runtime.accounts[1]
   ].filter(Boolean),
 };
 
 // In your script
-const mh = await getMovehat();
-const primaryAccount = mh.account;
-const secondaryAccount = mh.getAccountByIndex(1);
+import { Harness } from "movehat";
+
+const harness = await Harness.createLive("testnet");
+try {
+  const primaryAccount = harness.runtime.account;
+  const secondaryAccount = harness.runtime.getAccountByIndex(1);
+  // ...
+} finally {
+  await harness.cleanup();
+}
 ```

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -43,67 +43,79 @@ movehat test:move
 
 ## TypeScript Integration Tests (Local Blockchain)
 
-Write tests in TypeScript that run on a **real local Movement blockchain** (just like Hardhat!):
+Write tests in TypeScript that run on a **real local Movement blockchain** using the Hardhat-style `Harness` API:
 
 ```typescript
 import { describe, it, before, after } from "mocha";
 import { expect } from "chai";
-import { setupTestFixture, teardownTestFixture, type TestFixture } from "movehat/helpers";
+import { Harness, AccountManager } from "movehat";
+import type { MoveContract } from "movehat/helpers";
+import type { Account } from "@aptos-labs/ts-sdk";
 
 describe("Counter Contract", () => {
-  let fixture: TestFixture<'counter'>;
+  let harness: Harness;
+  let counter: MoveContract;
+  let deployer: Account, alice: Account;
 
   before(async function () {
     this.timeout(60000);
-    fixture = await setupTestFixture(['counter'] as const, ['alice', 'bob']);
+    harness = await Harness.createLocal({
+      accountLabels: ["deployer", "alice", "bob"],
+      autoDeploy: ["counter"],
+    });
+
+    const labeled = AccountManager.getLabeledAccounts();
+    deployer = labeled.deployer!;
+    alice = labeled.alice!;
+
+    const addr = harness.runtime.getDeploymentAddress("counter")!;
+    counter = harness.runtime.getContract(addr, "counter");
 
     console.log(`\nTesting on local blockchain`);
-    console.log(`   Deployer: ${fixture.accounts.deployer.accountAddress.toString()}`);
-    console.log(`   Alice: ${fixture.accounts.alice.accountAddress.toString()}`);
+    console.log(`   Deployer: ${deployer.accountAddress.toString()}`);
+    console.log(`   Alice: ${alice.accountAddress.toString()}`);
   });
 
-  it("should initialize with value 0", async () => {
-    const counter = fixture.contracts.counter;
-    const deployer = fixture.accounts.deployer;
+  it("should initialize with value 0 (via harness.runViewFunction)", async () => {
+    // runViewFunction returns the raw unknown[] tuple from aptos.view —
+    // destructure for singletons.
+    const [value] = await harness.runViewFunction({
+      function: `${counter.moduleAddress}::counter::get`,
+      functionArguments: [deployer.accountAddress.toString()],
+    });
 
-    const value = await counter.view<string>("get", [
-      deployer.accountAddress.toString()
-    ]);
-
-    expect(parseInt(value)).to.equal(0);
+    expect(parseInt(value as string)).to.equal(0);
   });
 
   it("should increment counter", async () => {
-    const counter = fixture.contracts.counter;
-    const deployer = fixture.accounts.deployer;
-
     const tx = await counter.call(deployer, "increment", []);
     console.log(`   Transaction: ${tx.hash}`);
 
     const value = await counter.view<string>("get", [
-      deployer.accountAddress.toString()
+      deployer.accountAddress.toString(),
     ]);
 
     expect(parseInt(value)).to.equal(1);
   });
 
   it("alice can also increment counter", async () => {
-    const counter = fixture.contracts.counter;
-    const alice = fixture.accounts.alice;
-
     await counter.call(alice, "increment", []);
 
     const aliceValue = await counter.view<string>("get", [
-      alice.accountAddress.toString()
+      alice.accountAddress.toString(),
     ]);
     expect(parseInt(aliceValue)).to.equal(1);
   });
 
   after(async () => {
-    await teardownTestFixture();
+    // cleanup() is idempotent and poisons the harness so any further
+    // method call (other than cleanup) throws HarnessDisposedError.
+    await harness.cleanup();
   });
 });
 ```
+
+> **Looking for the older API?** `setupTestFixture` from `movehat/helpers` is still supported — see [`movehat/helpers`](../api/harness) for details on coexistence.
 
 **When to use TypeScript tests:**
 - Testing real transaction flows with actual state changes

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -11,10 +11,12 @@ Write your tests and deployment scripts in TypeScript while building Move smart 
 
 ## Features
 
+- **Hardhat-style Harness API** - `Harness.createLocal()` / `createFork()` / `createLive()` with explicit lifecycle and use-after-cleanup safety
 - **Local Node Testing** - Run a real Movement blockchain locally for testing (just like Hardhat!)
 - **Dual Testing Modes** - Choose between `local-node` (full blockchain) or `fork` (read-only snapshot)
 - **Auto-Deploy in Tests** - Contracts deploy automatically when tests run — zero manual setup
-- **setupTestFixture Helper** - High-level API for test setup with type-safe contracts
+- **Code-Object Deployment** - `harness.deployCodeObject()` wraps `movement move deploy-object` with security-hardened profile management
+- **setupTestFixture Helper** - High-level API for test setup with type-safe contracts (alternative to Harness)
 - **Zero Setup Testing** - Auto-generated test accounts funded from local faucet
 - **Auto-detection of Named Addresses** - Automatically detects and configures addresses from your Move code
 - **Native Fork System** - Create local snapshots of Movement L1 with actual network state

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -17,6 +17,8 @@
     "cli/test",
     "cli/run",
     "cli/fork",
+    "---API Reference---",
+    "api/harness",
     "---Community---",
     "contributing/index"
   ]

--- a/packages/movehat/src/__tests__/harness/codeObject.deploy.test.ts
+++ b/packages/movehat/src/__tests__/harness/codeObject.deploy.test.ts
@@ -303,6 +303,59 @@ version = "0.0.1"
     }
   });
 
+  it("addressName override is used in --address-name CLI flag; moduleName remains the save-record key", async () => {
+    // Example use case: Move source `module hello_blockchain::counter`
+    // with Move.toml `[addresses] hello_blockchain = "_"`. The CLI's
+    // --address-name must match the Move.toml entry (`hello_blockchain`)
+    // while the on-chain module identifier + the save key + the
+    // getContract argument stay `counter`.
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: { exitCode: 0, stdout: successStdout(), stderr: "" },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      const result = await harness.deployCodeObject({
+        moduleName: "counter",
+        addressName: "hello_blockchain",
+        adapter,
+      });
+
+      // Save record + return value use moduleName (not addressName).
+      expect(result.moduleName).toBe("counter");
+      const deploymentPath = join(tmpCwd, "deployments", "testnet", "counter.json");
+      expect(existsSync(deploymentPath)).toBe(true);
+      const saved = JSON.parse(readFileSync(deploymentPath, "utf-8"));
+      expect(saved.moduleName).toBe("counter");
+
+      // CLI flag was the overridden addressName.
+      const deployCall = calls.find((c) => c.args[1] === "deploy-object")!;
+      const addressNameIdx = deployCall.args.indexOf("--address-name");
+      expect(addressNameIdx).toBeGreaterThanOrEqual(0);
+      expect(deployCall.args[addressNameIdx + 1]).toBe("hello_blockchain");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("addressName defaults to moduleName when omitted (back-compat for template case)", async () => {
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: { exitCode: 0, stdout: successStdout(), stderr: "" },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      await harness.deployCodeObject({ moduleName: "counter", adapter });
+      const deployCall = calls.find((c) => c.args[1] === "deploy-object")!;
+      const addressNameIdx = deployCall.args.indexOf("--address-name");
+      expect(deployCall.args[addressNameIdx + 1]).toBe("counter");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
   it("fork-mode harness throws synchronously before any CLI call (covered separately for createLocal/createFork in M4 integration suite)", async () => {
     // This case can't be tested with a real createFork (it spawns a fork
     // server). Instead, prove that the disposed-instance path also fires

--- a/packages/movehat/src/harness/codeObject.ts
+++ b/packages/movehat/src/harness/codeObject.ts
@@ -55,6 +55,7 @@ export async function deployCodeObject(
   return executeMovementMoveObject({
     runtime,
     moduleName: options.moduleName,
+    addressName: options.addressName,
     packageDir: options.packageDir,
     namedAddresses: options.namedAddresses,
     includedArtifacts: options.includedArtifacts,
@@ -87,6 +88,7 @@ export async function upgradeCodeObject(
   return executeMovementMoveObject({
     runtime,
     moduleName: options.moduleName,
+    addressName: options.addressName,
     packageDir: options.packageDir,
     namedAddresses: options.namedAddresses,
     includedArtifacts: options.includedArtifacts,
@@ -101,6 +103,11 @@ export async function upgradeCodeObject(
 interface ExecuteOptions {
   runtime: MovehatRuntime;
   moduleName: string;
+  /**
+   * Move.toml named address for the `--address-name` CLI flag.
+   * Defaults to `moduleName` when undefined.
+   */
+  addressName?: string | undefined;
   packageDir?: string | undefined;
   namedAddresses?: Record<string, string> | undefined;
   includedArtifacts?: "none" | "sparse" | "all" | undefined;
@@ -246,7 +253,7 @@ async function executeMovementMoveObject(
             "move",
             subcommand,
             "--address-name",
-            moduleName,
+            opts.addressName ?? moduleName,
             "--package-dir",
             safeDir,
             "--url",

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -2,7 +2,11 @@
 export * from "./helpers/index.js";
 export type { MovehatConfig } from "./types/config.js";
 
-// Export Movehat Runtime Environment
+// Export Movehat Runtime Environment.
+// `getMovehat` is @deprecated as of M2.4 — see runtime.ts JSDoc. Use
+// the Harness.create* factories below for new code.
+// `initRuntime` stays as a public utility but external callers should
+// prefer Harness; it's the construction primitive Harness.createLive uses.
 export { initRuntime, getMovehat } from "./runtime.js";
 export type { MovehatRuntime, NetworkInfo } from "./types/runtime.js";
 

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -26,8 +26,18 @@ export interface InitRuntimeOptions {
 }
 
 /**
- * Initialize the Movehat Runtime Environment
- * This function loads the configuration and creates the runtime context
+ * Initialize the Movehat Runtime Environment.
+ *
+ * Lower-level construction utility — loads `movehat.config.ts`, resolves
+ * the active network, and builds a `MovehatRuntime` bound to it. Used
+ * internally by {@link Harness.createLive} (see `harness/Harness.ts`).
+ *
+ * **External callers should prefer the `Harness.create*` factories**
+ * (`Harness.createLocal` / `createFork` / `createLive`) for the Hardhat-
+ * style lifecycle + use-after-cleanup safety. `initRuntime` remains
+ * exported as a public utility for advanced use cases that need to
+ * skip the Harness abstraction (e.g. embedding movehat inside another
+ * framework).
  */
 export async function initRuntime(
   options: InitRuntimeOptions = {}
@@ -150,10 +160,30 @@ export async function initRuntime(
 /**
  * Get the Movehat Runtime Environment.
  *
- * As of M1.5 this is a thin alias of {@link initRuntime} — each call
- * constructs a fresh runtime. The previous module-cached behavior was
- * removed because it leaked state between parallel tests and hid the
- * runtime dependency from script signatures.
+ * @deprecated Since `0.0.0-dev`. Prefer the Hardhat-style `Harness`
+ * factories (`Harness.createLocal` / `createFork` / `createLive`)
+ * which carry explicit lifecycle (`harness.cleanup()`) and
+ * use-after-cleanup safety. `getMovehat()` will be removed in
+ * `0.1.0` (M6 / issue #73).
+ *
+ * Migration:
+ * ```diff
+ * - import { getMovehat } from "movehat";
+ * - const mh = await getMovehat();
+ * - const deployment = await mh.deployContract("counter");
+ * + import { Harness } from "movehat";
+ * + const harness = await Harness.createLive("testnet");
+ * + try {
+ * +   const deployment = await harness.deployCodeObject({ moduleName: "counter" });
+ * +   // ...
+ * + } finally {
+ * +   await harness.cleanup();
+ * + }
+ * ```
+ *
+ * As of M1.5 each call constructs a fresh runtime — the previous
+ * module-cached behavior was removed because it leaked state between
+ * parallel tests and hid the runtime dependency from script signatures.
  */
 export async function getMovehat(): Promise<MovehatRuntime> {
   return initRuntime();

--- a/packages/movehat/src/templates/movehat.config.ts
+++ b/packages/movehat/src/templates/movehat.config.ts
@@ -1,3 +1,14 @@
+// Movehat configuration.
+//
+// Movehat's primary public API is the Hardhat-style `Harness` class
+// (see scripts/deploy-counter.ts and tests/Counter.test.ts in this
+// template). The `Harness.create*` factories read this file via
+// `loadUserConfig` to resolve the active network + accounts.
+//
+// The older `getMovehat()` / `setupTestFixture()` helpers also read
+// the same shape and are still supported (marked `@deprecated` from
+// M2; removal is M6 / 0.1.0).
+
 import dotenv from "dotenv";
 dotenv.config();
 

--- a/packages/movehat/src/templates/scripts/deploy-counter.ts
+++ b/packages/movehat/src/templates/scripts/deploy-counter.ts
@@ -1,48 +1,56 @@
-import { getMovehat, ModuleAlreadyDeployedError } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
   console.log("🚀 Deploying Counter contract...\n");
 
-  // Get the Movehat Runtime Environment
-  const mh = await getMovehat();
+  // Hardhat-style Harness — primary public API since M2.
+  // createLive binds to a real running network (testnet / mainnet / a
+  // custom one defined in movehat.config.ts). No local process spawned.
+  const network = process.env.MOVEHAT_NETWORK ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    console.log(`✅ Runtime initialized on ${harness.runtime.network.name}`);
+    console.log(`   Account: ${harness.runtime.account.accountAddress.toString()}`);
+    console.log(`   RPC: ${harness.runtime.network.rpc}\n`);
 
-  console.log(`✅ Runtime initialized`);
-  console.log(`   Account: ${mh.account.accountAddress.toString()}`);
-  console.log(`   Network: ${mh.network.name}`);
-  console.log(`   RPC: ${mh.network.rpc}\n`);
+    // Deploy as a code object via `movement move deploy-object`. If the
+    // Move.toml's named address differs from the module identifier
+    // (e.g. `module my_pkg::counter` with `[addresses] my_pkg = "_"`),
+    // pass `addressName: "my_pkg"` in addition to `moduleName: "counter"`.
+    //
+    // To redeploy an existing record, set MH_CLI_REDEPLOY=true.
+    const deployment = await harness.deployCodeObject({
+      moduleName: "counter",
+    });
 
-  // Deploy (publish) the module
-  // Automatically checks if already deployed and suggests --redeploy if needed
-  const deployment = await mh.deployContract("counter");
+    console.log(`\n✅ Module deployed at: ${deployment.address}::counter`);
+    if (deployment.txHash) {
+      console.log(`   Transaction: ${deployment.txHash}`);
+    }
 
-  console.log(`\n✅ Module deployed at: ${deployment.address}::counter`);
-  if (deployment.txHash) {
-    console.log(`   Transaction: ${deployment.txHash}`);
+    // Interact with the freshly deployed module via the runtime helper.
+    const counter = harness.runtime.getContract(deployment.address, "counter");
+
+    console.log("\n📝 Incrementing counter...");
+    const txResult = await counter.call(harness.runtime.account, "increment", []);
+    console.log(`✅ Transaction hash: ${txResult.hash}`);
+
+    // Use harness.runViewFunction directly when you have a fully
+    // qualified function id; counter.view<T>(...) is the shorter form.
+    const [value] = await harness.runViewFunction({
+      function: `${deployment.address}::counter::get`,
+      functionArguments: [harness.runtime.account.accountAddress.toString()],
+    });
+    console.log(`\n📊 Counter value: ${value}`);
+  } finally {
+    // Always release the Harness — cleanup() is idempotent and safe to
+    // call on a `createLive` instance even though no local process was
+    // spawned (it just flips the use-after-cleanup poison flag).
+    await harness.cleanup();
   }
-
-  // Get contract instance
-  const counter = mh.getContract(deployment.address, "counter");
-
-  // Initialize the counter
-  console.log("\n📝 Initializing counter...");
-  const txResult = await counter.call(mh.account, "init", []);
-
-  console.log(`✅ Transaction hash: ${txResult.hash}`);
-  console.log(`✅ Counter initialized successfully!`);
-
-  // Verify
-  const value = await counter.view<number>("get", [
-    mh.account.accountAddress.toString()
-  ]);
-
-  console.log(`\n📊 Initial counter value: ${value}`);
 }
 
 main().catch((error) => {
-  // ModuleAlreadyDeployedError is already logged with full details by deployContract()
-  // For other errors, show the message
-  if (!(error instanceof ModuleAlreadyDeployedError)) {
-    console.error("❌ Deployment failed:", error?.message || error);
-  }
+  console.error("❌ Deployment failed:", error?.message || error);
   process.exit(1);
 });

--- a/packages/movehat/src/templates/tests/Counter.test.ts
+++ b/packages/movehat/src/templates/tests/Counter.test.ts
@@ -1,95 +1,87 @@
 // @ts-nocheck - This is a template file, dependencies are installed in user projects
 import { describe, it, before, after } from "mocha";
 import { expect } from "chai";
-import { setupTestFixture, type TestFixture } from "movehat/helpers";
+import { Harness, AccountManager } from "movehat";
 
 describe("Counter Contract", () => {
-  let fixture: TestFixture<'counter'>;
+  let harness;
+  let counter;
+  let deployer, alice, bob;
 
   before(async function () {
     this.timeout(60000); // Allow time for local node startup + deployment
 
-    // Setup local testing environment with auto-deployment
-    // This will:
-    // 1. Start a local Movement blockchain node
-    // 2. Generate and fund test accounts from local faucet
-    // 3. Auto-deploy the counter module
-    // 4. Return everything ready to use
+    // Hardhat-style Harness — primary public API since M2.
+    // createLocal spins up a Movement local node, funds the labeled
+    // accounts from the local faucet, and (via autoDeploy) builds +
+    // publishes the named modules so they're ready to use.
     //
-    // By default uses 'local-node' mode (full blockchain)
-    // For faster tests on existing state, pass { mode: 'fork' }
-    //
-    // Note: Use 'as const' for type inference
-    fixture = await setupTestFixture(['counter'] as const, ['alice', 'bob']);
+    // The setupTestFixture helper still works if you prefer the older
+    // pattern; see `import { setupTestFixture } from "movehat/helpers"`.
+    harness = await Harness.createLocal({
+      accountLabels: ["deployer", "alice", "bob"],
+      autoDeploy: ["counter"],
+    });
+
+    const labeled = AccountManager.getLabeledAccounts();
+    deployer = labeled.deployer;
+    alice = labeled.alice;
+    bob = labeled.bob;
+
+    const counterAddr = harness.runtime.getDeploymentAddress("counter");
+    counter = harness.runtime.getContract(counterAddr, "counter");
 
     console.log(`\n✅ Testing on local blockchain`);
-    console.log(`   Deployer: ${fixture.accounts.deployer.accountAddress.toString()}`);
-    console.log(`   Alice: ${fixture.accounts.alice.accountAddress.toString()}`);
-    console.log(`   Bob: ${fixture.accounts.bob.accountAddress.toString()}\n`);
+    console.log(`   Deployer: ${deployer.accountAddress.toString()}`);
+    console.log(`   Alice: ${alice.accountAddress.toString()}`);
+    console.log(`   Bob: ${bob.accountAddress.toString()}\n`);
   });
 
   describe("Counter functionality", () => {
     it("should initialize counter for deployer", async () => {
-      const counter = fixture.contracts.counter; // Type-safe, no `!` needed
-      const deployer = fixture.accounts.deployer;
-
       // Initialize counter for deployer (required before get/increment)
       const tx = await counter.call(deployer, "init", []);
       console.log(`   Init transaction: ${tx.hash}`);
 
-      // Read counter value (returns string from view function)
-      const value = await counter.view<string>("get", [
-        deployer.accountAddress.toString()
-      ]);
+      // Read counter value via harness.runViewFunction (new in M2)
+      const [value] = await harness.runViewFunction({
+        function: `${counter.moduleAddress}::counter::get`,
+        functionArguments: [deployer.accountAddress.toString()],
+      });
 
       console.log(`   Counter value: ${value}`);
-
-      // Assert the counter is 0 (note: values from view are strings)
       expect(parseInt(value)).to.equal(0);
     });
 
     it("should increment counter", async () => {
-      const counter = fixture.contracts.counter;
-      const deployer = fixture.accounts.deployer;
-
-      // Increment the counter
       const tx = await counter.call(deployer, "increment", []);
       console.log(`   Transaction: ${tx.hash}`);
 
-      // Read new value
+      // counter.view is the shorter form when you already have the contract.
       const value = await counter.view<string>("get", [
-        deployer.accountAddress.toString()
+        deployer.accountAddress.toString(),
       ]);
 
       console.log(`   New counter value: ${value}`);
-
-      // Should be 1 now
       expect(parseInt(value)).to.equal(1);
     });
 
     it("alice can initialize and increment her counter", async () => {
-      const counter = fixture.contracts.counter;
-      const alice = fixture.accounts.alice;
-
-      // Alice must initialize her counter first
       const initTx = await counter.call(alice, "init", []);
       console.log(`   Alice init transaction: ${initTx.hash}`);
 
-      // Alice increments her own counter
       const tx = await counter.call(alice, "increment", []);
       console.log(`   Alice's increment transaction: ${tx.hash}`);
 
-      // Read counter value for Alice (each user has their own counter)
       const aliceValue = await counter.view<string>("get", [
-        alice.accountAddress.toString()
+        alice.accountAddress.toString(),
       ]);
 
       console.log(`   Alice's counter value: ${aliceValue}`);
       expect(parseInt(aliceValue)).to.equal(1);
 
-      // Deployer's counter should still be 1 (unchanged)
       const deployerValue = await counter.view<string>("get", [
-        fixture.accounts.deployer.accountAddress.toString()
+        deployer.accountAddress.toString(),
       ]);
 
       console.log(`   Deployer's counter value: ${deployerValue}`);
@@ -97,20 +89,14 @@ describe("Counter Contract", () => {
     });
 
     it("bob can initialize and increment his counter", async () => {
-      const counter = fixture.contracts.counter;
-      const bob = fixture.accounts.bob;
-
-      // Bob must initialize his counter first
       const initTx = await counter.call(bob, "init", []);
       console.log(`   Bob init transaction: ${initTx.hash}`);
 
-      // Bob increments his own counter
       const tx = await counter.call(bob, "increment", []);
       console.log(`   Bob's increment transaction: ${tx.hash}`);
 
-      // Read counter value for Bob (each user has their own counter)
       const bobValue = await counter.view<string>("get", [
-        bob.accountAddress.toString()
+        bob.accountAddress.toString(),
       ]);
 
       console.log(`   Bob's counter value: ${bobValue}`);
@@ -119,7 +105,9 @@ describe("Counter Contract", () => {
   });
 
   after(async () => {
-    // Cleanup: Stop local node
-    await fixture.teardown();
+    // harness.cleanup() stops the local node and poisons the harness —
+    // any further method call (other than cleanup itself) throws
+    // HarnessDisposedError synchronously.
+    await harness.cleanup();
   });
 });

--- a/packages/movehat/src/types/harness.ts
+++ b/packages/movehat/src/types/harness.ts
@@ -12,12 +12,36 @@ import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
  */
 export interface DeployCodeObjectOptions {
   /**
-   * Logical module name. Used as the `--address-name` for `deploy-object`
-   * so the derived object address is bound to this name in the package's
-   * named-addresses at compile time. Also the key under which the
-   * deployment is persisted (`deployments/{network}/{moduleName}.json`).
+   * Logical module identifier (the `name` part of `module addr::name`).
+   * Used as the persistence key (`deployments/{network}/{moduleName}.json`)
+   * and as the `name` arg you'd pass to `runtime.getContract(addr, name)`
+   * after deployment.
+   *
+   * If `addressName` is omitted, `moduleName` is also used as the CLI's
+   * `--address-name` flag (correct when the Move.toml's named address
+   * matches the module identifier). For packages where they differ —
+   * e.g. `module hello_blockchain::counter` (named address
+   * `hello_blockchain`, module `counter`) — set `addressName` explicitly.
    */
   moduleName: string;
+
+  /**
+   * Move.toml named address that the derived object address binds to
+   * at compile time (the `--address-name` flag of `move deploy-object`).
+   *
+   * Defaults to `moduleName`. Set this when the Move.toml's named
+   * address differs from the on-chain module identifier:
+   *
+   * ```ts
+   * // Move source: `module hello_blockchain::counter`
+   * // Move.toml:   `[addresses] hello_blockchain = "_"`
+   * await harness.deployCodeObject({
+   *   moduleName: "counter",            // for getContract + save key
+   *   addressName: "hello_blockchain",  // for --address-name
+   * });
+   * ```
+   */
+  addressName?: string;
 
   /**
    * Extra named-address overrides merged on top of the addresses


### PR DESCRIPTION
## Summary

Final sub-PR of M2 (#69). Migrates the install-experience surface to the Hardhat-style `Harness` API, adds the API-reference docs page, fixes a latent M2.2 bug surfaced during the migration, and ticks every remaining M2 DoD bullet in ROADMAP.

## Commits

1. **`docs(runtime): @deprecated JSDoc on getMovehat; clarify initRuntime`** — `getMovehat` gets a full migration snippet inline. `initRuntime` stays public (no `@deprecated`) because `Harness.createLive` calls it internally — its JSDoc now clarifies that external callers should prefer Harness factories.

2. **`fix(harness/codeObject): add optional addressName for Move.toml named-address mismatch`** — M2.2 follow-up. Adds optional `addressName?: string` to `DeployCodeObjectOptions`. Defaults to `moduleName`. Required because `examples/counter-example/move/Move.toml` has `[addresses] hello_blockchain = "_"` while the module is `module hello_blockchain::counter` — calling `deployCodeObject({ moduleName: "counter" })` would have failed compile. 2 new test cases (222/222).

3. **`feat(templates): migrate deploy-counter.ts + tests/Counter.test.ts to Harness`** — full rewrite of both template files using `Harness.createLive` + `deployCodeObject` + `runViewFunction` (deploy script) and `Harness.createLocal` + `autoDeploy` (test). Plus a JSDoc header on `templates/movehat.config.ts` pointing at Harness as the recommended entry. Tier 2 `test:smoke` ✅.

4. **`feat(example): migrate Counter.test.ts + scripts/deploy-counter.ts to Harness`** — `examples/counter-example/tests/Counter.test.ts` switches to `Harness.createLocal` (autoDeploy path). One test case demonstrates `harness.runViewFunction`; others keep `counter.view` for shape continuity. `examples/counter-example/scripts/deploy-counter.ts` is the canonical `addressName: \"hello_blockchain\"` example. `greeting.test.ts` + `message.test.ts` + `deploy-greeting.ts` + `demo-fork.ts` left on the legacy API as the coexistence demo. **Tier 2 `pnpm test:example` 9/9 ✅** in ~1 min — no teardown lag (prior session hangs were `| tail -N` output buffering, not real mocha issues).

5. **`docs: migrate 8 MDX pages + add api/harness.mdx; ROADMAP closeout`** — 8 MDX files migrated (`index`, `getting-started/{quickstart,configuration}`, `guides/{testing,scripts,deployment}`, `cli/{init,run}`); ~200-line `api/harness.mdx` with factory matrix + per-method options reference + fork guard + cleanup contract + AccountManager quirk; new `api/meta.json` + top-level `meta.json` adds \"---API Reference---\" section. ROADMAP all M2 DoD bullets flipped to `[x]`, sub-PR table closed out with PR numbers + commit hashes.

## DoD ticked in ROADMAP (full M2 closeout)

API surface — all 9 bullets ✅:
- `import { Harness } from 'movehat'` works from the built package
- `Harness.createLocal()` / `createFork()` / `createLive()` all return usable instances
- `harness.deployCodeObject` / `upgradeCodeObject` / `runViewFunction` / `runMoveScript` all functional
- `harness.cleanup()` releases resources + sets `poisoned = true`

Use-after-cleanup safety — both bullets ✅:
- Any method on a disposed harness throws `HarnessDisposedError` synchronously
- `HarnessDisposedError` exported

Migration — all 6 bullets ✅:
- `examples/counter-example/` uses `Harness.createLocal()`
- `templates/scripts/deploy-counter.ts` uses the new API
- All MDX code snippets updated
- `api/harness.mdx` covers 7 methods + cleanup
- `getMovehat()` exported with `@deprecated` JSDoc
- `pnpm test` green

## Test plan

- [x] Tier 1: `pnpm --filter movehat exec tsc --noEmit` — clean
- [x] Tier 1: `pnpm --filter movehat test` — **222/222 passing** (220 prior + 2 new from C2's addressName tests)
- [x] Tier 1: `pnpm check:example` — green
- [x] Tier 1: `npx next build` MDX compilation — ✓ Compiled successfully in 2.5s. (Note: full Next.js build fails on a **pre-existing missing `lucide-react`** in `app/layout.config.tsx`, unrelated to this PR's MDX changes.)
- [x] Tier 2: `pnpm test:smoke` — pass (validates the migrated templates ship in the tarball)
- [x] Tier 2: `pnpm test:example` — **9/9 passing in ~1 min** (3 Counter on Harness + 3 greeting on setupTestFixture + 3 message on setupTestFixture)
- [x] Tier 3: `pnpm test:e2e` — **32/32 passing in 32s** (init → install → compile → Move tests → TS tests → fork create/list)

## Open follow-ups (not blocking)

- `lucide-react` missing in `packages/docs/app/layout.config.tsx` — pre-existing; not introduced here. Should be tracked as its own docs issue.
- `Harness.createFork`'s `apiKey` parameter is still a silent no-op (TODO from M2.1). Wiring depends on `MovementApiClient` header support — file a follow-up issue if/when a fork harness needs authenticated upstream reads.

Tracks #69. Closes #119.

**M2 status: ready for the `develop → main` batch PR after this merges.**