### PR TITLE
M2 batch: Hardhat-style Harness API (KPI 1) — 4 sub-PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ pnpm-debug.log*
 !MOVEMENT_CLI_COMPAT.md
 !NOTICE.md
 !.github/**/*.md
+*.pdf

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,7 +96,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 | ✅ | M2.1 | [#116](https://github.com/gilbertsahumada/movehat/issues/116) (shipped in PR #120 @ `c44f9cb`) | Harness skeleton + 3 factories + Proxy poisoning + cleanup + HarnessDisposedError (4 methods stubbed) | foundations |
 | ✅ | M2.2 | [#117](https://github.com/gilbertsahumada/movehat/issues/117) (shipped in PR #121 @ `c336077`) | `deployCodeObject` + `upgradeCodeObject` via `movement move deploy-object` / `upgrade-object` + extract `core/movementProfile.ts` | (partial of #69) |
 | ✅ | M2.3 | [#118](https://github.com/gilbertsahumada/movehat/issues/118) (shipped in PR #122 @ `a334991`) | `runViewFunction` + `runMoveScript` + extract `utils/parseCliOutput.ts` | (partial of #69) |
-| ✅ | M2.4 | [#119](https://github.com/gilbertsahumada/movehat/issues/119) | Migrate `examples/counter-example/` + templates + 8 docs MDX + new `api/harness.mdx`; `@deprecated` JSDoc on `getMovehat`; fix M2.2 `addressName` bug | closes #69 |
+| ✅ | M2.4 | [#119](https://github.com/gilbertsahumada/movehat/issues/119) (shipped in PR #123 @ `602cfca`) | Migrate `examples/counter-example/` + templates + 8 docs MDX + new `api/harness.mdx`; `@deprecated` JSDoc on `getMovehat`; fix M2.2 `addressName` bug | closes #69 |
 
 **Definition of Done — API surface**:
 - [x] `import { Harness } from 'movehat'` works from the built package (M2.4 — verified by Tier 2 smoke + Tier 3 e2e on the dev→main batch)
@@ -121,7 +121,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `getMovehat()` still exported with `@deprecated` JSDoc tag (M2.4 — full migration snippet inline; `initRuntime` stays public as a low-level utility used by `Harness.createLive`)
 - [x] `pnpm test` green (M2.4 — 222/222 unit tests; Tier 2 `test:example` 9/9 passing in ~1 min)
 
-**M2 status: ✅ ready for `develop → main` batch — all 4 sub-PRs (M2.1 PR #120, M2.2 PR #121, M2.3 PR #122, M2.4 PR #N) merged to develop. Tier 3 `pnpm test:e2e` to be run on the batch PR per CLAUDE.md §6.3.**
+**M2 status: ✅ ready for `develop → main` batch (PR #124) — all 4 sub-PRs (M2.1 PR #120, M2.2 PR #121, M2.3 PR #122, M2.4 PR #123) merged to develop. Tier 3 `pnpm test:e2e` 32/32 captured on M2.4 (PR #123) per CLAUDE.md §6.3.**
 
 ### M3 — 80% unit coverage + Movement CLI cache (~5 days, issue #70) — (KPI 1)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,20 +89,29 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 
 **Goal**: Provide a Hardhat-style testing harness with explicit lifecycle and use-after-cleanup safety.
 
+**Sub-issues** (each is a separate PR. Execution order: M2.1 → M2.2 → M2.3 → M2.4 in serial — M2.2/M2.3 replace M2.1's method stubs and M2.4 migrates consumers, so each depends on the previous):
+
+| Status | Sub-PR | Issue | Focus | Closes |
+|---|---|---|---|---|
+|   | M2.1 | [#116](https://github.com/gilbertsahumada/movehat/issues/116) | Harness skeleton + 3 factories + Proxy poisoning + cleanup + HarnessDisposedError (4 methods stubbed) | foundations |
+|   | M2.2 | [#117](https://github.com/gilbertsahumada/movehat/issues/117) | `deployCodeObject` + `upgradeCodeObject` via `movement move deploy-object` / `upgrade-object` | (partial of #69) |
+|   | M2.3 | [#118](https://github.com/gilbertsahumada/movehat/issues/118) | `runViewFunction` + `runMoveScript` | (partial of #69) |
+|   | M2.4 | [#119](https://github.com/gilbertsahumada/movehat/issues/119) | Migrate `examples/counter-example/` + templates + 8 docs MDX; `@deprecated` JSDoc on `mh()` / `getMovehat` | closes #69 |
+
 **Definition of Done — API surface**:
 - [ ] `import { Harness } from 'movehat'` works from the built package
 - [ ] `Harness.createLocal()` returns a usable instance
 - [ ] `Harness.createFork(network: string, apiKey?: string)` returns a usable instance
-- [ ] `Harness.createLive(network: string, faucetUrl?: string)` returns a usable instance
+- [x] `Harness.createLive(network: string, faucetUrl?: string)` returns a usable instance (M2.1)
 - [ ] `harness.deployCodeObject(options)` deploys a real Move package
 - [ ] `harness.upgradeCodeObject(options)` upgrades an existing code object
 - [ ] `harness.runViewFunction(options)` executes a view function
 - [ ] `harness.runMoveScript(options)` compiles and executes a Move script
-- [ ] `harness.cleanup()` releases the local node, removes temp dirs, and sets `poisoned = true`
+- [x] `harness.cleanup()` releases the local node, removes temp dirs, and sets `poisoned = true` (M2.1 — idempotent; stops owned localNode / forkServer; tested)
 
 **Definition of Done — Use-after-cleanup safety**:
-- [ ] Calling **any** method on a disposed harness (other than `cleanup`) throws `HarnessDisposedError` synchronously
-- [ ] `HarnessDisposedError` exported from the package
+- [x] Calling **any** method on a disposed harness (other than `cleanup`) throws `HarnessDisposedError` synchronously (M2.1 — Proxy `get` trap fires on property access before the awaited body)
+- [x] `HarnessDisposedError` exported from the package (M2.1)
 
 **Definition of Done — Migration**:
 - [ ] `examples/counter-example/` uses `Harness.createLocal()`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -103,8 +103,8 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [ ] `Harness.createLocal()` returns a usable instance
 - [ ] `Harness.createFork(network: string, apiKey?: string)` returns a usable instance
 - [x] `Harness.createLive(network: string, faucetUrl?: string)` returns a usable instance (M2.1)
-- [ ] `harness.deployCodeObject(options)` deploys a real Move package
-- [ ] `harness.upgradeCodeObject(options)` upgrades an existing code object
+- [x] `harness.deployCodeObject(options)` deploys a real Move package (M2.2 — wraps `movement move deploy-object`; reuses Publisher hardening via the extracted `core/movementProfile.ts` helpers; integration coverage in M4)
+- [x] `harness.upgradeCodeObject(options)` upgrades an existing code object (M2.2 — wraps `movement move upgrade-object`; same shared helpers)
 - [ ] `harness.runViewFunction(options)` executes a view function
 - [ ] `harness.runMoveScript(options)` compiles and executes a Move script
 - [x] `harness.cleanup()` releases the local node, removes temp dirs, and sets `poisoned = true` (M2.1 — idempotent; stops owned localNode / forkServer; tested)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,15 +93,15 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 
 | Status | Sub-PR | Issue | Focus | Closes |
 |---|---|---|---|---|
-|   | M2.1 | [#116](https://github.com/gilbertsahumada/movehat/issues/116) | Harness skeleton + 3 factories + Proxy poisoning + cleanup + HarnessDisposedError (4 methods stubbed) | foundations |
-|   | M2.2 | [#117](https://github.com/gilbertsahumada/movehat/issues/117) | `deployCodeObject` + `upgradeCodeObject` via `movement move deploy-object` / `upgrade-object` | (partial of #69) |
-|   | M2.3 | [#118](https://github.com/gilbertsahumada/movehat/issues/118) | `runViewFunction` + `runMoveScript` | (partial of #69) |
-|   | M2.4 | [#119](https://github.com/gilbertsahumada/movehat/issues/119) | Migrate `examples/counter-example/` + templates + 8 docs MDX; `@deprecated` JSDoc on `mh()` / `getMovehat` | closes #69 |
+| ✅ | M2.1 | [#116](https://github.com/gilbertsahumada/movehat/issues/116) (shipped in PR #120 @ `c44f9cb`) | Harness skeleton + 3 factories + Proxy poisoning + cleanup + HarnessDisposedError (4 methods stubbed) | foundations |
+| ✅ | M2.2 | [#117](https://github.com/gilbertsahumada/movehat/issues/117) (shipped in PR #121 @ `c336077`) | `deployCodeObject` + `upgradeCodeObject` via `movement move deploy-object` / `upgrade-object` + extract `core/movementProfile.ts` | (partial of #69) |
+| ✅ | M2.3 | [#118](https://github.com/gilbertsahumada/movehat/issues/118) (shipped in PR #122 @ `a334991`) | `runViewFunction` + `runMoveScript` + extract `utils/parseCliOutput.ts` | (partial of #69) |
+| ✅ | M2.4 | [#119](https://github.com/gilbertsahumada/movehat/issues/119) | Migrate `examples/counter-example/` + templates + 8 docs MDX + new `api/harness.mdx`; `@deprecated` JSDoc on `getMovehat`; fix M2.2 `addressName` bug | closes #69 |
 
 **Definition of Done — API surface**:
-- [ ] `import { Harness } from 'movehat'` works from the built package
-- [ ] `Harness.createLocal()` returns a usable instance
-- [ ] `Harness.createFork(network: string, apiKey?: string)` returns a usable instance
+- [x] `import { Harness } from 'movehat'` works from the built package (M2.4 — verified by Tier 2 smoke + Tier 3 e2e on the dev→main batch)
+- [x] `Harness.createLocal()` returns a usable instance (M2.4 — exercised end-to-end by the migrated `examples/counter-example/tests/Counter.test.ts`)
+- [x] `Harness.createFork(network: string, apiKey?: string)` returns a usable instance (M2.1 factory + documented in `api/harness.mdx`; integration coverage in M4)
 - [x] `Harness.createLive(network: string, faucetUrl?: string)` returns a usable instance (M2.1)
 - [x] `harness.deployCodeObject(options)` deploys a real Move package (M2.2 — wraps `movement move deploy-object`; reuses Publisher hardening via the extracted `core/movementProfile.ts` helpers; integration coverage in M4)
 - [x] `harness.upgradeCodeObject(options)` upgrades an existing code object (M2.2 — wraps `movement move upgrade-object`; same shared helpers)
@@ -114,12 +114,14 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `HarnessDisposedError` exported from the package (M2.1)
 
 **Definition of Done — Migration**:
-- [ ] `examples/counter-example/` uses `Harness.createLocal()`
-- [ ] `packages/movehat/src/templates/scripts/deploy-counter.ts` uses the new API
-- [ ] All MDX code snippets in `packages/docs/content/docs/` updated
-- [ ] `packages/docs/content/docs/api/harness.mdx` covers the 7 methods + cleanup
-- [ ] `mh()` still exported with `@deprecated` JSDoc tag
-- [ ] `pnpm test` green
+- [x] `examples/counter-example/` uses `Harness.createLocal()` (M2.4 — `tests/Counter.test.ts` + `scripts/deploy-counter.ts`; `greeting.test.ts` + `message.test.ts` + `scripts/deploy-greeting.ts` stay on `setupTestFixture` / `getMovehat` as the coexistence demo)
+- [x] `packages/movehat/src/templates/scripts/deploy-counter.ts` uses the new API (M2.4 — plus `templates/tests/Counter.test.ts`)
+- [x] All MDX code snippets in `packages/docs/content/docs/` updated (M2.4 — 8 MDX files: index, getting-started/{quickstart,configuration}, guides/{testing,scripts,deployment}, cli/{init,run})
+- [x] `packages/docs/content/docs/api/harness.mdx` covers the 7 methods + cleanup (M2.4 — ~200 lines: factory matrix, options reference, fork-mode guard, HarnessDisposedError, AccountManager shared-pool quirk)
+- [x] `getMovehat()` still exported with `@deprecated` JSDoc tag (M2.4 — full migration snippet inline; `initRuntime` stays public as a low-level utility used by `Harness.createLive`)
+- [x] `pnpm test` green (M2.4 — 222/222 unit tests; Tier 2 `test:example` 9/9 passing in ~1 min)
+
+**M2 status: ✅ ready for `develop → main` batch — all 4 sub-PRs (M2.1 PR #120, M2.2 PR #121, M2.3 PR #122, M2.4 PR #N) merged to develop. Tier 3 `pnpm test:e2e` to be run on the batch PR per CLAUDE.md §6.3.**
 
 ### M3 — 80% unit coverage + Movement CLI cache (~5 days, issue #70) — (KPI 1)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,8 +105,8 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `Harness.createLive(network: string, faucetUrl?: string)` returns a usable instance (M2.1)
 - [x] `harness.deployCodeObject(options)` deploys a real Move package (M2.2 — wraps `movement move deploy-object`; reuses Publisher hardening via the extracted `core/movementProfile.ts` helpers; integration coverage in M4)
 - [x] `harness.upgradeCodeObject(options)` upgrades an existing code object (M2.2 — wraps `movement move upgrade-object`; same shared helpers)
-- [ ] `harness.runViewFunction(options)` executes a view function
-- [ ] `harness.runMoveScript(options)` compiles and executes a Move script
+- [x] `harness.runViewFunction(options)` executes a view function (M2.3 — delegates to `aptos.view`; returns raw `unknown[]`; works on all 3 harness modes including fork since views are read-only)
+- [x] `harness.runMoveScript(options)` compiles and executes a Move script (M2.3 — wraps `movement move run-script`; auto-detects `.move` vs `.mv` from extension; `parseTxHash` shared via `utils/parseCliOutput.ts`)
 - [x] `harness.cleanup()` releases the local node, removes temp dirs, and sets `poisoned = true` (M2.1 — idempotent; stops owned localNode / forkServer; tested)
 
 **Definition of Done — Use-after-cleanup safety**:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,10 @@
 
 This roadmap organizes the next phase of Movehat development. Each milestone has explicit Definition of Done criteria and is tracked as a meta-issue on GitHub.
 
+## Reference documents
+
+- **`GRANT.pdf`** (local-only, gitignored) — underlying MOU that defines the deliverable KPIs this roadmap maps to. Kept out of the repo by the `*.pdf` rule in `.gitignore`. Milestone headers below carry `(KPI 1)` / `(KPI 2)` tags pointing at the relevant KPI section in `GRANT.pdf`. When in doubt about acceptance criteria, the MOU text is the source of truth.
+
 ## Current state
 
 - Documentation site shipped (Fumadocs + Next.js, static export)
@@ -33,7 +37,7 @@ This roadmap organizes the next phase of Movehat development. Each milestone has
 
 Each milestone below lists **explicit, mechanically verifiable** acceptance criteria. The criteria use exact file paths, command outputs, and CLI invocations so progress is unambiguous.
 
-### M0 — Repository housekeeping (~1.5 days, issue #67) — ✅ shipped in PR #75
+### M0 — Repository housekeeping (~1.5 days, issue #67) — ✅ shipped in PR #75 — (KPI 2)
 
 **Goal**: Bring the repo to standard open-source hygiene.
 
@@ -48,7 +52,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `git commit -m "test"` is **rejected** by the local hook; `git commit -m "chore: test"` is accepted
 - [N/A] CI green after PR lands — GitHub Actions paused by user; security checks (GitGuardian, Socket, CodeRabbit) green
 
-### M1 — Testability refactors (~5 days, issue #68)
+### M1 — Testability refactors (~5 days, issue #68) — ✅ shipped in PR #106 — (prerequisite for KPI 1)
 
 **Goal**: Refactor core modules so they can be unit-tested without spawning real processes or relying on global state.
 
@@ -81,7 +85,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 
 **M1 status: ✅ shipped via PRs #76, #87, #89, #92, #97, #99 (M1.4), #107 (M1.5), #109 (M1.6), and #110 (M1.7). Tier 3 verification `pnpm test:e2e` 32/32 passing (captured on the `develop → main` batch PR #106). Ready for `develop → main` batch.**
 
-### M2 — Hardhat-style Harness API (~6 days, issue #69)
+### M2 — Hardhat-style Harness API (~6 days, issue #69) — (KPI 1)
 
 **Goal**: Provide a Hardhat-style testing harness with explicit lifecycle and use-after-cleanup safety.
 
@@ -108,7 +112,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [ ] `mh()` still exported with `@deprecated` JSDoc tag
 - [ ] `pnpm test` green
 
-### M3 — 80% unit coverage + Movement CLI cache (~5 days, issue #70)
+### M3 — 80% unit coverage + Movement CLI cache (~5 days, issue #70) — (KPI 1)
 
 **Goal**: Raise unit coverage on critical modules to ≥80% statements; cut CI time by caching the Movement CLI tarball.
 
@@ -138,7 +142,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [ ] Cache hit path skips the 66 MB tarball download
 - [ ] Visible runtime drop on cache hit vs miss in CI logs
 
-### M4 — Zero-mock integration suite + E2E SLO (~4 days, issue #71)
+### M4 — Zero-mock integration suite + E2E SLO (~4 days, issue #71) — (KPI 1)
 
 **Goal**: Build an integration suite running real Movement CLI; tighten CI policy.
 
@@ -156,7 +160,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [ ] Wall-clock for the E2E job is observed **<5 minutes** on cache hit
 - [ ] CI is green on `main` and on at least one non-`main` branch (e.g., a feature/security branch)
 
-### M5 — TypeDoc API ref + benchmarks + Movement CLI compat (~4 days, issue #72)
+### M5 — TypeDoc API ref + benchmarks + Movement CLI compat (~4 days, issue #72) — (KPI 2)
 
 **Goal**: Auto-generate API reference from source; document fork-system performance and Movement CLI compatibility.
 
@@ -177,7 +181,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [ ] At least 2 versions tested green
 - [ ] CI cache key references the pinned version(s)
 
-### M6 — Publish workflow with changelog gate + 0.1.0 release (~2 days, issue #73)
+### M6 — Publish workflow with changelog gate + 0.1.0 release (~2 days, issue #73) — (KPI 2)
 
 **Goal**: Establish a release pipeline that validates the changelog and publishes to npm.
 
@@ -195,7 +199,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [ ] `npm view movehat@0.1.0` returns the new version after publish
 - [ ] `npm pack` output does not contain `mh` exports
 
-### M7 — Maintenance quota (continuous)
+### M7 — Maintenance quota (continuous) — (KPI 2)
 
 **Goal**: Address open audit issues throughout the roadmap.
 

--- a/examples/counter-example/scripts/deploy-counter.ts
+++ b/examples/counter-example/scripts/deploy-counter.ts
@@ -1,48 +1,55 @@
-import { getMovehat, ModuleAlreadyDeployedError } from "movehat";
+import { Harness } from "movehat";
 
+/**
+ * Canonical example of `harness.deployCodeObject` against a Move
+ * package where the Move.toml's named address differs from the
+ * module identifier:
+ *
+ *   move/Move.toml:    [addresses] hello_blockchain = "_"
+ *   move/sources/...:  module hello_blockchain::counter { ... }
+ *
+ * `--address-name` must be `hello_blockchain` (the Move.toml slot),
+ * but `moduleName` stays `counter` (the on-chain module identifier
+ * + the persistence key + the `runtime.getContract(addr, "counter")`
+ * argument). The `addressName` option carries that distinction.
+ */
 async function main() {
   console.log("🚀 Deploying Counter contract...\n");
 
-  // Get the Movehat Runtime Environment
-  const mh = await getMovehat();
+  const network = process.env.MOVEHAT_NETWORK ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    console.log(`✅ Runtime initialized on ${harness.runtime.network.name}`);
+    console.log(`   Account: ${harness.runtime.account.accountAddress.toString()}`);
+    console.log(`   RPC: ${harness.runtime.network.rpc}\n`);
 
-  console.log(`✅ Runtime initialized`);
-  console.log(`   Account: ${mh.account.accountAddress.toString()}`);
-  console.log(`   Network: ${mh.network.name}`);
-  console.log(`   RPC: ${mh.network.rpc}\n`);
+    const deployment = await harness.deployCodeObject({
+      moduleName: "counter",
+      addressName: "hello_blockchain",
+    });
 
-  // Deploy (publish) the module
-  // Automatically checks if already deployed and suggests --redeploy if needed
-  const deployment = await mh.deployContract("counter");
+    console.log(`\n✅ Module deployed at: ${deployment.address}::counter`);
+    if (deployment.txHash) {
+      console.log(`   Transaction: ${deployment.txHash}`);
+    }
 
-  console.log(`\n✅ Module deployed at: ${deployment.address}::counter`);
-  if (deployment.txHash) {
-    console.log(`   Transaction: ${deployment.txHash}`);
+    const counter = harness.runtime.getContract(deployment.address, "counter");
+
+    console.log("\n📝 Incrementing counter...");
+    const txResult = await counter.call(harness.runtime.account, "increment", []);
+    console.log(`✅ Transaction hash: ${txResult.hash}`);
+
+    const [value] = await harness.runViewFunction({
+      function: `${deployment.address}::counter::get`,
+      functionArguments: [harness.runtime.account.accountAddress.toString()],
+    });
+    console.log(`\n📊 Counter value: ${value}`);
+  } finally {
+    await harness.cleanup();
   }
-
-  // Get contract instance
-  const counter = mh.getContract(deployment.address, "counter");
-
-  // Increment the counter (this also initializes it if not exists)
-  console.log("\n📝 Incrementing counter...");
-  const txResult = await counter.call(mh.account, "increment", []);
-
-  console.log(`✅ Transaction hash: ${txResult.hash}`);
-  console.log(`✅ Counter incremented successfully!`);
-
-  // Verify
-  const value = await counter.view<number>("get", [
-    mh.account.accountAddress.toString()
-  ]);
-
-  console.log(`\n📊 Counter value: ${value}`);
 }
 
 main().catch((error) => {
-  // ModuleAlreadyDeployedError is already logged with full details by deployContract()
-  // For other errors, show the message
-  if (!(error instanceof ModuleAlreadyDeployedError)) {
-    console.error("❌ Deployment failed:", error?.message || error);
-  }
+  console.error("❌ Deployment failed:", error?.message || error);
   process.exit(1);
 });

--- a/examples/counter-example/tests/Counter.test.ts
+++ b/examples/counter-example/tests/Counter.test.ts
@@ -1,70 +1,77 @@
-import { setupTestFixture, type TestFixture } from "movehat/helpers";
+import { Harness, AccountManager } from "movehat";
+import type { MoveContract } from "movehat/helpers";
+import type { Account } from "@aptos-labs/ts-sdk";
 import { expect } from "chai";
 
+/**
+ * Migrated to the M2 Harness API. Uses Harness.createLocal with
+ * autoDeploy — same Publisher-based publish path the previous
+ * setupTestFixture flow used. The sibling tests (greeting.test.ts,
+ * message.test.ts) stay on setupTestFixture to demonstrate that the
+ * older API continues to work side-by-side.
+ *
+ * For the new code-object deploy path (`harness.deployCodeObject`),
+ * see scripts/deploy-counter.ts in this directory.
+ */
 describe("Counter Contract", () => {
-  let fixture: TestFixture<'counter'>;
+  let harness: Harness;
+  let counter: MoveContract;
+  let counterAddr: string;
+  let deployer: Account, alice: Account;
 
   before(async function () {
-    this.timeout(60000); // Allow time for fork creation + deployment
+    this.timeout(60000); // Allow time for local node startup + autoDeploy
 
-    // Setup local testing environment with auto-deployment
-    // TypeScript will infer that fixture.contracts.counter exists!
-    fixture = await setupTestFixture(['counter'] as const, ['alice', 'bob']);
+    harness = await Harness.createLocal({
+      accountLabels: ["deployer", "alice", "bob"],
+      autoDeploy: ["counter"],
+    });
+
+    const labeled = AccountManager.getLabeledAccounts();
+    deployer = labeled.deployer!;
+    alice = labeled.alice!;
+
+    counterAddr = harness.runtime.getDeploymentAddress("counter")!;
+    counter = harness.runtime.getContract(counterAddr, "counter");
   });
 
-  it("should initialize with value 0", async () => {
-    const counter = fixture.contracts.counter; // ✅ No need for `!` anymore
-    const deployer = fixture.accounts.deployer;
-
-    // Read counter value (returns string from view function)
-    const value = await counter.view<string>("get", [
-      deployer.accountAddress.toString()
-    ]);
+  it("should initialize with value 0 (via harness.runViewFunction)", async () => {
+    // Demonstrate the new SDK-backed view path. Returns the raw
+    // unknown[] tuple from aptos.view — destructure for singletons.
+    const [value] = await harness.runViewFunction({
+      function: `${counterAddr}::counter::get`,
+      functionArguments: [deployer.accountAddress.toString()],
+    });
 
     console.log(`   Counter value: ${value}`);
-
-    // Assert the counter is 0 (note: values from view are strings)
-    expect(parseInt(value)).to.equal(0);
+    expect(parseInt(value as string)).to.equal(0);
   });
 
   it("should increment counter", async () => {
-    const counter = fixture.contracts.counter;
-    const deployer = fixture.accounts.deployer;
-
-    // Increment the counter
     const tx = await counter.call(deployer, "increment", []);
     console.log(`   Transaction: ${tx.hash}`);
 
-    // Read new value
     const value = await counter.view<string>("get", [
-      deployer.accountAddress.toString()
+      deployer.accountAddress.toString(),
     ]);
 
     console.log(`   New counter value: ${value}`);
-
-    // Should be 1 now
     expect(parseInt(value)).to.equal(1);
   });
 
   it("alice can also increment counter", async () => {
-    const counter = fixture.contracts.counter;
-    const alice = fixture.accounts.alice;
-
-    // Alice increments her own counter
     const tx = await counter.call(alice, "increment", []);
     console.log(`   Alice's transaction: ${tx.hash}`);
 
-    // Read counter value for Alice (each user has their own counter)
     const aliceValue = await counter.view<string>("get", [
-      alice.accountAddress.toString()
+      alice.accountAddress.toString(),
     ]);
 
     console.log(`   Alice's counter value: ${aliceValue}`);
     expect(parseInt(aliceValue)).to.equal(1);
 
-    // Deployer's counter should still be 1 (unchanged)
     const deployerValue = await counter.view<string>("get", [
-      fixture.accounts.deployer.accountAddress.toString()
+      deployer.accountAddress.toString(),
     ]);
 
     console.log(`   Deployer's counter value: ${deployerValue}`);
@@ -72,6 +79,6 @@ describe("Counter Contract", () => {
   });
 
   after(async () => {
-    await fixture.teardown();
+    await harness.cleanup();
   });
 });

--- a/packages/docs/content/docs/api/harness.mdx
+++ b/packages/docs/content/docs/api/harness.mdx
@@ -1,0 +1,209 @@
+---
+title: Harness
+description: Hardhat-style harness API — factories, deployment, view + script execution, cleanup
+icon: Wrench
+---
+
+The `Harness` class is the primary public API of Movehat since M2 (KPI 1). It wraps the Movement TypeScript SDK + Movement CLI behind a Hardhat-style lifecycle: a static factory constructs the instance, methods do the work, and `cleanup()` releases resources + poisons the instance so any further method call throws `HarnessDisposedError` synchronously.
+
+## Quick Start
+
+```typescript
+import { Harness } from "movehat";
+
+const harness = await Harness.createLocal({
+  accountLabels: ["deployer", "alice", "bob"],
+  autoDeploy: ["counter"],
+});
+try {
+  const addr = harness.runtime.getDeploymentAddress("counter");
+  const counter = harness.runtime.getContract(addr, "counter");
+  await counter.call(harness.runtime.account, "increment", []);
+  const [value] = await harness.runViewFunction({
+    function: `${addr}::counter::get`,
+    functionArguments: [harness.runtime.account.accountAddress.toString()],
+  });
+  console.log("counter:", value);
+} finally {
+  await harness.cleanup();
+}
+```
+
+## Factory Methods
+
+Three static factories cover the three execution modes. Each returns a `Harness` instance whose `mode` field reflects the chosen path.
+
+| Factory | Mode | What it spawns | When to use |
+|---|---|---|---|
+| `Harness.createLocal(options?)` | `'local'` | Movement local node (real blockchain on `localhost:8080`) | Unit + integration tests that need real transaction flow |
+| `Harness.createFork(network, apiKey?)` | `'fork'` | Movement fork server (read-only snapshot of `network`) | View-only tests against real network state, no writes |
+| `Harness.createLive(network, faucetUrl?)` | `'live'` | Nothing — binds to a real RPC (testnet / mainnet / custom) | Deployment scripts, real-network interactions |
+
+### `Harness.createLocal(options?: LocalTestOptions)`
+
+Spins up a Movement local node (`movement node run-localnet`), generates and funds the named accounts from the local faucet, and (when `autoDeploy` is set) publishes the named modules via the existing Publisher path.
+
+```typescript
+const harness = await Harness.createLocal({
+  accountLabels: ["deployer", "alice", "bob"],
+  autoDeploy: ["counter"],
+  // mode is forced to 'local-node'; other LocalTestOptions pass through
+});
+```
+
+`LocalTestOptions` (see `movehat/helpers`) supports `nodeApiPort`, `nodeFaucetPort`, `accountLabels`, `autoDeploy`, `autoFund`, `defaultBalance`, and more.
+
+### `Harness.createFork(network: string, apiKey?: string)`
+
+Read-only path. `network` is `'testnet'`, `'mainnet'`, or any custom name resolvable by `loadUserConfig`. Spawns a `ForkServer` reading from the upstream JSON-RPC endpoint and caching responses on disk.
+
+```typescript
+const harness = await Harness.createFork("testnet");
+// harness.runViewFunction works
+// harness.deployCodeObject / upgradeCodeObject / runMoveScript throw a clear error
+```
+
+> The `apiKey` parameter is reserved — wiring into the `MovementApiClient` Authorization header is a TODO for an upcoming sub-PR. Passing it today is a silent no-op.
+
+### `Harness.createLive(network: string, faucetUrl?: string)`
+
+Binds to a real running network. No local process is spawned; transactions hit the configured RPC. Use for testnet / mainnet deployments and real-network reads/writes.
+
+```typescript
+const harness = await Harness.createLive(process.env.MOVEHAT_NETWORK ?? "testnet");
+```
+
+## Methods
+
+### `harness.deployCodeObject(options)`
+
+Wraps `movement move deploy-object`. The derived object address is bound to a Move.toml named address at compile time and returned as `DeploymentInfo.address`.
+
+```typescript
+const deployment = await harness.deployCodeObject({
+  moduleName: "counter",     // persistence key + getContract argument
+  addressName: "my_pkg",     // optional — Move.toml named address (defaults to moduleName)
+  packageDir: "./move",      // optional — defaults to config.moveDir
+  namedAddresses: { extra: "0x..." }, // optional overrides
+});
+```
+
+| Option | Description |
+|---|---|
+| `moduleName` | The on-chain module identifier (the `name` part of `module addr::name`). Used as the deployments registry key (`deployments/{network}/{moduleName}.json`) and as the `name` argument you pass to `runtime.getContract(addr, name)`. |
+| `addressName` | The Move.toml named address that the derived object address binds to (the `--address-name` CLI flag). Defaults to `moduleName`. Set when they differ — e.g. `module hello_blockchain::counter` with `[addresses] hello_blockchain = "_"` needs `addressName: "hello_blockchain"`, `moduleName: "counter"`. |
+| `packageDir` | Path to the Move package. Defaults to `config.moveDir` (usually `./move`). |
+| `namedAddresses` | Overlay on top of the named addresses auto-detected from `<packageDir>/sources/**.move`. |
+| `includedArtifacts` | One of `'none'` / `'sparse'` / `'all'` — defaults to the CLI default (`'sparse'`). |
+
+**Re-deploying:** the local record at `deployments/{network}/{moduleName}.json` makes a second call refuse with `ModuleAlreadyDeployedError`. Set `MH_CLI_REDEPLOY=true` to force a re-deploy.
+
+**Fork-mode guard:** throws a clear error on a `Harness.createFork(...)` instance (forks are read-only).
+
+### `harness.upgradeCodeObject(options)`
+
+Wraps `movement move upgrade-object`. Requires `objectAddress` — the existing on-chain object's address. The local `DeploymentInfo` record is overwritten with a new `timestamp` + `txHash`; the address stays the same.
+
+```typescript
+const upgraded = await harness.upgradeCodeObject({
+  moduleName: "counter",
+  objectAddress: "0xCAFE...",
+});
+```
+
+Fork-mode guard applies.
+
+### `harness.runViewFunction(options)`
+
+Pure SDK call — no Movement CLI invocation, no profile management. Works on all 3 harness modes (read-only).
+
+```typescript
+const result = await harness.runViewFunction({
+  function: "0xCAFE::counter::get",      // fully qualified function id
+  typeArguments: [],                     // optional Move type tags
+  functionArguments: ["0xdeployer..."],  // optional Move function args
+});
+// result: unknown[] — the raw view-function return tuple
+const [value] = result;
+```
+
+Returns the SDK's raw `unknown[]` (Move view functions can return tuples of any arity). Destructure for singletons.
+
+### `harness.runMoveScript(options)`
+
+Wraps `movement move run-script`. Accepts either a `.move` source path (CLI auto-compiles) or a pre-compiled `.mv` bytecode path — the extension picks the right CLI flag.
+
+```typescript
+const result = await harness.runMoveScript({
+  scriptPath: "scripts/init.move",       // or scripts/init.mv
+  args: ["address:0x1", "u64:42"],       // typed args per Movement CLI grammar
+  typeArgs: ["0x1::aptos_coin::AptosCoin"],
+});
+// result: { txHash, success?, vmStatus? }
+```
+
+`success` and `vmStatus` are best-effort parsed from the CLI's Result JSON block. `txHash` is always present (the parser throws if it can't extract one). Fork-mode guard applies.
+
+### `harness.cleanup()`
+
+Releases owned services and poisons the harness:
+
+- `createLocal`: stops the Movement local node
+- `createFork`: stops the fork server
+- `createLive`: no-op (no spawned process), but still poisons the instance
+
+After `cleanup()`, any call to `deployCodeObject`, `upgradeCodeObject`, `runViewFunction`, or `runMoveScript` throws `HarnessDisposedError` **synchronously on property access** (before the awaited body runs). `cleanup()` is idempotent — calling it twice is a no-op.
+
+```typescript
+const harness = await Harness.createLocal();
+await harness.cleanup();
+harness.deployCodeObject({ moduleName: "x" });
+// throws HarnessDisposedError immediately
+```
+
+## Use-After-Cleanup Safety
+
+`HarnessDisposedError` is exported alongside `Harness`:
+
+```typescript
+import { Harness, HarnessDisposedError } from "movehat";
+
+try {
+  await disposedHarness.runViewFunction({ function: "..." });
+} catch (err) {
+  if (err instanceof HarnessDisposedError) {
+    console.error(`Method '${err.methodName}' rejected — harness is disposed.`);
+  }
+}
+```
+
+The poisoning is implemented via a `Proxy` whose `get` trap throws on access to any of the four mutating/view methods listed above. Properties like `mode`, `poisoned`, `runtime`, and `cleanup` itself stay readable — so `await harness.cleanup()` after a previous `cleanup()` is safe and idempotent, and `console.log(harness)` / promise-protocol checks (`.then`, etc.) don't fire the trap.
+
+## Coexistence with `setupTestFixture` / `mh()`
+
+Both pre-M2 helpers continue to work in M2.4:
+
+- `import { setupTestFixture } from "movehat/helpers"` — still exported, still functional.
+- `import { getMovehat } from "movehat"` — exported with a `@deprecated` JSDoc tag; removed in `0.1.0` (M6 / [#73](https://github.com/gilbertsahumada/movehat/issues/73)).
+
+`Harness.createLocal` actually goes through `setupLocalTesting` (which `setupTestFixture` also uses) under the hood — the test environment is identical. The migration is API-level, not infrastructure-level.
+
+## AccountManager Shared Pool
+
+`AccountManager` is a process-wide static. Two `Harness` instances in the same process share account labels:
+
+```typescript
+const h1 = await Harness.createLocal({ accountLabels: ["alice"] });
+const h2 = await Harness.createLocal({ accountLabels: ["alice"] });
+// h1 and h2 see the SAME alice key — AccountManager doesn't re-derive per harness.
+```
+
+This is the same constraint that already governs `setupTestFixture`. A per-Harness pool is a future change tracked under M3.
+
+## Reference Implementation
+
+The canonical end-to-end migration:
+
+- **Counter test using `Harness.createLocal`:** [`examples/counter-example/tests/Counter.test.ts`](https://github.com/gilbertsahumada/movehat/blob/develop/examples/counter-example/tests/Counter.test.ts)
+- **Deploy script using `Harness.createLive` + `deployCodeObject` + `addressName`:** [`examples/counter-example/scripts/deploy-counter.ts`](https://github.com/gilbertsahumada/movehat/blob/develop/examples/counter-example/scripts/deploy-counter.ts)
+- **Template the `movehat init` CLI ships:** [`packages/movehat/src/templates/scripts/deploy-counter.ts`](https://github.com/gilbertsahumada/movehat/blob/develop/packages/movehat/src/templates/scripts/deploy-counter.ts)

--- a/packages/docs/content/docs/api/meta.json
+++ b/packages/docs/content/docs/api/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "API Reference",
+  "pages": ["harness"]
+}

--- a/packages/docs/content/docs/cli/init.mdx
+++ b/packages/docs/content/docs/cli/init.mdx
@@ -43,8 +43,8 @@ my-project/
 ## What It Creates
 
 - **Counter.move** — A sample Move smart contract with increment/decrement functions and Move unit tests
-- **Counter.test.ts** — TypeScript integration test file using `setupTestFixture`
-- **deploy-counter.ts** — Deployment script using the Movehat Runtime Environment
+- **Counter.test.ts** — TypeScript integration test file using `Harness.createLocal`
+- **deploy-counter.ts** — Deployment script using `Harness.createLive` + `deployCodeObject`
 - **movehat.config.ts** — Network configuration (testnet, mainnet, local)
 - **package.json** — Dependencies including `movehat`
 - **.env.example** — Environment variable template

--- a/packages/docs/content/docs/cli/run.mdx
+++ b/packages/docs/content/docs/cli/run.mdx
@@ -36,11 +36,11 @@ movehat run scripts/deploy-counter.ts --network testnet --redeploy
 
 ## How It Works
 
-1. Parses `--network` and `--redeploy` flags
+1. Parses `--network` and `--redeploy` flags (`--redeploy` sets `MH_CLI_REDEPLOY=true` for the spawned script)
 2. Spawns `tsx` with your script
-3. Your script calls `getMovehat()` to get the runtime
-4. The runtime loads configuration, connects to the network, and sets up accounts
-5. If `deployContract()` is called, deployment tracking checks/saves are performed
+3. Your script constructs a `Harness` via one of the `Harness.create*` factories
+4. The harness loads configuration, connects to the network, and sets up accounts
+5. If `harness.deployCodeObject()` is called, deployment tracking checks/saves are performed
 
 ## Deployment Tracking
 
@@ -53,15 +53,22 @@ When a script deploys a contract:
 ## Script Template
 
 ```typescript
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const harness = await Harness.createLive(process.env.MOVEHAT_NETWORK ?? "testnet");
+  try {
+    console.log("Network:", harness.runtime.network.name);
+    console.log("Account:", harness.runtime.account.accountAddress.toString());
 
-  console.log("Network:", mh.config.network);
-  console.log("Account:", mh.account.accountAddress.toString());
-
-  // Your deployment logic here
+    // Your deployment logic here, e.g.:
+    //   const deployment = await harness.deployCodeObject({ moduleName: "counter" });
+    //   const [value] = await harness.runViewFunction({ function: "..." });
+    //   const result = await harness.runMoveScript({ scriptPath: "scripts/init.move" });
+  } finally {
+    // cleanup() is idempotent and safe to always call.
+    await harness.cleanup();
+  }
 }
 
 main().catch((error) => {

--- a/packages/docs/content/docs/getting-started/configuration.mdx
+++ b/packages/docs/content/docs/getting-started/configuration.mdx
@@ -104,13 +104,20 @@ PRIVATE_KEY=0x<YOUR_PRIVATE_KEY>
 // movehat.config.ts
 export default {
   accounts: [
-    process.env.PRIVATE_KEY,     // Primary (mh.account)
-    process.env.SECONDARY_KEY,   // mh.accounts[1]
+    process.env.PRIVATE_KEY,     // Primary (harness.runtime.account)
+    process.env.SECONDARY_KEY,   // harness.runtime.accounts[1]
   ].filter(Boolean),
 };
 
 // In your script
-const mh = await getMovehat();
-const primaryAccount = mh.account;               // accounts[0]
-const secondaryAccount = mh.getAccountByIndex(1); // accounts[1]
+import { Harness } from "movehat";
+
+const harness = await Harness.createLive("testnet");
+try {
+  const primaryAccount = harness.runtime.account;                  // accounts[0]
+  const secondaryAccount = harness.runtime.getAccountByIndex(1);   // accounts[1]
+  // ...
+} finally {
+  await harness.cleanup();
+}
 ```

--- a/packages/docs/content/docs/getting-started/quickstart.mdx
+++ b/packages/docs/content/docs/getting-started/quickstart.mdx
@@ -75,39 +75,47 @@ Run with: `movehat test --move` (ultra-fast, milliseconds)
 
 ### TypeScript Integration Tests (Local Node)
 
-Tests written in TypeScript that run on a **local Movement blockchain**:
+Tests written in TypeScript that run on a **local Movement blockchain** using the Hardhat-style `Harness` API:
 
 ```typescript
-import { setupTestFixture, teardownTestFixture } from "movehat/helpers";
+import { Harness, AccountManager } from "movehat";
 
 describe("Counter Contract", () => {
-  let fixture;
+  let harness;
+  let counter, deployer;
 
   before(async function () {
     this.timeout(60000);
-    // Starts local node, funds accounts, deploys contracts
-    fixture = await setupTestFixture(['counter'] as const, ['alice', 'bob']);
+    // Starts local node, funds accounts, deploys the named module(s)
+    harness = await Harness.createLocal({
+      accountLabels: ["deployer", "alice", "bob"],
+      autoDeploy: ["counter"],
+    });
+    deployer = AccountManager.getLabeledAccounts().deployer;
+    const addr = harness.runtime.getDeploymentAddress("counter");
+    counter = harness.runtime.getContract(addr, "counter");
   });
 
   it("should increment counter", async () => {
-    const counter = fixture.contracts.counter;
-    const deployer = fixture.accounts.deployer;
-
-    // Real transaction on local blockchain
     await counter.call(deployer, "increment", []);
 
-    const value = await counter.view<string>("get", [
-      deployer.accountAddress.toString()
-    ]);
+    const [value] = await harness.runViewFunction({
+      function: `${counter.moduleAddress}::counter::get`,
+      functionArguments: [deployer.accountAddress.toString()],
+    });
 
     expect(parseInt(value)).to.equal(1);
   });
 
   after(async () => {
-    await teardownTestFixture();
+    // Stops the local node and poisons the harness — any further
+    // method call (other than cleanup) throws HarnessDisposedError.
+    await harness.cleanup();
   });
 });
 ```
+
+> **Looking for the older API?** `setupTestFixture` / `teardownTestFixture` still works (see `movehat/helpers`); use whichever style fits your codebase. `Harness` is the new primary surface since M2.
 
 Run with: `movehat test --ts` (starts local node)
 

--- a/packages/docs/content/docs/guides/deployment.mdx
+++ b/packages/docs/content/docs/guides/deployment.mdx
@@ -6,31 +6,36 @@ icon: CloudUpload
 
 ## Writing Deployment Scripts
 
-Deployment scripts use the **Movehat Runtime Environment (MRE)**:
+Deployment scripts use the **Hardhat-style `Harness` API**, which wraps the Movement SDK + the new code-object publish path (`movement move deploy-object`):
 
 ```typescript
 // scripts/deploy-counter.ts
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const harness = await Harness.createLive(process.env.MOVEHAT_NETWORK ?? "testnet");
+  try {
+    console.log("Deploying from:", harness.runtime.account.accountAddress.toString());
+    console.log("Network:", harness.runtime.network.name);
 
-  console.log("Deploying from:", mh.account.accountAddress.toString());
-  console.log("Network:", mh.config.network);
+    // Deploy as a code object. If your Move.toml's named address
+    // differs from the module identifier (e.g. `module my_pkg::counter`
+    // with `[addresses] my_pkg = "_"`), set `addressName: "my_pkg"`.
+    const deployment = await harness.deployCodeObject({ moduleName: "counter" });
 
-  // Deploy (publish) the module
-  const deployment = await mh.deployContract("counter");
+    console.log("Module deployed at:", deployment.address);
+    console.log("Transaction:", deployment.txHash);
 
-  console.log("Module deployed at:", deployment.address);
-  console.log("Transaction:", deployment.txHash);
+    // Get contract instance
+    const contract = harness.runtime.getContract(deployment.address, "counter");
 
-  // Get contract instance
-  const contract = mh.getContract(deployment.address, "counter");
+    // Initialize the counter
+    await contract.call(harness.runtime.account, "init", []);
 
-  // Initialize the counter
-  await contract.call(mh.account, "init", []);
-
-  console.log("Counter initialized!");
+    console.log("Counter initialized!");
+  } finally {
+    await harness.cleanup();
+  }
 }
 
 main().catch((error) => {
@@ -38,6 +43,8 @@ main().catch((error) => {
   process.exit(1);
 });
 ```
+
+> **Re-deploying:** the local deployment record lives at `deployments/{network}/{moduleName}.json`. A second `deployCodeObject({ moduleName: "counter" })` call refuses with `ModuleAlreadyDeployedError`. To force a re-deploy, set `MH_CLI_REDEPLOY=true` in the environment.
 
 ## Running Deployment Scripts
 
@@ -99,56 +106,60 @@ movehat run scripts/deploy-counter.ts --network testnet
 #    Deployed at: 2025-12-05 23:38:14 UTC
 #    Transaction: 0x59cb0c2df832...
 #
-#    To redeploy, run with the --redeploy flag:
-#    movehat run <script> --network testnet --redeploy
+#    To redeploy, set MH_CLI_REDEPLOY=true:
+#    MH_CLI_REDEPLOY=true movehat run <script> --network testnet
 ```
 
 **Force redeploy:**
 
 ```bash
-movehat run scripts/deploy-counter.ts --network testnet --redeploy
+MH_CLI_REDEPLOY=true movehat run scripts/deploy-counter.ts --network testnet
 # Redeploys and updates deployment info
 ```
 
-## Runtime Environment Properties
+## Harness Properties
 
 ```typescript
-const mh = await getMovehat();
+const harness = await Harness.createLive("testnet");
 
-// Core
-mh.config         // Resolved configuration
-mh.network        // Network info (name, chainId, rpc)
-mh.aptos          // Movement TypeScript SDK client
-mh.account        // Primary account
-mh.accounts       // All configured accounts
+// Harness methods (M2 public API)
+harness.mode               // 'local' | 'fork' | 'live'
+harness.deployCodeObject   // movement move deploy-object
+harness.upgradeCodeObject  // movement move upgrade-object
+harness.runViewFunction    // aptos.view
+harness.runMoveScript      // movement move run-script
+harness.cleanup            // release resources + poison
 
-// Contract helpers
-mh.getContract    // Get contract helper
-
-// Deployment functions
-mh.deployContract       // Deploy and track module
-mh.getDeployment        // Get deployment info for a module
-mh.getDeployments       // Get all deployments for current network
-mh.getDeploymentAddress // Get deployed address for a module
-
-// Network management
-mh.switchNetwork  // Switch to different network
+// Underlying runtime
+harness.runtime.config              // Resolved configuration
+harness.runtime.network             // Network info
+harness.runtime.aptos               // Movement TypeScript SDK client
+harness.runtime.account             // Primary account
+harness.runtime.accounts            // All configured accounts
+harness.runtime.getContract         // Get a MoveContract helper
+harness.runtime.getDeployment       // Get deployment info
+harness.runtime.getDeployments      // Get all deployments
+harness.runtime.getDeploymentAddress // Get deployed address
 ```
 
 ## Multi-Network Deployment
 
 ```typescript
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const network = process.env.MOVEHAT_NETWORK ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    if (harness.runtime.network.name === "mainnet") {
+      console.log("WARNING: Deploying to MAINNET");
+    }
 
-  if (mh.config.network === "mainnet") {
-    console.log("WARNING: Deploying to MAINNET");
+    const deployment = await harness.deployCodeObject({ moduleName: "counter" });
+    console.log(`Deployed on ${harness.runtime.network.name}:`, deployment.address);
+  } finally {
+    await harness.cleanup();
   }
-
-  const deployment = await mh.deployContract("counter");
-  console.log(`Deployed on ${mh.config.network}:`, deployment.address);
 }
 
 main().catch(console.error);

--- a/packages/docs/content/docs/guides/scripts.mdx
+++ b/packages/docs/content/docs/guides/scripts.mdx
@@ -12,30 +12,64 @@ Execute TypeScript/JavaScript scripts with the Movehat Runtime:
 movehat run scripts/deploy-counter.ts --network testnet
 ```
 
-The `movehat run` command provides your script with access to the **Movehat Runtime Environment (MRE)**, which includes the Movement TypeScript SDK client, account management, contract helpers, and more.
+The `movehat run` command provides your script with access to the **Hardhat-style `Harness` API**, which wraps the Movement TypeScript SDK client, account management, contract helpers, and the new code-object deployment path.
 
 ## Writing Scripts
 
 ### Deploy and Initialize
 
 ```typescript
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const harness = await Harness.createLive(process.env.MOVEHAT_NETWORK ?? "testnet");
+  try {
+    // 1. Deploy via `movement move deploy-object` (code object).
+    //    Set `addressName` if Move.toml's named address ≠ moduleName.
+    const deployment = await harness.deployCodeObject({ moduleName: "counter" });
+    console.log("Module deployed at:", deployment.address);
+    console.log("Transaction:", deployment.txHash);
 
-  // 1. Deploy (publish) the module
-  const deployment = await mh.deployContract("counter");
-  console.log("Module deployed at:", deployment.address);
-  console.log("Transaction:", deployment.txHash);
+    // 2. Initialize
+    const contract = harness.runtime.getContract(deployment.address, "counter");
+    await contract.call(harness.runtime.account, "init", []);
 
-  // 2. Initialize
-  const contract = mh.getContract(deployment.address, "counter");
-  await contract.call(mh.account, "init", []);
+    // 3. Verify via the SDK-backed view path
+    const [value] = await harness.runViewFunction({
+      function: `${deployment.address}::counter::getValue`,
+    });
+    console.log("Initial value:", value);
+  } finally {
+    // Always release — cleanup() is idempotent and poisons the harness.
+    await harness.cleanup();
+  }
+}
 
-  // 3. Verify
-  const value = await contract.view("getValue", []);
-  console.log("Initial value:", value);
+main().catch(console.error);
+```
+
+### Running a Move Script
+
+For Move scripts (one-shot transactions, not module publishes), use `harness.runMoveScript`. It accepts either a `.move` source path (CLI auto-compiles) or a pre-compiled `.mv` bytecode path — the extension determines which CLI flag is used.
+
+```typescript
+import { Harness } from "movehat";
+
+async function main() {
+  const harness = await Harness.createLive("testnet");
+  try {
+    const result = await harness.runMoveScript({
+      scriptPath: "scripts/initialize.move",  // or scripts/initialize.mv
+      typeArgs: ["0x1::aptos_coin::AptosCoin"],
+      args: ["address:0xCAFE", "u64:100"],
+    });
+    console.log("Transaction:", result.txHash);
+    if (result.success === false) {
+      throw new Error(`Script failed: ${result.vmStatus}`);
+    }
+  } finally {
+    await harness.cleanup();
+  }
 }
 
 main().catch(console.error);
@@ -44,19 +78,22 @@ main().catch(console.error);
 ### Multi-Network Deployment
 
 ```typescript
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const network = process.env.MOVEHAT_NETWORK ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    if (harness.runtime.config.network === "mainnet") {
+      console.log("WARNING: Deploying to MAINNET");
+      // Add confirmation logic
+    }
 
-  if (mh.config.network === "mainnet") {
-    console.log("WARNING: Deploying to MAINNET");
-    // Add confirmation logic
+    const deployment = await harness.deployCodeObject({ moduleName: "counter" });
+    console.log(`Deployed on ${harness.runtime.network.name}:`, deployment.address);
+  } finally {
+    await harness.cleanup();
   }
-
-  // Deploy module — automatically tracked per network
-  const deployment = await mh.deployContract("counter");
-  console.log(`Deployed on ${mh.config.network}:`, deployment.address);
 }
 
 main().catch(console.error);
@@ -76,30 +113,36 @@ movehat run scripts/deploy-counter.ts --network local
 movehat run scripts/deploy-counter.ts --network testnet --redeploy
 ```
 
-## Available Runtime Properties
+## Available Harness Properties
 
 ```typescript
-const mh = await getMovehat();
+const harness = await Harness.createLive("testnet");
 
-// Core
-mh.config         // Resolved configuration
-mh.network        // Network info (name, chainId, rpc)
-mh.aptos          // Movement TypeScript SDK client
-mh.account        // Primary account
-mh.accounts       // All configured accounts
+// Mode + cleanup state
+harness.mode               // 'local' | 'fork' | 'live'
+harness.poisoned           // true once cleanup() has been called
 
-// Contract helpers
-mh.getContract    // Get contract helper
+// Harness methods (M2 public API)
+harness.deployCodeObject   // movement move deploy-object
+harness.upgradeCodeObject  // movement move upgrade-object
+harness.runViewFunction    // aptos.view (read-only, works in all modes)
+harness.runMoveScript      // movement move run-script
+harness.cleanup            // release resources + poison harness
 
-// Deployment functions
-mh.deployContract       // Deploy and track module
-mh.getDeployment        // Get deployment info
-mh.getDeployments       // Get all deployments
-mh.getDeploymentAddress // Get deployed address
-
-// Network management
-mh.switchNetwork  // Switch to different network
+// Underlying runtime (Movement SDK + account/contract/deployment helpers)
+harness.runtime.config              // Resolved configuration
+harness.runtime.network             // Network info (name, chainId, rpc)
+harness.runtime.aptos               // Movement TypeScript SDK client
+harness.runtime.account             // Primary account
+harness.runtime.accounts            // All configured accounts
+harness.runtime.getContract         // Get a MoveContract helper
+harness.runtime.getDeployment       // Get deployment info
+harness.runtime.getDeployments      // Get all deployments
+harness.runtime.getDeploymentAddress // Get deployed address
+harness.runtime.switchNetwork       // Switch to different network (returns a new runtime)
 ```
+
+> **`harness.runtime.deployContract` (legacy `move publish` path)** is still available for users who prefer it. New code should use `harness.deployCodeObject` (code-object path).
 
 ## Using Multiple Accounts
 
@@ -107,13 +150,20 @@ mh.switchNetwork  // Switch to different network
 // movehat.config.ts
 export default {
   accounts: [
-    process.env.PRIVATE_KEY,     // Primary (mh.account)
-    process.env.SECONDARY_KEY,   // mh.accounts[1]
+    process.env.PRIVATE_KEY,     // Primary (harness.runtime.account)
+    process.env.SECONDARY_KEY,   // harness.runtime.accounts[1]
   ].filter(Boolean),
 };
 
 // In your script
-const mh = await getMovehat();
-const primaryAccount = mh.account;
-const secondaryAccount = mh.getAccountByIndex(1);
+import { Harness } from "movehat";
+
+const harness = await Harness.createLive("testnet");
+try {
+  const primaryAccount = harness.runtime.account;
+  const secondaryAccount = harness.runtime.getAccountByIndex(1);
+  // ...
+} finally {
+  await harness.cleanup();
+}
 ```

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -43,67 +43,79 @@ movehat test:move
 
 ## TypeScript Integration Tests (Local Blockchain)
 
-Write tests in TypeScript that run on a **real local Movement blockchain** (just like Hardhat!):
+Write tests in TypeScript that run on a **real local Movement blockchain** using the Hardhat-style `Harness` API:
 
 ```typescript
 import { describe, it, before, after } from "mocha";
 import { expect } from "chai";
-import { setupTestFixture, teardownTestFixture, type TestFixture } from "movehat/helpers";
+import { Harness, AccountManager } from "movehat";
+import type { MoveContract } from "movehat/helpers";
+import type { Account } from "@aptos-labs/ts-sdk";
 
 describe("Counter Contract", () => {
-  let fixture: TestFixture<'counter'>;
+  let harness: Harness;
+  let counter: MoveContract;
+  let deployer: Account, alice: Account;
 
   before(async function () {
     this.timeout(60000);
-    fixture = await setupTestFixture(['counter'] as const, ['alice', 'bob']);
+    harness = await Harness.createLocal({
+      accountLabels: ["deployer", "alice", "bob"],
+      autoDeploy: ["counter"],
+    });
+
+    const labeled = AccountManager.getLabeledAccounts();
+    deployer = labeled.deployer!;
+    alice = labeled.alice!;
+
+    const addr = harness.runtime.getDeploymentAddress("counter")!;
+    counter = harness.runtime.getContract(addr, "counter");
 
     console.log(`\nTesting on local blockchain`);
-    console.log(`   Deployer: ${fixture.accounts.deployer.accountAddress.toString()}`);
-    console.log(`   Alice: ${fixture.accounts.alice.accountAddress.toString()}`);
+    console.log(`   Deployer: ${deployer.accountAddress.toString()}`);
+    console.log(`   Alice: ${alice.accountAddress.toString()}`);
   });
 
-  it("should initialize with value 0", async () => {
-    const counter = fixture.contracts.counter;
-    const deployer = fixture.accounts.deployer;
+  it("should initialize with value 0 (via harness.runViewFunction)", async () => {
+    // runViewFunction returns the raw unknown[] tuple from aptos.view —
+    // destructure for singletons.
+    const [value] = await harness.runViewFunction({
+      function: `${counter.moduleAddress}::counter::get`,
+      functionArguments: [deployer.accountAddress.toString()],
+    });
 
-    const value = await counter.view<string>("get", [
-      deployer.accountAddress.toString()
-    ]);
-
-    expect(parseInt(value)).to.equal(0);
+    expect(parseInt(value as string)).to.equal(0);
   });
 
   it("should increment counter", async () => {
-    const counter = fixture.contracts.counter;
-    const deployer = fixture.accounts.deployer;
-
     const tx = await counter.call(deployer, "increment", []);
     console.log(`   Transaction: ${tx.hash}`);
 
     const value = await counter.view<string>("get", [
-      deployer.accountAddress.toString()
+      deployer.accountAddress.toString(),
     ]);
 
     expect(parseInt(value)).to.equal(1);
   });
 
   it("alice can also increment counter", async () => {
-    const counter = fixture.contracts.counter;
-    const alice = fixture.accounts.alice;
-
     await counter.call(alice, "increment", []);
 
     const aliceValue = await counter.view<string>("get", [
-      alice.accountAddress.toString()
+      alice.accountAddress.toString(),
     ]);
     expect(parseInt(aliceValue)).to.equal(1);
   });
 
   after(async () => {
-    await teardownTestFixture();
+    // cleanup() is idempotent and poisons the harness so any further
+    // method call (other than cleanup) throws HarnessDisposedError.
+    await harness.cleanup();
   });
 });
 ```
+
+> **Looking for the older API?** `setupTestFixture` from `movehat/helpers` is still supported — see [`movehat/helpers`](../api/harness) for details on coexistence.
 
 **When to use TypeScript tests:**
 - Testing real transaction flows with actual state changes

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -115,7 +115,7 @@ describe("Counter Contract", () => {
 });
 ```
 
-> **Looking for the older API?** `setupTestFixture` from `movehat/helpers` is still supported — see [`movehat/helpers`](../api/harness) for details on coexistence.
+> **Looking for the older API?** `setupTestFixture` from `movehat/helpers` is still supported — see the [Harness API page](../api/harness) for details on coexistence with the legacy helpers.
 
 **When to use TypeScript tests:**
 - Testing real transaction flows with actual state changes

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -11,10 +11,12 @@ Write your tests and deployment scripts in TypeScript while building Move smart 
 
 ## Features
 
+- **Hardhat-style Harness API** - `Harness.createLocal()` / `createFork()` / `createLive()` with explicit lifecycle and use-after-cleanup safety
 - **Local Node Testing** - Run a real Movement blockchain locally for testing (just like Hardhat!)
 - **Dual Testing Modes** - Choose between `local-node` (full blockchain) or `fork` (read-only snapshot)
 - **Auto-Deploy in Tests** - Contracts deploy automatically when tests run — zero manual setup
-- **setupTestFixture Helper** - High-level API for test setup with type-safe contracts
+- **Code-Object Deployment** - `harness.deployCodeObject()` wraps `movement move deploy-object` with security-hardened profile management
+- **setupTestFixture Helper** - High-level API for test setup with type-safe contracts (alternative to Harness)
 - **Zero Setup Testing** - Auto-generated test accounts funded from local faucet
 - **Auto-detection of Named Addresses** - Automatically detects and configures addresses from your Move code
 - **Native Fork System** - Create local snapshots of Movement L1 with actual network state

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -17,6 +17,8 @@
     "cli/test",
     "cli/run",
     "cli/fork",
+    "---API Reference---",
+    "api/harness",
     "---Community---",
     "contributing/index"
   ]

--- a/packages/movehat/src/__tests__/harness/Harness.createLive.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.createLive.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Harness } from "../../harness/index.js";
+import { _resetConfigCache } from "../../core/config.js";
+
+describe("Harness.createLive", () => {
+  let tmpCwd: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-harness-live-"));
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    },
+    custom: {
+      url: "https://custom.example.com/v1",
+      chainId: "custom",
+      accounts: ["0x${"a".repeat(64)}"]
+    }
+  }
+};
+`
+    );
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]
+name = "dummy"
+version = "0.0.1"
+
+[addresses]
+`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// intentionally empty\n");
+
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+      _resetConfigCache();
+    }
+  });
+
+  it("returns a Harness bound to the requested network with mode='live'", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      expect(harness.mode).toBe("live");
+      expect(harness.runtime).toBeDefined();
+      expect(harness.runtime.network.name).toBe("testnet");
+      expect(harness.runtime.network.rpc).toContain("testnet.movementnetwork.xyz");
+      // createLive does not own a local node or fork server.
+      expect(harness.localNode).toBeUndefined();
+      expect(harness.forkServer).toBeUndefined();
+      expect(harness.forkManager).toBeUndefined();
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("can switch networks via the first argument", async () => {
+    const harness = await Harness.createLive("custom");
+    try {
+      expect(harness.runtime.network.name).toBe("custom");
+      expect(harness.runtime.network.rpc).toContain("custom.example.com");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("cleanup() is a no-op for createLive (no owned services) but still poisons", async () => {
+    const harness = await Harness.createLive("testnet");
+    expect(harness.poisoned).toBe(false);
+    await harness.cleanup();
+    expect(harness.poisoned).toBe(true);
+  });
+});

--- a/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
@@ -85,14 +85,20 @@ version = "0.0.1"
     await harness.cleanup();
 
     // Property access itself throws — the call site never gets a Promise back.
-    expect(() => harness.deployCodeObject({})).toThrow(HarnessDisposedError);
+    // The args ({moduleName: "x"}) typecheck but never execute (the get trap
+    // fires before the method body runs).
+    expect(() => harness.deployCodeObject({ moduleName: "x" })).toThrow(
+      HarnessDisposedError
+    );
   });
 
   it("post-cleanup, upgradeCodeObject / runViewFunction / runMoveScript all throw HarnessDisposedError synchronously", async () => {
     const harness = await Harness.createLive("testnet");
     await harness.cleanup();
 
-    expect(() => harness.upgradeCodeObject({})).toThrow(HarnessDisposedError);
+    expect(() =>
+      harness.upgradeCodeObject({ moduleName: "x", objectAddress: "0x1" })
+    ).toThrow(HarnessDisposedError);
     expect(() => harness.runViewFunction({})).toThrow(HarnessDisposedError);
     expect(() => harness.runMoveScript({})).toThrow(HarnessDisposedError);
   });
@@ -103,7 +109,7 @@ version = "0.0.1"
 
     let captured: unknown;
     try {
-      harness.deployCodeObject({});
+      harness.deployCodeObject({ moduleName: "x" });
     } catch (err) {
       captured = err;
     }
@@ -121,11 +127,12 @@ version = "0.0.1"
     expect(harness.runtime).toBeDefined();
   });
 
-  it("before cleanup, the 4 stub methods reject (real impls in M2.2/M2.3) — but do NOT throw HarnessDisposedError", async () => {
+  it("before cleanup, the remaining M2.3 stub methods reject — but do NOT throw HarnessDisposedError", async () => {
+    // deployCodeObject + upgradeCodeObject got real bodies in M2.2; their
+    // behavior is covered by the codeObject test suite. The view + script
+    // stubs remain until M2.3.
     const harness = await Harness.createLive("testnet");
     try {
-      await expect(harness.deployCodeObject({})).rejects.toThrow(/not yet implemented/);
-      await expect(harness.upgradeCodeObject({})).rejects.toThrow(/not yet implemented/);
       await expect(harness.runViewFunction({})).rejects.toThrow(/not yet implemented/);
       await expect(harness.runMoveScript({})).rejects.toThrow(/not yet implemented/);
     } finally {
@@ -141,7 +148,7 @@ version = "0.0.1"
     // shape uses await. Confirm that pattern surfaces the error too.
     let captured: unknown;
     try {
-      await harness.deployCodeObject({});
+      await harness.deployCodeObject({ moduleName: "x" });
     } catch (err) {
       captured = err;
     }

--- a/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Harness, HarnessDisposedError } from "../../harness/index.js";
+import { _resetConfigCache } from "../../core/config.js";
+
+/**
+ * Proxy poisoning is the load-bearing safety guarantee of M2: once a
+ * Harness has been cleaned up, any further deploy / view / script /
+ * upgrade call must throw `HarnessDisposedError` synchronously on
+ * property access — not after the awaited method body. These tests
+ * lock that contract.
+ *
+ * Uses `Harness.createLive(network)` because it does not spawn a real
+ * Movement node — `initRuntime` only constructs the SDK client (no RPC
+ * round-trip) from the fixture config. `createLocal` / `createFork`
+ * runtime tests live in the M4 integration suite where spinning a real
+ * node is acceptable.
+ */
+describe("Harness — proxy poisoning", () => {
+  let tmpCwd: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-harness-test-"));
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    }
+  }
+};
+`
+    );
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]
+name = "dummy"
+version = "0.0.1"
+
+[addresses]
+`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// intentionally empty\n");
+
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+      _resetConfigCache();
+    }
+  });
+
+  it("cleanup() flips poisoned to true", async () => {
+    const harness = await Harness.createLive("testnet");
+    expect(harness.poisoned).toBe(false);
+    await harness.cleanup();
+    expect(harness.poisoned).toBe(true);
+  });
+
+  it("cleanup() is idempotent", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+    // Second call must not throw and must leave the harness poisoned.
+    await expect(harness.cleanup()).resolves.toBeUndefined();
+    expect(harness.poisoned).toBe(true);
+  });
+
+  it("post-cleanup, deployCodeObject throws HarnessDisposedError synchronously on property access", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+
+    // Property access itself throws — the call site never gets a Promise back.
+    expect(() => harness.deployCodeObject({})).toThrow(HarnessDisposedError);
+  });
+
+  it("post-cleanup, upgradeCodeObject / runViewFunction / runMoveScript all throw HarnessDisposedError synchronously", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+
+    expect(() => harness.upgradeCodeObject({})).toThrow(HarnessDisposedError);
+    expect(() => harness.runViewFunction({})).toThrow(HarnessDisposedError);
+    expect(() => harness.runMoveScript({})).toThrow(HarnessDisposedError);
+  });
+
+  it("HarnessDisposedError carries the offending method name", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+
+    let captured: unknown;
+    try {
+      harness.deployCodeObject({});
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(HarnessDisposedError);
+    expect((captured as HarnessDisposedError).methodName).toBe("deployCodeObject");
+  });
+
+  it("post-cleanup, metadata accessors (mode, poisoned, runtime) still work", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+
+    // None of these should throw — only the 4 poisoned methods do.
+    expect(harness.mode).toBe("live");
+    expect(harness.poisoned).toBe(true);
+    expect(harness.runtime).toBeDefined();
+  });
+
+  it("before cleanup, the 4 stub methods reject (real impls in M2.2/M2.3) — but do NOT throw HarnessDisposedError", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      await expect(harness.deployCodeObject({})).rejects.toThrow(/not yet implemented/);
+      await expect(harness.upgradeCodeObject({})).rejects.toThrow(/not yet implemented/);
+      await expect(harness.runViewFunction({})).rejects.toThrow(/not yet implemented/);
+      await expect(harness.runMoveScript({})).rejects.toThrow(/not yet implemented/);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("await harness.someAsyncMethod() pattern: post-cleanup throw happens before await", async () => {
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+
+    // The error is synchronous (property access), but the typical caller
+    // shape uses await. Confirm that pattern surfaces the error too.
+    let captured: unknown;
+    try {
+      await harness.deployCodeObject({});
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(HarnessDisposedError);
+  });
+});

--- a/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
@@ -99,8 +99,12 @@ version = "0.0.1"
     expect(() =>
       harness.upgradeCodeObject({ moduleName: "x", objectAddress: "0x1" })
     ).toThrow(HarnessDisposedError);
-    expect(() => harness.runViewFunction({})).toThrow(HarnessDisposedError);
-    expect(() => harness.runMoveScript({})).toThrow(HarnessDisposedError);
+    expect(() =>
+      harness.runViewFunction({ function: "0x1::m::f" })
+    ).toThrow(HarnessDisposedError);
+    expect(() =>
+      harness.runMoveScript({ scriptPath: "irrelevant.move" })
+    ).toThrow(HarnessDisposedError);
   });
 
   it("HarnessDisposedError carries the offending method name", async () => {
@@ -127,18 +131,10 @@ version = "0.0.1"
     expect(harness.runtime).toBeDefined();
   });
 
-  it("before cleanup, the remaining M2.3 stub methods reject — but do NOT throw HarnessDisposedError", async () => {
-    // deployCodeObject + upgradeCodeObject got real bodies in M2.2; their
-    // behavior is covered by the codeObject test suite. The view + script
-    // stubs remain until M2.3.
-    const harness = await Harness.createLive("testnet");
-    try {
-      await expect(harness.runViewFunction({})).rejects.toThrow(/not yet implemented/);
-      await expect(harness.runMoveScript({})).rejects.toThrow(/not yet implemented/);
-    } finally {
-      await harness.cleanup();
-    }
-  });
+  // The M2.3-era "stubs reject" assertion was retired when M2.3 shipped
+  // real bodies for runViewFunction and runMoveScript. All four methods
+  // now have dedicated test suites (codeObject.deploy/upgrade.test.ts,
+  // view.test.ts, script.test.ts).
 
   it("await harness.someAsyncMethod() pattern: post-cleanup throw happens before await", async () => {
     const harness = await Harness.createLive("testnet");

--- a/packages/movehat/src/__tests__/harness/codeObject.deploy.test.ts
+++ b/packages/movehat/src/__tests__/harness/codeObject.deploy.test.ts
@@ -303,6 +303,59 @@ version = "0.0.1"
     }
   });
 
+  it("addressName override is used in --address-name CLI flag; moduleName remains the save-record key", async () => {
+    // Example use case: Move source `module hello_blockchain::counter`
+    // with Move.toml `[addresses] hello_blockchain = "_"`. The CLI's
+    // --address-name must match the Move.toml entry (`hello_blockchain`)
+    // while the on-chain module identifier + the save key + the
+    // getContract argument stay `counter`.
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: { exitCode: 0, stdout: successStdout(), stderr: "" },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      const result = await harness.deployCodeObject({
+        moduleName: "counter",
+        addressName: "hello_blockchain",
+        adapter,
+      });
+
+      // Save record + return value use moduleName (not addressName).
+      expect(result.moduleName).toBe("counter");
+      const deploymentPath = join(tmpCwd, "deployments", "testnet", "counter.json");
+      expect(existsSync(deploymentPath)).toBe(true);
+      const saved = JSON.parse(readFileSync(deploymentPath, "utf-8"));
+      expect(saved.moduleName).toBe("counter");
+
+      // CLI flag was the overridden addressName.
+      const deployCall = calls.find((c) => c.args[1] === "deploy-object")!;
+      const addressNameIdx = deployCall.args.indexOf("--address-name");
+      expect(addressNameIdx).toBeGreaterThanOrEqual(0);
+      expect(deployCall.args[addressNameIdx + 1]).toBe("hello_blockchain");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("addressName defaults to moduleName when omitted (back-compat for template case)", async () => {
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: { exitCode: 0, stdout: successStdout(), stderr: "" },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      await harness.deployCodeObject({ moduleName: "counter", adapter });
+      const deployCall = calls.find((c) => c.args[1] === "deploy-object")!;
+      const addressNameIdx = deployCall.args.indexOf("--address-name");
+      expect(deployCall.args[addressNameIdx + 1]).toBe("counter");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
   it("fork-mode harness throws synchronously before any CLI call (covered separately for createLocal/createFork in M4 integration suite)", async () => {
     // This case can't be tested with a real createFork (it spawns a fork
     // server). Instead, prove that the disposed-instance path also fires

--- a/packages/movehat/src/__tests__/harness/codeObject.deploy.test.ts
+++ b/packages/movehat/src/__tests__/harness/codeObject.deploy.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Harness, HarnessDisposedError } from "../../harness/index.js";
+import { _resetConfigCache } from "../../core/config.js";
+import {
+  CliExecutionError,
+  ModuleAlreadyDeployedError,
+  PostPublishError,
+} from "../../errors.js";
+import type {
+  ChildProcessAdapter,
+  RunInput,
+  RunResult,
+} from "../../utils/childProcessAdapter.js";
+
+/**
+ * Tests for `Harness.deployCodeObject` — exercises the new
+ * `move deploy-object` code path with the shared profile helpers
+ * lifted out of Publisher in Commit 1 of this PR.
+ *
+ * Uses the same fake-adapter + tmpdir-HOME pattern as
+ * `__tests__/deployContract.test.ts`. No real Movement CLI calls.
+ */
+describe("Harness.deployCodeObject", () => {
+  let tmpHome: string;
+  let tmpCwd: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+
+  const OBJECT_ADDRESS = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+  const TX_HASH = "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "movehat-codeobj-home-"));
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-codeobj-cwd-"));
+
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    }
+  }
+};
+`
+    );
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]
+name = "dummy"
+version = "0.0.1"
+
+[addresses]
+`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// empty\n");
+
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+      delete process.env.MH_CLI_REDEPLOY;
+      _resetConfigCache();
+    }
+  });
+
+  function makeAdapter(steps: {
+    build: RunResult;
+    deploy: RunResult;
+  }): {
+    adapter: ChildProcessAdapter;
+    calls: RunInput[];
+  } {
+    const calls: RunInput[] = [];
+    const adapter: ChildProcessAdapter = {
+      async run(input) {
+        calls.push(input);
+        if (input.args[1] === "build") return steps.build;
+        if (input.args[1] === "deploy-object") return steps.deploy;
+        if (input.args[1] === "upgrade-object") return steps.deploy;
+        throw new Error(`unexpected movement subcommand: ${input.args[1]}`);
+      },
+      spawn() {
+        throw new Error("spawn not used in codeObject tests");
+      },
+    };
+    return { adapter, calls };
+  }
+
+  function successStdout(): string {
+    return [
+      "Building package...",
+      "BUILDING dummy",
+      "Code was successfully deployed to object address " + OBJECT_ADDRESS,
+      `transaction hash: ${TX_HASH}`,
+      "{ \"Result\": { \"success\": true } }",
+    ].join("\n");
+  }
+
+  it("happy path: returns CodeObjectInfo with parsed object address + txHash and writes deployment record", async () => {
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: { exitCode: 0, stdout: successStdout(), stderr: "" },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      const result = await harness.deployCodeObject({
+        moduleName: "counter",
+        adapter,
+      });
+
+      expect(result.address).toBe(OBJECT_ADDRESS);
+      expect(result.txHash).toBe(TX_HASH);
+      expect(result.moduleName).toBe("counter");
+      expect(result.network).toBe("testnet");
+      expect(result.deployer).toBe(harness.runtime.account.accountAddress.toString());
+      expect(result.timestamp).toBeGreaterThan(0);
+
+      // Deployment file written to deployments/testnet/counter.json
+      const deploymentPath = join(tmpCwd, "deployments", "testnet", "counter.json");
+      expect(existsSync(deploymentPath)).toBe(true);
+      const saved = JSON.parse(readFileSync(deploymentPath, "utf-8"));
+      expect(saved.address).toBe(OBJECT_ADDRESS);
+      expect(saved.txHash).toBe(TX_HASH);
+
+      // Verify the CLI calls: build then deploy-object
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.args.slice(0, 2)).toEqual(["move", "build"]);
+      expect(calls[1]?.args.slice(0, 4)).toEqual([
+        "move",
+        "deploy-object",
+        "--address-name",
+        "counter",
+      ]);
+      expect(calls[1]?.args).toContain("--assume-yes");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("idempotency: re-deploying the same module throws ModuleAlreadyDeployedError and does NOT invoke the CLI", async () => {
+    // First, plant an existing deployment record by running a successful deploy.
+    const first = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: { exitCode: 0, stdout: successStdout(), stderr: "" },
+    });
+
+    const harness1 = await Harness.createLive("testnet");
+    await harness1.deployCodeObject({ moduleName: "counter", adapter: first.adapter });
+    await harness1.cleanup();
+
+    // Second deploy with same moduleName + same network — must reject.
+    const second = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: { exitCode: 0, stdout: successStdout(), stderr: "" },
+    });
+    const harness2 = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness2.deployCodeObject({ moduleName: "counter", adapter: second.adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ModuleAlreadyDeployedError);
+      const err = caught as ModuleAlreadyDeployedError;
+      expect(err.moduleName).toBe("counter");
+      expect(err.network).toBe("testnet");
+      // CLI must not have been invoked on the second attempt.
+      expect(second.calls).toHaveLength(0);
+    } finally {
+      await harness2.cleanup();
+    }
+  });
+
+  it("MH_CLI_REDEPLOY=true bypasses the idempotency check", async () => {
+    // Plant the first deployment.
+    const first = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: { exitCode: 0, stdout: successStdout(), stderr: "" },
+    });
+    const harness1 = await Harness.createLive("testnet");
+    await harness1.deployCodeObject({ moduleName: "counter", adapter: first.adapter });
+    await harness1.cleanup();
+
+    // Redeploy with the env flag — should call the CLI again.
+    process.env.MH_CLI_REDEPLOY = "true";
+    const second = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: { exitCode: 0, stdout: successStdout(), stderr: "" },
+    });
+    const harness2 = await Harness.createLive("testnet");
+    try {
+      const result = await harness2.deployCodeObject({
+        moduleName: "counter",
+        adapter: second.adapter,
+      });
+      expect(result.address).toBe(OBJECT_ADDRESS);
+      // The CLI WAS invoked the second time.
+      expect(second.calls.length).toBeGreaterThan(0);
+    } finally {
+      await harness2.cleanup();
+    }
+  });
+
+  it("build failure rethrows CliExecutionError and never writes a profile to ~/.aptos/config.yaml", async () => {
+    const { adapter } = makeAdapter({
+      build: { exitCode: 1, stdout: "", stderr: "compilation error: undefined identifier" },
+      deploy: { exitCode: 0, stdout: "", stderr: "" },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.deployCodeObject({ moduleName: "counter", adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(CliExecutionError);
+      // The profile-write happens AFTER build, so build failure should
+      // never have touched ~/.aptos/config.yaml.
+      expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("deploy-object failure rethrows AND the temp profile is removed from ~/.aptos/config.yaml in finally", async () => {
+    const { adapter } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: { exitCode: 1, stdout: "", stderr: "transaction failed: insufficient funds" },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.deployCodeObject({ moduleName: "counter", adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(CliExecutionError);
+      // The finally block must have cleaned the temp profile — file
+      // unlinked because we wrote a fresh profile-only yaml.
+      expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("output without a parseable object address throws a clear error (not CliExecutionError)", async () => {
+    const { adapter } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      deploy: {
+        exitCode: 0,
+        stdout: "deployed successfully (but no object address mentioned)",
+        stderr: "",
+      },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.deployCodeObject({ moduleName: "counter", adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      // Not a CliExecutionError — the CLI succeeded, our parser failed.
+      expect(caught).not.toBeInstanceOf(CliExecutionError);
+      expect((caught as Error).message).toMatch(/Could not parse object address/);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("fork-mode harness throws synchronously before any CLI call (covered separately for createLocal/createFork in M4 integration suite)", async () => {
+    // This case can't be tested with a real createFork (it spawns a fork
+    // server). Instead, prove that the disposed-instance path also fires
+    // synchronously: a poisoned harness throws HarnessDisposedError on
+    // property access, BEFORE any CLI call is attempted. The fork-mode
+    // guard uses the same synchronous-throw pattern.
+    const harness = await Harness.createLive("testnet");
+    await harness.cleanup();
+    expect(() => harness.deployCodeObject({ moduleName: "x" })).toThrow(
+      HarnessDisposedError
+    );
+  });
+});

--- a/packages/movehat/src/__tests__/harness/codeObject.upgrade.test.ts
+++ b/packages/movehat/src/__tests__/harness/codeObject.upgrade.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Harness } from "../../harness/index.js";
+import { _resetConfigCache } from "../../core/config.js";
+import { CliExecutionError } from "../../errors.js";
+import type {
+  ChildProcessAdapter,
+  RunInput,
+  RunResult,
+} from "../../utils/childProcessAdapter.js";
+
+describe("Harness.upgradeCodeObject", () => {
+  let tmpHome: string;
+  let tmpCwd: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+
+  const EXISTING_OBJECT =
+    "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+  const NEW_TX_HASH =
+    "0x2222222222222222222222222222222222222222222222222222222222222222";
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "movehat-codeobj-upg-home-"));
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-codeobj-upg-cwd-"));
+
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    }
+  }
+};
+`
+    );
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]
+name = "dummy"
+version = "0.0.1"
+
+[addresses]
+`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// empty\n");
+
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+      _resetConfigCache();
+    }
+  });
+
+  function makeAdapter(steps: { build: RunResult; upgrade: RunResult }): {
+    adapter: ChildProcessAdapter;
+    calls: RunInput[];
+  } {
+    const calls: RunInput[] = [];
+    const adapter: ChildProcessAdapter = {
+      async run(input) {
+        calls.push(input);
+        if (input.args[1] === "build") return steps.build;
+        if (input.args[1] === "upgrade-object") return steps.upgrade;
+        throw new Error(`unexpected movement subcommand: ${input.args[1]}`);
+      },
+      spawn() {
+        throw new Error("spawn not used in codeObject.upgrade tests");
+      },
+    };
+    return { adapter, calls };
+  }
+
+  function upgradeStdout(): string {
+    return [
+      "Building package...",
+      "BUILDING dummy",
+      "Successfully upgraded modules at object address " + EXISTING_OBJECT,
+      `transaction hash: ${NEW_TX_HASH}`,
+    ].join("\n");
+  }
+
+  it("happy path: upgrades existing object, returns DeploymentInfo with new txHash and the same (existing) address", async () => {
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      upgrade: { exitCode: 0, stdout: upgradeStdout(), stderr: "" },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      const result = await harness.upgradeCodeObject({
+        moduleName: "counter",
+        objectAddress: EXISTING_OBJECT,
+        adapter,
+      });
+
+      expect(result.address).toBe(EXISTING_OBJECT);
+      expect(result.txHash).toBe(NEW_TX_HASH);
+      expect(result.moduleName).toBe("counter");
+
+      // Saved deployment record reflects the new state.
+      const deploymentPath = join(tmpCwd, "deployments", "testnet", "counter.json");
+      expect(existsSync(deploymentPath)).toBe(true);
+      const saved = JSON.parse(readFileSync(deploymentPath, "utf-8"));
+      expect(saved.address).toBe(EXISTING_OBJECT);
+      expect(saved.txHash).toBe(NEW_TX_HASH);
+
+      // CLI args contain the required --object-address flag.
+      const upgradeCall = calls.find((c) => c.args[1] === "upgrade-object");
+      expect(upgradeCall).toBeDefined();
+      expect(upgradeCall?.args).toContain("--object-address");
+      expect(upgradeCall?.args).toContain(EXISTING_OBJECT);
+      expect(upgradeCall?.args.slice(0, 4)).toEqual([
+        "move",
+        "upgrade-object",
+        "--address-name",
+        "counter",
+      ]);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("missing objectAddress throws synchronously before any CLI call", async () => {
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      upgrade: { exitCode: 0, stdout: upgradeStdout(), stderr: "" },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.upgradeCodeObject({
+          moduleName: "counter",
+          // Intentionally empty — exercise the early-throw path.
+          objectAddress: "",
+          adapter,
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toMatch(/objectAddress/);
+      // No CLI calls should have been made.
+      expect(calls).toHaveLength(0);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("upgrade-object CLI failure rethrows AND cleans the temp profile", async () => {
+    const { adapter } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      upgrade: {
+        exitCode: 1,
+        stdout: "",
+        stderr: "upgrade failed: incompatible module",
+      },
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.upgradeCodeObject({
+          moduleName: "counter",
+          objectAddress: EXISTING_OBJECT,
+          adapter,
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(CliExecutionError);
+      // Temp profile cleaned up in finally.
+      expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/packages/movehat/src/__tests__/harness/script.test.ts
+++ b/packages/movehat/src/__tests__/harness/script.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Harness } from "../../harness/index.js";
+import { _resetConfigCache } from "../../core/config.js";
+import { CliExecutionError } from "../../errors.js";
+import type {
+  ChildProcessAdapter,
+  RunInput,
+  RunResult,
+} from "../../utils/childProcessAdapter.js";
+
+describe("Harness.runMoveScript", () => {
+  let tmpHome: string;
+  let tmpCwd: string;
+  let origHome: string | undefined;
+  let origCwd: string;
+
+  const TX_HASH =
+    "0x9999999999999999999999999999999999999999999999999999999999999999";
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "movehat-script-home-"));
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-script-cwd-"));
+
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    }
+  }
+};
+`
+    );
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]\nname = "dummy"\nversion = "0.0.1"\n\n[addresses]\n`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// empty\n");
+
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+      _resetConfigCache();
+    }
+  });
+
+  function makeAdapter(result: RunResult): {
+    adapter: ChildProcessAdapter;
+    calls: RunInput[];
+  } {
+    const calls: RunInput[] = [];
+    const adapter: ChildProcessAdapter = {
+      async run(input) {
+        calls.push(input);
+        if (input.args[1] === "run-script") return result;
+        throw new Error(`unexpected movement subcommand: ${input.args[1]}`);
+      },
+      spawn() {
+        throw new Error("spawn not used in script tests");
+      },
+    };
+    return { adapter, calls };
+  }
+
+  function successStdout(): string {
+    return [
+      `transaction hash: ${TX_HASH}`,
+      '{ "Result": { "success": true, "vm_status": "Executed successfully" } }',
+    ].join("\n");
+  }
+
+  it("happy path with .move source: uses --script-path and returns parsed MoveScriptResult", async () => {
+    const scriptPath = join(tmpCwd, "scripts", "init.move");
+    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    writeFileSync(scriptPath, "// dummy move script\n");
+
+    const { adapter, calls } = makeAdapter({
+      exitCode: 0,
+      stdout: successStdout(),
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      const result = await harness.runMoveScript({
+        scriptPath,
+        args: ["u64:42", "bool:true"],
+        typeArgs: ["0x1::aptos_coin::AptosCoin"],
+        adapter,
+      });
+
+      expect(result.txHash).toBe(TX_HASH);
+      expect(result.success).toBe(true);
+      expect(result.vmStatus).toBe("Executed successfully");
+
+      expect(calls).toHaveLength(1);
+      const call = calls[0]!;
+      expect(call.args.slice(0, 2)).toEqual(["move", "run-script"]);
+      expect(call.args).toContain("--script-path");
+      expect(call.args).not.toContain("--compiled-script-path");
+      expect(call.args).toContain(scriptPath);
+      expect(call.args).toContain("--type-args");
+      expect(call.args).toContain("0x1::aptos_coin::AptosCoin");
+      expect(call.args).toContain("--args");
+      expect(call.args).toContain("u64:42");
+      expect(call.args).toContain("bool:true");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("happy path with .mv compiled: uses --compiled-script-path", async () => {
+    const scriptPath = join(tmpCwd, "build", "init.mv");
+    mkdirSync(join(tmpCwd, "build"), { recursive: true });
+    writeFileSync(scriptPath, "compiled bytecode placeholder");
+
+    const { adapter, calls } = makeAdapter({
+      exitCode: 0,
+      stdout: successStdout(),
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      const result = await harness.runMoveScript({ scriptPath, adapter });
+
+      expect(result.txHash).toBe(TX_HASH);
+      const call = calls[0]!;
+      expect(call.args).toContain("--compiled-script-path");
+      expect(call.args).not.toContain("--script-path");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("unsupported extension throws synchronously before any CLI call", async () => {
+    const scriptPath = join(tmpCwd, "notes.txt");
+    writeFileSync(scriptPath, "not a script");
+
+    const { adapter, calls } = makeAdapter({
+      exitCode: 0,
+      stdout: successStdout(),
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.runMoveScript({ scriptPath, adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toMatch(/unsupported script extension/i);
+      expect(calls).toHaveLength(0);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("missing script file throws before any CLI call", async () => {
+    const scriptPath = join(tmpCwd, "scripts", "missing.move");
+    const { adapter, calls } = makeAdapter({
+      exitCode: 0,
+      stdout: successStdout(),
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.runMoveScript({ scriptPath, adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toMatch(/script not found/i);
+      expect(calls).toHaveLength(0);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("CLI failure rethrows CliExecutionError and removes the temp profile", async () => {
+    const scriptPath = join(tmpCwd, "scripts", "fail.move");
+    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    writeFileSync(scriptPath, "// dummy\n");
+
+    const { adapter } = makeAdapter({
+      exitCode: 1,
+      stdout: "",
+      stderr: "compile error: undefined identifier",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.runMoveScript({ scriptPath, adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(CliExecutionError);
+      // Temp profile cleaned up in finally.
+      expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("CLI succeeded but output has no txHash: throws clear non-CliExecutionError", async () => {
+    const scriptPath = join(tmpCwd, "scripts", "weird.move");
+    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    writeFileSync(scriptPath, "// dummy\n");
+
+    const { adapter } = makeAdapter({
+      exitCode: 0,
+      stdout: "ran successfully but no hash here",
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      let caught: unknown;
+      try {
+        await harness.runMoveScript({ scriptPath, adapter });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught).not.toBeInstanceOf(CliExecutionError);
+      expect((caught as Error).message).toMatch(/Could not parse transaction hash/);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("`success: false` in Result JSON surfaces in MoveScriptResult.success", async () => {
+    const scriptPath = join(tmpCwd, "scripts", "bad.move");
+    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    writeFileSync(scriptPath, "// dummy\n");
+
+    const { adapter } = makeAdapter({
+      exitCode: 0,
+      stdout: [
+        `transaction hash: ${TX_HASH}`,
+        '{ "Result": { "success": false, "vm_status": "ABORTED" } }',
+      ].join("\n"),
+      stderr: "",
+    });
+
+    const harness = await Harness.createLive("testnet");
+    try {
+      const result = await harness.runMoveScript({ scriptPath, adapter });
+      expect(result.txHash).toBe(TX_HASH);
+      expect(result.success).toBe(false);
+      expect(result.vmStatus).toBe("ABORTED");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/packages/movehat/src/__tests__/harness/view.test.ts
+++ b/packages/movehat/src/__tests__/harness/view.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Harness } from "../../harness/index.js";
+import { _resetConfigCache } from "../../core/config.js";
+
+/**
+ * Tests for `Harness.runViewFunction` — the SDK delegation path.
+ *
+ * The Aptos SDK isn't behind an injectable adapter, so we monkey-patch
+ * `harness.runtime.aptos.view` after `createLive`. One-off for M2.3.
+ * Acceptable here because the function under test is a 6-line wrapper
+ * that only forwards options.
+ */
+describe("Harness.runViewFunction", () => {
+  let tmpCwd: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-view-"));
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet"
+    }
+  }
+};
+`
+    );
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]\nname = "dummy"\nversion = "0.0.1"\n\n[addresses]\n`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// empty\n");
+
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+      _resetConfigCache();
+    }
+  });
+
+  it("happy path: forwards correct payload to aptos.view and returns the raw result array", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      const fake = vi.fn().mockResolvedValue([42n, "hello"]);
+      // Monkey-patch — the SDK boundary isn't behind an adapter.
+      harness.runtime.aptos.view = fake as never;
+
+      const result = await harness.runViewFunction({
+        function: "0xCAFE::counter::get",
+        typeArguments: ["0x1::aptos_coin::AptosCoin"],
+        functionArguments: ["0xdeployer", 1n],
+      });
+
+      expect(result).toEqual([42n, "hello"]);
+      expect(fake).toHaveBeenCalledTimes(1);
+      expect(fake).toHaveBeenCalledWith({
+        payload: {
+          function: "0xCAFE::counter::get",
+          typeArguments: ["0x1::aptos_coin::AptosCoin"],
+          functionArguments: ["0xdeployer", 1n],
+        },
+      });
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("defaults typeArguments and functionArguments to empty arrays when omitted", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      const fake = vi.fn().mockResolvedValue([0n]);
+      harness.runtime.aptos.view = fake as never;
+
+      const result = await harness.runViewFunction({
+        function: "0xCAFE::counter::count",
+      });
+
+      expect(result).toEqual([0n]);
+      expect(fake).toHaveBeenCalledWith({
+        payload: {
+          function: "0xCAFE::counter::count",
+          typeArguments: [],
+          functionArguments: [],
+        },
+      });
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("passes empty results through unchanged", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      const fake = vi.fn().mockResolvedValue([]);
+      harness.runtime.aptos.view = fake as never;
+
+      const result = await harness.runViewFunction({
+        function: "0xCAFE::nothing::nothing",
+      });
+
+      expect(result).toEqual([]);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("rethrows errors from aptos.view", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      const fake = vi.fn().mockRejectedValue(new Error("module not found"));
+      harness.runtime.aptos.view = fake as never;
+
+      await expect(
+        harness.runViewFunction({ function: "0xCAFE::missing::get" })
+      ).rejects.toThrow(/module not found/);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -1,17 +1,6 @@
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  unlinkSync,
-  writeFileSync,
-} from "fs";
-import { readFile } from "fs/promises";
 import { homedir } from "os";
-import { dirname, join } from "path";
+import { join } from "path";
 import { randomUUID } from "crypto";
-import * as yaml from "js-yaml";
 import { Account } from "@aptos-labs/ts-sdk";
 import { MovehatConfig } from "../types/config.js";
 import { extractNamedAddresses } from "../commands/compile.js";
@@ -26,161 +15,14 @@ import { CliExecutionError, ModuleAlreadyDeployedError, PostPublishError } from 
 import { runCli } from "../utils/runCli.js";
 import { logger } from "../ui/index.js";
 import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
-
-/**
- * In-process serializer for `~/.aptos/config.yaml` mutations. Without it,
- * two concurrent `Publisher.deploy()` calls would race in the
- * read-modify-write cycle and the second writer would silently drop the
- * first deploy's profile. See #37.
- */
-let yamlLock: Promise<unknown> = Promise.resolve();
-function withYamlLock<T>(fn: () => Promise<T>): Promise<T> {
-  const prev = yamlLock;
-  // .then(success, failure) — continue even if the previous holder rejected,
-  // so a failure in one deploy doesn't poison the lock for the others.
-  const next = prev.then(
-    () => fn(),
-    () => fn()
-  );
-  yamlLock = next.catch(() => {}); // swallow on the shared chain; caller still gets the original
-  return next;
-}
-
-interface ProfileData {
-  private_key: string;
-  public_key: string;
-  account: string;
-  rest_url: string;
-}
-
-/**
- * Atomic write: write payload to a temp sibling → chmod the temp to 0o600
- * → rename over the target. The chmod-before-rename order eliminates a
- * window where the target file could be observable with default umask
- * perms (typically 0o644) while carrying the private key.
- */
-function atomicWriteYaml(path: string, content: string): void {
-  const tmpPath = `${path}.tmp.${randomUUID().slice(0, 8)}`;
-  writeFileSync(tmpPath, content, { mode: 0o600 });
-  chmodSync(tmpPath, 0o600); // defense in depth in case umask filtered the open mode
-  renameSync(tmpPath, path);
-}
-
-/** Add the deploy's profile to ~/.aptos/config.yaml. Creates the file if absent. */
-interface AptosConfigYaml {
-  profiles?: Record<string, ProfileData>;
-  [key: string]: unknown;
-}
-
-async function addProfile(
-  configPath: string,
-  name: string,
-  data: ProfileData
-): Promise<void> {
-  const configDir = dirname(configPath);
-  if (!existsSync(configDir)) {
-    mkdirSync(configDir, { recursive: true, mode: 0o700 });
-  }
-  let yamlObj: AptosConfigYaml = {};
-  if (existsSync(configPath)) {
-    const raw = await readFile(configPath, "utf-8");
-    yamlObj = (yaml.load(raw) as AptosConfigYaml) || {};
-  }
-  if (!yamlObj.profiles) yamlObj.profiles = {};
-  yamlObj.profiles[name] = data;
-  atomicWriteYaml(configPath, yaml.dump(yamlObj));
-}
-
-/**
- * Remove the deploy's profile from ~/.aptos/config.yaml. Idempotent —
- * a missing file or missing profile is a no-op. If removal leaves the
- * yaml with only an empty `profiles:` block, the whole file is unlinked
- * to preserve the "didn't exist before" semantic for the first-ever deploy.
- */
-async function removeProfile(configPath: string, name: string): Promise<void> {
-  if (!existsSync(configPath)) return;
-  const raw = await readFile(configPath, "utf-8");
-  const yamlObj: AptosConfigYaml = (yaml.load(raw) as AptosConfigYaml) || {};
-  if (!yamlObj.profiles || !(name in yamlObj.profiles)) return;
-  delete yamlObj.profiles[name];
-
-  const profilesEmpty = Object.keys(yamlObj.profiles).length === 0;
-  const onlyProfilesKey =
-    Object.keys(yamlObj).length === 1 && "profiles" in yamlObj;
-  if (profilesEmpty && onlyProfilesKey) {
-    // We created this file fresh; remove it.
-    try {
-      unlinkSync(configPath);
-    } catch {
-      // best-effort
-    }
-    return;
-  }
-  atomicWriteYaml(configPath, yaml.dump(yamlObj));
-}
-
-/**
- * Synchronous twin of `removeProfile` for the SIGINT/SIGTERM handler.
- * The event loop is dead by the time the handler runs — we cannot
- * await. Bypasses the async mutex because signal handlers are
- * sequential by construction; the operation is idempotent so a
- * benign double-delete (handler then finally, or vice versa) is fine.
- */
-function removeProfileSync(configPath: string, name: string): void {
-  try {
-    if (!existsSync(configPath)) return;
-    const raw = readFileSync(configPath, "utf-8");
-    const yamlObj: AptosConfigYaml = (yaml.load(raw) as AptosConfigYaml) || {};
-    if (!yamlObj.profiles || !(name in yamlObj.profiles)) return;
-    delete yamlObj.profiles[name];
-
-    const profilesEmpty = Object.keys(yamlObj.profiles).length === 0;
-    const onlyProfilesKey =
-      Object.keys(yamlObj).length === 1 && "profiles" in yamlObj;
-    if (profilesEmpty && onlyProfilesKey) {
-      unlinkSync(configPath);
-      return;
-    }
-    atomicWriteYaml(configPath, yaml.dump(yamlObj));
-  } catch {
-    // Signal handlers should never throw — swallow and exit. Better to
-    // leave a stale profile (recoverable by re-running the deploy) than
-    // to crash the parent process mid-shutdown.
-  }
-}
-
-/**
- * Process-level signal handling. A single registered handler iterates
- * the per-deploy cleanup callbacks. Install-once because multiple
- * concurrent deploys share the same parent process — installing per
- * deploy would re-add the listener and exceed Node's max-listeners
- * warning threshold under heavy parallelism.
- */
-const cleanupCallbacks = new Set<() => void>();
-let signalHandlerInstalled = false;
-
-function ensureSignalHandler(): void {
-  if (signalHandlerInstalled) return;
-  signalHandlerInstalled = true;
-  const handler = (sig: NodeJS.Signals) => {
-    // Synchronous cleanup of every active deploy's profile entry.
-    for (const cb of [...cleanupCallbacks]) {
-      try {
-        cb();
-      } catch {
-        /* sync best-effort */
-      }
-    }
-    // Defer the actual exit one tick so other listeners (vitest's own
-    // SIGINT handler, app-level shutdown hooks) still get to run.
-    // Without this we'd stomp on vitest's afterEach if a dev Ctrl+C'd
-    // a test run mid-suite.
-    const code = sig === "SIGTERM" ? 143 : 130;
-    setImmediate(() => process.exit(code));
-  };
-  process.on("SIGINT", handler);
-  process.on("SIGTERM", handler);
-}
+import {
+  withYamlLock,
+  addProfile,
+  removeProfile,
+  removeProfileSync,
+  ensureSignalHandler,
+  cleanupCallbacks,
+} from "./movementProfile.js";
 
 /** @internal */
 export interface PublisherDeps {

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -23,6 +23,7 @@ import {
   ensureSignalHandler,
   cleanupCallbacks,
 } from "./movementProfile.js";
+import { parseTxHash } from "../utils/parseCliOutput.js";
 
 /** @internal */
 export interface PublisherDeps {
@@ -250,22 +251,10 @@ export class Publisher {
         cleanupCallbacks.delete(syncCleanup);
       }
 
-      // Extract transaction hash from output
-      // Look for patterns like "Transaction hash: 0x..." or "Txn: 0x..." or just a 64-char hex
-      // The regex tries to match with context first, then falls back to any 64-char hex
-      let txHash: string | undefined;
-      const txHashMatchWithContext = publishOut.match(
-        /(?:transaction\s*(?:hash)?|txn\s*(?:hash)?|hash):\s*(0x[a-fA-F0-9]{64})\b/i
-      );
-      if (txHashMatchWithContext) {
-        txHash = txHashMatchWithContext[1];
-      } else {
-        // Fallback: try to find any 64-char hex string (exactly, not more)
-        const txHashMatch = publishOut.match(/\b(0x[a-fA-F0-9]{64})\b/);
-        if (txHashMatch) {
-          txHash = txHashMatch[1];
-        }
-      }
+      // Extract transaction hash from output via the shared helper
+      // (`utils/parseCliOutput.ts`). Same regex pair as before; lifted
+      // for reuse by harness/codeObject.ts and harness/script.ts.
+      const txHash = parseTxHash(publishOut);
 
       logger.success("Module published successfully!");
 

--- a/packages/movehat/src/core/movementProfile.ts
+++ b/packages/movehat/src/core/movementProfile.ts
@@ -1,0 +1,179 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { readFile } from "fs/promises";
+import { dirname } from "path";
+import { randomUUID } from "crypto";
+import * as yaml from "js-yaml";
+
+/**
+ * Shared helpers for working with the Movement CLI's `~/.aptos/config.yaml`
+ * profile file and the SIGINT/SIGTERM cleanup pipeline.
+ *
+ * Extracted from `core/Publisher.ts` so both the existing `move publish`
+ * flow (`Publisher`) and the new `move deploy-object` / `upgrade-object`
+ * flows (`harness/codeObject.ts`) can share the bug #36 / #37 / #43
+ * hardening without duplicating it.
+ *
+ * @internal — not exported from `src/index.ts`.
+ */
+
+/**
+ * In-process serializer for `~/.aptos/config.yaml` mutations. Without it,
+ * two concurrent profile writes would race in the read-modify-write cycle
+ * and the second writer would silently drop the first's profile. See #37.
+ */
+let yamlLock: Promise<unknown> = Promise.resolve();
+export function withYamlLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = yamlLock;
+  // .then(success, failure) — continue even if the previous holder rejected,
+  // so a failure in one deploy doesn't poison the lock for the others.
+  const next = prev.then(
+    () => fn(),
+    () => fn()
+  );
+  yamlLock = next.catch(() => {}); // swallow on the shared chain; caller still gets the original
+  return next;
+}
+
+export interface ProfileData {
+  private_key: string;
+  public_key: string;
+  account: string;
+  rest_url: string;
+}
+
+interface AptosConfigYaml {
+  profiles?: Record<string, ProfileData>;
+  [key: string]: unknown;
+}
+
+/**
+ * Atomic write: write payload to a temp sibling → chmod the temp to 0o600
+ * → rename over the target. The chmod-before-rename order eliminates a
+ * window where the target file could be observable with default umask
+ * perms (typically 0o644) while carrying the private key.
+ */
+function atomicWriteYaml(path: string, content: string): void {
+  const tmpPath = `${path}.tmp.${randomUUID().slice(0, 8)}`;
+  writeFileSync(tmpPath, content, { mode: 0o600 });
+  chmodSync(tmpPath, 0o600); // defense in depth in case umask filtered the open mode
+  renameSync(tmpPath, path);
+}
+
+/** Add the deploy's profile to ~/.aptos/config.yaml. Creates the file if absent. */
+export async function addProfile(
+  configPath: string,
+  name: string,
+  data: ProfileData
+): Promise<void> {
+  const configDir = dirname(configPath);
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  }
+  let yamlObj: AptosConfigYaml = {};
+  if (existsSync(configPath)) {
+    const raw = await readFile(configPath, "utf-8");
+    yamlObj = (yaml.load(raw) as AptosConfigYaml) || {};
+  }
+  if (!yamlObj.profiles) yamlObj.profiles = {};
+  yamlObj.profiles[name] = data;
+  atomicWriteYaml(configPath, yaml.dump(yamlObj));
+}
+
+/**
+ * Remove the deploy's profile from ~/.aptos/config.yaml. Idempotent —
+ * a missing file or missing profile is a no-op. If removal leaves the
+ * yaml with only an empty `profiles:` block, the whole file is unlinked
+ * to preserve the "didn't exist before" semantic for the first-ever deploy.
+ */
+export async function removeProfile(configPath: string, name: string): Promise<void> {
+  if (!existsSync(configPath)) return;
+  const raw = await readFile(configPath, "utf-8");
+  const yamlObj: AptosConfigYaml = (yaml.load(raw) as AptosConfigYaml) || {};
+  if (!yamlObj.profiles || !(name in yamlObj.profiles)) return;
+  delete yamlObj.profiles[name];
+
+  const profilesEmpty = Object.keys(yamlObj.profiles).length === 0;
+  const onlyProfilesKey =
+    Object.keys(yamlObj).length === 1 && "profiles" in yamlObj;
+  if (profilesEmpty && onlyProfilesKey) {
+    // We created this file fresh; remove it.
+    try {
+      unlinkSync(configPath);
+    } catch {
+      // best-effort
+    }
+    return;
+  }
+  atomicWriteYaml(configPath, yaml.dump(yamlObj));
+}
+
+/**
+ * Synchronous twin of `removeProfile` for the SIGINT/SIGTERM handler.
+ * The event loop is dead by the time the handler runs — we cannot
+ * await. Bypasses the async mutex because signal handlers are
+ * sequential by construction; the operation is idempotent so a
+ * benign double-delete (handler then finally, or vice versa) is fine.
+ */
+export function removeProfileSync(configPath: string, name: string): void {
+  try {
+    if (!existsSync(configPath)) return;
+    const raw = readFileSync(configPath, "utf-8");
+    const yamlObj: AptosConfigYaml = (yaml.load(raw) as AptosConfigYaml) || {};
+    if (!yamlObj.profiles || !(name in yamlObj.profiles)) return;
+    delete yamlObj.profiles[name];
+
+    const profilesEmpty = Object.keys(yamlObj.profiles).length === 0;
+    const onlyProfilesKey =
+      Object.keys(yamlObj).length === 1 && "profiles" in yamlObj;
+    if (profilesEmpty && onlyProfilesKey) {
+      unlinkSync(configPath);
+      return;
+    }
+    atomicWriteYaml(configPath, yaml.dump(yamlObj));
+  } catch {
+    // Signal handlers should never throw — swallow and exit. Better to
+    // leave a stale profile (recoverable by re-running the deploy) than
+    // to crash the parent process mid-shutdown.
+  }
+}
+
+/**
+ * Process-level signal handling. A single registered handler iterates
+ * the per-deploy cleanup callbacks. Install-once because multiple
+ * concurrent deploys share the same parent process — installing per
+ * deploy would re-add the listener and exceed Node's max-listeners
+ * warning threshold under heavy parallelism.
+ */
+export const cleanupCallbacks = new Set<() => void>();
+let signalHandlerInstalled = false;
+
+export function ensureSignalHandler(): void {
+  if (signalHandlerInstalled) return;
+  signalHandlerInstalled = true;
+  const handler = (sig: NodeJS.Signals) => {
+    // Synchronous cleanup of every active deploy's profile entry.
+    for (const cb of [...cleanupCallbacks]) {
+      try {
+        cb();
+      } catch {
+        /* sync best-effort */
+      }
+    }
+    // Defer the actual exit one tick so other listeners (vitest's own
+    // SIGINT handler, app-level shutdown hooks) still get to run.
+    // Without this we'd stomp on vitest's afterEach if a dev Ctrl+C'd
+    // a test run mid-suite.
+    const code = sig === "SIGTERM" ? 143 : 130;
+    setImmediate(() => process.exit(code));
+  };
+  process.on("SIGINT", handler);
+  process.on("SIGTERM", handler);
+}

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -1,0 +1,163 @@
+import type { MovehatRuntime } from "../types/runtime.js";
+import type { LocalNodeManager } from "../node/LocalNodeManager.js";
+import type { ForkServer } from "../fork/server.js";
+import type { ForkManager } from "../fork/manager.js";
+import type { LocalTestOptions } from "../types/config.js";
+import { setupLocalTesting } from "../helpers/setupLocalTesting.js";
+import { initRuntime } from "../runtime.js";
+import { createHarnessProxy } from "./proxy.js";
+
+export type HarnessMode = "local" | "fork" | "live";
+
+interface HarnessInit {
+  mode: HarnessMode;
+  runtime: MovehatRuntime;
+  localNode?: LocalNodeManager;
+  forkServer?: ForkServer;
+  forkManager?: ForkManager;
+}
+
+/**
+ * Hardhat-style testing harness for Movehat.
+ *
+ * Construct via the static factories — `createLocal`, `createFork`,
+ * `createLive` — never via `new Harness(...)`. The returned instance is
+ * a Proxy that synchronously throws {@link HarnessDisposedError} on any
+ * post-`cleanup()` call to one of the deployment / script / view methods.
+ *
+ * Methods `deployCodeObject`, `upgradeCodeObject`, `runViewFunction`,
+ * and `runMoveScript` are stubbed in M2.1 — they throw at runtime until
+ * M2.2/M2.3 lands. The type surface is complete so callers and docs can
+ * be written against it ahead of time.
+ *
+ * AccountManager note: as of M2.1 the underlying account pool is a
+ * process-wide static (see `core/AccountManager.ts`). Two Harness
+ * instances in the same process share account labels; this is the same
+ * constraint that already governs `setupTestFixture`. A per-Harness pool
+ * is a future change.
+ */
+export class Harness {
+  public readonly mode: HarnessMode;
+  public readonly runtime: MovehatRuntime;
+
+  /** @internal */
+  public readonly localNode?: LocalNodeManager;
+  /** @internal */
+  public readonly forkServer?: ForkServer;
+  /** @internal */
+  public readonly forkManager?: ForkManager;
+
+  private _poisoned = false;
+
+  private constructor(init: HarnessInit) {
+    this.mode = init.mode;
+    this.runtime = init.runtime;
+    if (init.localNode) this.localNode = init.localNode;
+    if (init.forkServer) this.forkServer = init.forkServer;
+    if (init.forkManager) this.forkManager = init.forkManager;
+  }
+
+  /** True once `cleanup()` has been awaited at least once. */
+  public get poisoned(): boolean {
+    return this._poisoned;
+  }
+
+  /**
+   * Spin up a local Movement node and return a Harness bound to it.
+   *
+   * Forwards to `setupLocalTesting({ mode: 'local-node', ... })` so all
+   * existing options (`nodeApiPort`, `accountLabels`, `autoDeploy`, ...)
+   * apply unchanged.
+   */
+  static async createLocal(options: LocalTestOptions = {}): Promise<Harness> {
+    const ctx = await setupLocalTesting({ ...options, mode: "local-node" });
+    const init: HarnessInit = {
+      mode: "local",
+      runtime: ctx.runtime,
+    };
+    if (ctx.localNode) init.localNode = ctx.localNode;
+    const instance = new Harness(init);
+    return createHarnessProxy(instance, () => instance._poisoned);
+  }
+
+  /**
+   * Create a fork-mode Harness reading from a snapshot of `network`.
+   *
+   * Fork mode is read-only: `deployCodeObject`, `upgradeCodeObject`, and
+   * `runMoveScript` will throw with a message pointing at `createLocal`
+   * once their real bodies land in M2.2/M2.3. `runViewFunction` works.
+   *
+   * @param network - Network to fork (e.g. `"testnet"`).
+   * @param _apiKey - Reserved for M2.2; if non-undefined a TODO will fire.
+   */
+  static async createFork(network: string, _apiKey?: string): Promise<Harness> {
+    if (_apiKey !== undefined) {
+      // TODO(M2.2): plumb into MovementApiClient headers when the
+      // fork manager needs authenticated upstream reads.
+    }
+    const ctx = await setupLocalTesting({ mode: "fork", forkNetwork: network });
+    const init: HarnessInit = {
+      mode: "fork",
+      runtime: ctx.runtime,
+    };
+    if (ctx.forkServer) init.forkServer = ctx.forkServer;
+    if (ctx.forkManager) init.forkManager = ctx.forkManager;
+    const instance = new Harness(init);
+    return createHarnessProxy(instance, () => instance._poisoned);
+  }
+
+  /**
+   * Bind a Harness to a real running network (testnet, mainnet, or any
+   * custom network defined in `movehat.config.ts`). No local process is
+   * spawned; transactions are submitted to the configured RPC.
+   *
+   * @param network - Named network from movehat.config.ts.
+   * @param _faucetUrl - Reserved for M2.2 (auto-fund on networks with a faucet).
+   */
+  static async createLive(network: string, _faucetUrl?: string): Promise<Harness> {
+    const runtime = await initRuntime({ network });
+    const instance = new Harness({ mode: "live", runtime });
+    return createHarnessProxy(instance, () => instance._poisoned);
+  }
+
+  /**
+   * Release resources owned by this harness (local node or fork server)
+   * and poison it. Idempotent: subsequent calls are no-ops.
+   *
+   * After `cleanup()` resolves, any call to `deployCodeObject`,
+   * `upgradeCodeObject`, `runViewFunction`, or `runMoveScript` throws
+   * `HarnessDisposedError` synchronously on property access.
+   */
+  async cleanup(): Promise<void> {
+    if (this._poisoned) return;
+    this._poisoned = true;
+    if (this.localNode) {
+      await this.localNode.stop().catch(() => {});
+    }
+    if (this.forkServer) {
+      await this.forkServer.stop().catch(() => {});
+    }
+  }
+
+  // ---- Stubbed methods (real bodies land in M2.2 / M2.3) ----
+
+  /** @stub M2.2 */
+  async deployCodeObject(_options: unknown): Promise<unknown> {
+    throw new Error("Harness.deployCodeObject is not yet implemented (M2.2).");
+  }
+
+  /** @stub M2.2 */
+  async upgradeCodeObject(_options: unknown): Promise<unknown> {
+    throw new Error("Harness.upgradeCodeObject is not yet implemented (M2.2).");
+  }
+
+  /** @stub M2.3 */
+  async runViewFunction(_options: unknown): Promise<unknown> {
+    throw new Error("Harness.runViewFunction is not yet implemented (M2.3).");
+  }
+
+  /** @stub M2.3 */
+  async runMoveScript(_options: unknown): Promise<unknown> {
+    throw new Error("Harness.runMoveScript is not yet implemented (M2.3).");
+  }
+}

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -7,11 +7,16 @@ import type {
   DeployCodeObjectOptions,
   UpgradeCodeObjectOptions,
   CodeObjectInfo,
+  RunViewFunctionOptions,
+  RunMoveScriptOptions,
+  MoveScriptResult,
 } from "../types/harness.js";
 import { setupLocalTesting } from "../helpers/setupLocalTesting.js";
 import { initRuntime } from "../runtime.js";
 import { createHarnessProxy } from "./proxy.js";
 import { deployCodeObject, upgradeCodeObject } from "./codeObject.js";
+import { runViewFunction } from "./view.js";
+import { runMoveScript } from "./script.js";
 
 export type HarnessMode = "local" | "fork" | "live";
 
@@ -185,13 +190,34 @@ export class Harness {
     return upgradeCodeObject(this.runtime, options);
   }
 
-  /** @stub M2.3 */
-  async runViewFunction(_options: unknown): Promise<unknown> {
-    throw new Error("Harness.runViewFunction is not yet implemented (M2.3).");
+  /**
+   * Execute a Move view function via the Aptos SDK.
+   *
+   * Returns the raw view-function result array. For single-value
+   * returns, destructure: `const [count] = await harness.runViewFunction(...)`.
+   *
+   * Works on all 3 harness modes (createLocal, createFork, createLive)
+   * — view functions are read-only.
+   */
+  async runViewFunction(options: RunViewFunctionOptions): Promise<unknown[]> {
+    return runViewFunction(this.runtime, options);
   }
 
-  /** @stub M2.3 */
-  async runMoveScript(_options: unknown): Promise<unknown> {
-    throw new Error("Harness.runMoveScript is not yet implemented (M2.3).");
+  /**
+   * Execute a Move script via `movement move run-script`.
+   *
+   * Accepts either a `.move` source path (CLI auto-compiles) or a
+   * pre-compiled `.mv` bytecode path. Other extensions throw
+   * synchronously.
+   *
+   * Not available on fork-mode harnesses (forks are read-only).
+   */
+  async runMoveScript(options: RunMoveScriptOptions): Promise<MoveScriptResult> {
+    if (this.mode === "fork") {
+      throw new Error(
+        "Harness.createFork is read-only; script execution requires Harness.createLocal or createLive."
+      );
+    }
+    return runMoveScript(this.runtime, options);
   }
 }

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -3,9 +3,15 @@ import type { LocalNodeManager } from "../node/LocalNodeManager.js";
 import type { ForkServer } from "../fork/server.js";
 import type { ForkManager } from "../fork/manager.js";
 import type { LocalTestOptions } from "../types/config.js";
+import type {
+  DeployCodeObjectOptions,
+  UpgradeCodeObjectOptions,
+  CodeObjectInfo,
+} from "../types/harness.js";
 import { setupLocalTesting } from "../helpers/setupLocalTesting.js";
 import { initRuntime } from "../runtime.js";
 import { createHarnessProxy } from "./proxy.js";
+import { deployCodeObject, upgradeCodeObject } from "./codeObject.js";
 
 export type HarnessMode = "local" | "fork" | "live";
 
@@ -139,16 +145,44 @@ export class Harness {
     }
   }
 
-  // ---- Stubbed methods (real bodies land in M2.2 / M2.3) ----
-
-  /** @stub M2.2 */
-  async deployCodeObject(_options: unknown): Promise<unknown> {
-    throw new Error("Harness.deployCodeObject is not yet implemented (M2.2).");
+  /**
+   * Deploy a Move package as a code object via `movement move deploy-object`.
+   *
+   * The derived object address is bound to `options.moduleName` as a
+   * named address at compile time, then captured into the returned
+   * {@link CodeObjectInfo.address} for later use with
+   * `harness.runtime.getContract(address, moduleName)`.
+   *
+   * Not available on fork-mode harnesses (forks are read-only). Calling
+   * this on a `Harness.createFork(...)` instance throws synchronously.
+   */
+  async deployCodeObject(options: DeployCodeObjectOptions): Promise<CodeObjectInfo> {
+    if (this.mode === "fork") {
+      throw new Error(
+        "Harness.createFork is read-only; code-object deployment requires Harness.createLocal or createLive."
+      );
+    }
+    return deployCodeObject(this.runtime, options);
   }
 
-  /** @stub M2.2 */
-  async upgradeCodeObject(_options: unknown): Promise<unknown> {
-    throw new Error("Harness.upgradeCodeObject is not yet implemented (M2.2).");
+  /**
+   * Upgrade an existing code object via `movement move upgrade-object`.
+   *
+   * Requires {@link UpgradeCodeObjectOptions.objectAddress} (the existing
+   * on-chain object). Overwrites the local deployment record's timestamp
+   * + txHash; address stays the same.
+   *
+   * Not available on fork-mode harnesses (forks are read-only).
+   */
+  async upgradeCodeObject(
+    options: UpgradeCodeObjectOptions
+  ): Promise<CodeObjectInfo> {
+    if (this.mode === "fork") {
+      throw new Error(
+        "Harness.createFork is read-only; code-object upgrade requires Harness.createLocal or createLive."
+      );
+    }
+    return upgradeCodeObject(this.runtime, options);
   }
 
   /** @stub M2.3 */

--- a/packages/movehat/src/harness/codeObject.ts
+++ b/packages/movehat/src/harness/codeObject.ts
@@ -55,6 +55,7 @@ export async function deployCodeObject(
   return executeMovementMoveObject({
     runtime,
     moduleName: options.moduleName,
+    addressName: options.addressName,
     packageDir: options.packageDir,
     namedAddresses: options.namedAddresses,
     includedArtifacts: options.includedArtifacts,
@@ -87,6 +88,7 @@ export async function upgradeCodeObject(
   return executeMovementMoveObject({
     runtime,
     moduleName: options.moduleName,
+    addressName: options.addressName,
     packageDir: options.packageDir,
     namedAddresses: options.namedAddresses,
     includedArtifacts: options.includedArtifacts,
@@ -101,6 +103,11 @@ export async function upgradeCodeObject(
 interface ExecuteOptions {
   runtime: MovehatRuntime;
   moduleName: string;
+  /**
+   * Move.toml named address for the `--address-name` CLI flag.
+   * Defaults to `moduleName` when undefined.
+   */
+  addressName?: string | undefined;
   packageDir?: string | undefined;
   namedAddresses?: Record<string, string> | undefined;
   includedArtifacts?: "none" | "sparse" | "all" | undefined;
@@ -246,7 +253,7 @@ async function executeMovementMoveObject(
             "move",
             subcommand,
             "--address-name",
-            moduleName,
+            opts.addressName ?? moduleName,
             "--package-dir",
             safeDir,
             "--url",

--- a/packages/movehat/src/harness/codeObject.ts
+++ b/packages/movehat/src/harness/codeObject.ts
@@ -1,0 +1,394 @@
+import { homedir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import type { MovehatRuntime } from "../types/runtime.js";
+import type {
+  DeployCodeObjectOptions,
+  UpgradeCodeObjectOptions,
+  CodeObjectInfo,
+} from "../types/harness.js";
+import { extractNamedAddresses } from "../commands/compile.js";
+import {
+  saveDeployment,
+  loadDeployment,
+  validateSafeName,
+  type DeploymentInfo,
+} from "../core/deployments.js";
+import { validatePathSafety, validateProfileSafety } from "../core/shell.js";
+import {
+  CliExecutionError,
+  ModuleAlreadyDeployedError,
+  PostPublishError,
+} from "../errors.js";
+import { runCli } from "../utils/runCli.js";
+import { logger } from "../ui/index.js";
+import {
+  withYamlLock,
+  addProfile,
+  removeProfile,
+  removeProfileSync,
+  ensureSignalHandler,
+  cleanupCallbacks,
+} from "../core/movementProfile.js";
+
+/**
+ * Deploy a Move package as a code object via `movement move deploy-object`.
+ *
+ * Mirrors `core/Publisher.deploy` exactly for the security-critical parts
+ * (per-deploy unique profile, atomic ~/.aptos/config.yaml mutation under
+ * the shared mutex, SIGINT-safe sync cleanup, stderr redaction via
+ * `runCli`). The only differences are:
+ *
+ *   1. CLI subcommand: `deploy-object` instead of `publish` + a required
+ *      `--address-name <moduleName>` flag that binds the derived object
+ *      address to the package's named-address slot.
+ *   2. `DeploymentInfo.address` is the derived **object address** parsed
+ *      from CLI output, not the deployer's account address.
+ *
+ * @internal — called from `Harness.deployCodeObject`.
+ */
+export async function deployCodeObject(
+  runtime: MovehatRuntime,
+  options: DeployCodeObjectOptions
+): Promise<CodeObjectInfo> {
+  return executeMovementMoveObject({
+    runtime,
+    moduleName: options.moduleName,
+    packageDir: options.packageDir,
+    namedAddresses: options.namedAddresses,
+    includedArtifacts: options.includedArtifacts,
+    adapter: options.adapter,
+    subcommand: "deploy-object",
+    extraArgs: [],
+    checkIdempotency: true,
+  });
+}
+
+/**
+ * Upgrade an existing code object via `movement move upgrade-object`.
+ *
+ * Requires {@link UpgradeCodeObjectOptions.objectAddress} — the address
+ * of the existing on-chain object. The local `DeploymentInfo` record
+ * for `moduleName` is overwritten with a new timestamp + txHash; the
+ * address stays the same.
+ *
+ * @internal — called from `Harness.upgradeCodeObject`.
+ */
+export async function upgradeCodeObject(
+  runtime: MovehatRuntime,
+  options: UpgradeCodeObjectOptions
+): Promise<CodeObjectInfo> {
+  if (!options.objectAddress) {
+    throw new Error(
+      "Harness.upgradeCodeObject requires options.objectAddress (the existing object's address)."
+    );
+  }
+  return executeMovementMoveObject({
+    runtime,
+    moduleName: options.moduleName,
+    packageDir: options.packageDir,
+    namedAddresses: options.namedAddresses,
+    includedArtifacts: options.includedArtifacts,
+    adapter: options.adapter,
+    subcommand: "upgrade-object",
+    extraArgs: ["--object-address", options.objectAddress],
+    checkIdempotency: false,
+    fixedAddress: options.objectAddress,
+  });
+}
+
+interface ExecuteOptions {
+  runtime: MovehatRuntime;
+  moduleName: string;
+  packageDir?: string | undefined;
+  namedAddresses?: Record<string, string> | undefined;
+  includedArtifacts?: "none" | "sparse" | "all" | undefined;
+  adapter?: import("../utils/childProcessAdapter.js").ChildProcessAdapter | undefined;
+  subcommand: "deploy-object" | "upgrade-object";
+  extraArgs: readonly string[];
+  /** Whether to throw `ModuleAlreadyDeployedError` if a record exists. */
+  checkIdempotency: boolean;
+  /**
+   * For upgrade-object: the object's existing address. Skips the parse-
+   * from-stdout step (the address is known up front).
+   */
+  fixedAddress?: string;
+}
+
+async function executeMovementMoveObject(
+  opts: ExecuteOptions
+): Promise<CodeObjectInfo> {
+  const { runtime, moduleName, subcommand } = opts;
+  const config = runtime.config;
+  const account = runtime.account;
+
+  validateSafeName(moduleName, "module");
+
+  // Idempotency: deploy-object refuses re-deploy unless MH_CLI_REDEPLOY=true.
+  // Upgrade does not check this (the whole point is to overwrite).
+  const forceRedeploy = process.env.MH_CLI_REDEPLOY === "true";
+  if (opts.checkIdempotency) {
+    const existing = loadDeployment(config.network, moduleName);
+    if (existing && !forceRedeploy) {
+      const errorDetails = [
+        `Module "${moduleName}" is already deployed on ${config.network}`,
+        `Address: ${existing.address}`,
+        `Deployed at: ${new Date(existing.timestamp).toLocaleString()}`,
+        existing.txHash ? `Transaction: ${existing.txHash}` : null,
+        `\nTo redeploy, set MH_CLI_REDEPLOY=true or call harness.upgradeCodeObject({ objectAddress: "${existing.address}", ... }).`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      logger.error(
+        `Module "${moduleName}" is already deployed on ${config.network}`
+      );
+      logger.plain(`   Address: ${existing.address}`);
+      logger.plain(
+        `   Deployed at: ${new Date(existing.timestamp).toLocaleString()}`
+      );
+      if (existing.txHash) logger.plain(`   Transaction: ${existing.txHash}`);
+      logger.newline();
+
+      throw new ModuleAlreadyDeployedError(
+        errorDetails,
+        moduleName,
+        config.network,
+        existing.address,
+        existing.timestamp,
+        existing.txHash
+      );
+    }
+  }
+
+  const dir = opts.packageDir || config.moveDir;
+  const profile = `movehat-deploy-${randomUUID().slice(0, 8)}`;
+  const safeDir = validatePathSafety(dir, "package directory");
+  const safeProfile = validateProfileSafety(profile);
+
+  logger.step(
+    `${subcommand === "deploy-object" ? "Deploying" : "Upgrading"} module "${moduleName}" from ${dir}...`
+  );
+
+  try {
+    const deployerAddress = account.accountAddress.toString();
+
+    // Build named-addresses arg: auto-detected names from Move sources
+    // are bound to the deployer's address (Publisher convention).
+    // Caller-supplied `namedAddresses` overlay on top.
+    const detectedAddresses = extractNamedAddresses(dir);
+    const addrMap = new Map<string, string>();
+    for (const name of detectedAddresses) addrMap.set(name, deployerAddress);
+    if (opts.namedAddresses) {
+      for (const [k, v] of Object.entries(opts.namedAddresses)) addrMap.set(k, v);
+    }
+    const namedAddrArgs: string[] =
+      addrMap.size > 0
+        ? [
+            "--named-addresses",
+            Array.from(addrMap.entries())
+              .map(([k, v]) => `${k}=${v}`)
+              .join(","),
+          ]
+        : [];
+
+    // Build step (same as Publisher — produces the bytecode the
+    // subcommand will publish/upgrade).
+    logger.step("Building package...");
+    const buildResult = await runCli(
+      {
+        command: "movement",
+        args: ["move", "build", "--package-dir", safeDir, ...namedAddrArgs],
+        timeoutMs: 120000,
+      },
+      { adapter: opts.adapter }
+    );
+    if (buildResult.stdout) console.log(buildResult.stdout.trim());
+
+    // Strip `ed25519-priv-` prefix if present — Movement CLI expects the
+    // raw hex.
+    let cleanPrivateKey = config.privateKey;
+    if (cleanPrivateKey.startsWith("ed25519-priv-")) {
+      cleanPrivateKey = cleanPrivateKey.replace("ed25519-priv-", "");
+    }
+
+    const movementConfigPath = join(homedir(), ".aptos", "config.yaml");
+
+    // Register SIGINT-safe sync cleanup BEFORE writing the key (same
+    // pattern as Publisher — closes bug #36).
+    ensureSignalHandler();
+    const syncCleanup = () => removeProfileSync(movementConfigPath, profile);
+    cleanupCallbacks.add(syncCleanup);
+
+    await withYamlLock(() =>
+      addProfile(movementConfigPath, profile, {
+        private_key: cleanPrivateKey,
+        public_key: account.publicKey.toString(),
+        account: deployerAddress,
+        rest_url: config.rpc,
+      })
+    );
+
+    let deployOut = "";
+    try {
+      logger.step(
+        `Running 'movement move ${subcommand}'${subcommand === "upgrade-object" ? "" : " (this may take a moment)"}...`
+      );
+      const includedArtifacts: ("--included-artifacts" | string)[] =
+        opts.includedArtifacts
+          ? ["--included-artifacts", opts.includedArtifacts]
+          : [];
+      const result = await runCli(
+        {
+          command: "movement",
+          args: [
+            "move",
+            subcommand,
+            "--address-name",
+            moduleName,
+            "--package-dir",
+            safeDir,
+            "--url",
+            config.rpc,
+            "--profile",
+            safeProfile,
+            "--assume-yes",
+            ...includedArtifacts,
+            ...namedAddrArgs,
+            ...opts.extraArgs,
+          ],
+          timeoutMs: 180000, // 3 min — deploy-object can be slow with chunked publishing.
+        },
+        { adapter: opts.adapter }
+      );
+      deployOut = result.stdout;
+      if (result.stdout) console.log(result.stdout.trim());
+      if (result.stderr) console.error(result.stderr.trim());
+    } finally {
+      // Best-effort profile removal. CRITICAL: catch + log instead of
+      // re-throwing — an await-in-finally that throws would clobber the
+      // try block's success/error (the bug-#37 lesson from Publisher).
+      await withYamlLock(() => removeProfile(movementConfigPath, profile)).catch(
+        (err) => {
+          const cleanupMsg = err instanceof Error ? err.message : String(err);
+          logger.warning(
+            `Failed to remove deploy profile "${profile}" from ${movementConfigPath}: ${cleanupMsg}. ` +
+              `Run 'movement config delete-profile --profile ${profile}' to clean up manually.`
+          );
+        }
+      );
+      cleanupCallbacks.delete(syncCleanup);
+    }
+
+    // Parse object address (for deploy-object) and txHash (both flows).
+    // No captured fixture exists at M2.2 commit time; M4 integration
+    // tests validate against real CLI output.
+    const objectAddress = opts.fixedAddress ?? parseObjectAddress(deployOut);
+    const txHash = parseTxHash(deployOut);
+
+    if (!objectAddress) {
+      throw new Error(
+        `Could not parse object address from '${subcommand}' output. ` +
+          `Expected a line containing 'object address 0x...' or a JSON ` +
+          `'Result' block with an 'object_address' field. Captured stdout:\n${deployOut.slice(0, 1000)}`
+      );
+    }
+
+    logger.success(
+      `${subcommand === "deploy-object" ? "Module deployed" : "Module upgraded"} successfully!`
+    );
+
+    // Publish/upgrade succeeded. Everything below this point that throws
+    // is a local-side bookkeeping failure, not an on-chain failure.
+
+    const deployment: DeploymentInfo = {
+      address: objectAddress,
+      moduleName,
+      network: config.network,
+      deployer: deployerAddress,
+      timestamp: Date.now(),
+      ...(txHash !== undefined ? { txHash } : {}),
+    };
+
+    try {
+      saveDeployment(deployment);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      throw new PostPublishError(
+        `Module "${moduleName}" ${subcommand === "deploy-object" ? "deployed" : "upgraded"} to ${deployment.address} ` +
+          `but local deployment record could not be written: ${err.message}`,
+        deployment,
+        err
+      );
+    }
+
+    return deployment;
+  } catch (error) {
+    if (error instanceof PostPublishError) {
+      logger.warning(
+        `Module ${subcommand === "deploy-object" ? "deployed" : "upgraded"} successfully to ${error.deployment.address} ` +
+          `(tx=${error.deployment.txHash ?? "unknown"}) but local deployment record could not be written.`
+      );
+      logger.warning(`   Cause: ${error.cause.message}`);
+      logger.warning(
+        `   To recover, manually write the deployment to deployments/${error.deployment.network}/${error.deployment.moduleName}.json.`
+      );
+      throw error;
+    }
+    if (error instanceof CliExecutionError) {
+      if (error.stdoutPreview) console.log(error.stdoutPreview);
+      logger.error(
+        `Failed to ${subcommand === "deploy-object" ? "deploy" : "upgrade"} module: ${error.message}\n${error.stderr}`
+      );
+    } else {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error(
+        `Failed to ${subcommand === "deploy-object" ? "deploy" : "upgrade"} module: ${err.message}`
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Extract a code-object address from `movement move deploy-object` stdout.
+ *
+ * Movement CLI typically emits the address in one of these shapes (none
+ * of them captured at M2.2 commit time — patterns are speculative, with
+ * M4 integration tests as the validation gate):
+ *
+ *   - Free text: `Code was successfully deployed to object address 0x…`
+ *   - Free text: `Object address: 0x…`
+ *   - JSON `Result` block with `"object_address": "0x…"`
+ *
+ * Falls through the patterns in order. Returns `undefined` on no match.
+ */
+function parseObjectAddress(stdout: string): string | undefined {
+  // Pattern 1: phrase-context match.
+  const phraseMatch = stdout.match(
+    /object\s+address[:\s]+\b(0x[a-fA-F0-9]{1,64})\b/i
+  );
+  if (phraseMatch?.[1]) return phraseMatch[1];
+
+  // Pattern 2: JSON-shaped key.
+  const jsonMatch = stdout.match(
+    /"object_address"\s*:\s*"(0x[a-fA-F0-9]{1,64})"/
+  );
+  if (jsonMatch?.[1]) return jsonMatch[1];
+
+  return undefined;
+}
+
+/**
+ * Extract a transaction hash from CLI stdout. Identical regex to
+ * `core/Publisher.ts` (the publish success message uses the same
+ * shape) — kept here to avoid coupling.
+ */
+function parseTxHash(stdout: string): string | undefined {
+  const withContext = stdout.match(
+    /(?:transaction\s*(?:hash)?|txn\s*(?:hash)?|hash):\s*(0x[a-fA-F0-9]{64})\b/i
+  );
+  if (withContext?.[1]) return withContext[1];
+  const fallback = stdout.match(/\b(0x[a-fA-F0-9]{64})\b/);
+  return fallback?.[1];
+}

--- a/packages/movehat/src/harness/codeObject.ts
+++ b/packages/movehat/src/harness/codeObject.ts
@@ -21,6 +21,7 @@ import {
   PostPublishError,
 } from "../errors.js";
 import { runCli } from "../utils/runCli.js";
+import { parseTxHash } from "../utils/parseCliOutput.js";
 import { logger } from "../ui/index.js";
 import {
   withYamlLock,
@@ -377,18 +378,4 @@ function parseObjectAddress(stdout: string): string | undefined {
   if (jsonMatch?.[1]) return jsonMatch[1];
 
   return undefined;
-}
-
-/**
- * Extract a transaction hash from CLI stdout. Identical regex to
- * `core/Publisher.ts` (the publish success message uses the same
- * shape) — kept here to avoid coupling.
- */
-function parseTxHash(stdout: string): string | undefined {
-  const withContext = stdout.match(
-    /(?:transaction\s*(?:hash)?|txn\s*(?:hash)?|hash):\s*(0x[a-fA-F0-9]{64})\b/i
-  );
-  if (withContext?.[1]) return withContext[1];
-  const fallback = stdout.match(/\b(0x[a-fA-F0-9]{64})\b/);
-  return fallback?.[1];
 }

--- a/packages/movehat/src/harness/errors.ts
+++ b/packages/movehat/src/harness/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Thrown synchronously when any method other than `cleanup` is invoked
+ * on a Harness instance whose `cleanup()` has already run.
+ *
+ * The throw happens on property access (Proxy `get` trap), not after the
+ * async method body. That means `await harness.deployCodeObject(...)`
+ * throws *before* the call site awaits — callers can use a plain
+ * `try`/`catch` or rely on the rejected promise; either form will fire.
+ */
+export class HarnessDisposedError extends Error {
+  constructor(public readonly methodName: string) {
+    super(
+      `Harness is disposed; call to '${methodName}' is not allowed. ` +
+        `Create a new Harness via Harness.createLocal/createFork/createLive instead.`
+    );
+    this.name = "HarnessDisposedError";
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, HarnessDisposedError);
+    }
+  }
+}

--- a/packages/movehat/src/harness/index.ts
+++ b/packages/movehat/src/harness/index.ts
@@ -1,0 +1,3 @@
+export { Harness } from "./Harness.js";
+export type { HarnessMode } from "./Harness.js";
+export { HarnessDisposedError } from "./errors.js";

--- a/packages/movehat/src/harness/proxy.ts
+++ b/packages/movehat/src/harness/proxy.ts
@@ -1,0 +1,40 @@
+import { HarnessDisposedError } from "./errors.js";
+
+/**
+ * Names of Harness methods that must throw `HarnessDisposedError`
+ * synchronously once the harness has been disposed (via `cleanup()`).
+ *
+ * Properties NOT in this set — `cleanup`, `mode`, `poisoned`, the runtime
+ * accessors, well-known Symbols, and the promise-protocol hooks
+ * (`then`/`catch`/`finally`) — always pass through. That keeps:
+ *  - `await harness` from breaking on `.then` access
+ *  - debug tools (`console.log`, `util.inspect`) from throwing
+ *  - idempotent `cleanup()` callable post-poisoning
+ *
+ * New Harness methods that should fail post-cleanup MUST be added here.
+ */
+const POISONED_METHODS: ReadonlySet<string> = new Set([
+  "deployCodeObject",
+  "upgradeCodeObject",
+  "runViewFunction",
+  "runMoveScript",
+]);
+
+/**
+ * Wrap a Harness instance in a Proxy that throws `HarnessDisposedError`
+ * synchronously on access to any method in {@link POISONED_METHODS} once
+ * `isPoisoned()` returns true.
+ */
+export function createHarnessProxy<T extends object>(
+  target: T,
+  isPoisoned: () => boolean
+): T {
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      if (typeof prop === "string" && POISONED_METHODS.has(prop) && isPoisoned()) {
+        throw new HarnessDisposedError(prop);
+      }
+      return Reflect.get(obj, prop, receiver);
+    },
+  });
+}

--- a/packages/movehat/src/harness/script.ts
+++ b/packages/movehat/src/harness/script.ts
@@ -1,0 +1,196 @@
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { extname, join } from "path";
+import { randomUUID } from "crypto";
+import type { MovehatRuntime } from "../types/runtime.js";
+import type {
+  RunMoveScriptOptions,
+  MoveScriptResult,
+} from "../types/harness.js";
+import { validatePathSafety, validateProfileSafety } from "../core/shell.js";
+import { CliExecutionError } from "../errors.js";
+import { runCli } from "../utils/runCli.js";
+import { parseTxHash } from "../utils/parseCliOutput.js";
+import { logger } from "../ui/index.js";
+import {
+  withYamlLock,
+  addProfile,
+  removeProfile,
+  removeProfileSync,
+  ensureSignalHandler,
+  cleanupCallbacks,
+} from "../core/movementProfile.js";
+
+/**
+ * Execute a Move script via `movement move run-script`.
+ *
+ * Auto-detects the script kind from the extension:
+ *   - `.move` source → `--script-path` (CLI compiles inline)
+ *   - `.mv` compiled bytecode → `--compiled-script-path`
+ *
+ * Reuses Publisher's security model via the shared `movementProfile`
+ * helpers: per-deploy unique profile, atomic 0o600 yaml writes under
+ * the mutex, SIGINT-safe sync cleanup, `--profile` auth (key never
+ * appears in `ps` output).
+ *
+ * Returns {@link MoveScriptResult}. `txHash` is guaranteed; `success`
+ * and `vmStatus` are best-effort parsed from the CLI's Result JSON.
+ *
+ * @internal — called from `Harness.runMoveScript`.
+ */
+export async function runMoveScript(
+  runtime: MovehatRuntime,
+  options: RunMoveScriptOptions
+): Promise<MoveScriptResult> {
+  const config = runtime.config;
+  const account = runtime.account;
+
+  // Synchronous validation before any CLI call.
+  if (!options.scriptPath || typeof options.scriptPath !== "string") {
+    throw new Error(
+      "Harness.runMoveScript requires options.scriptPath (string path to .move or .mv)."
+    );
+  }
+  const ext = extname(options.scriptPath).toLowerCase();
+  let scriptFlag: "--script-path" | "--compiled-script-path";
+  if (ext === ".move") {
+    scriptFlag = "--script-path";
+  } else if (ext === ".mv") {
+    scriptFlag = "--compiled-script-path";
+  } else {
+    throw new Error(
+      `Harness.runMoveScript: unsupported script extension '${ext || "<none>"}'. ` +
+        `Expected '.move' (source — CLI auto-compiles) or '.mv' (pre-compiled bytecode).`
+    );
+  }
+  if (!existsSync(options.scriptPath)) {
+    throw new Error(
+      `Harness.runMoveScript: script not found at '${options.scriptPath}'.`
+    );
+  }
+
+  const safeScriptPath = validatePathSafety(options.scriptPath, "script path");
+  const profile = `movehat-script-${randomUUID().slice(0, 8)}`;
+  const safeProfile = validateProfileSafety(profile);
+
+  logger.step(
+    `Running Move script '${options.scriptPath}' on ${config.network}...`
+  );
+
+  try {
+    const deployerAddress = account.accountAddress.toString();
+
+    let cleanPrivateKey = config.privateKey;
+    if (cleanPrivateKey.startsWith("ed25519-priv-")) {
+      cleanPrivateKey = cleanPrivateKey.replace("ed25519-priv-", "");
+    }
+
+    const movementConfigPath = join(homedir(), ".aptos", "config.yaml");
+
+    ensureSignalHandler();
+    const syncCleanup = () => removeProfileSync(movementConfigPath, profile);
+    cleanupCallbacks.add(syncCleanup);
+
+    await withYamlLock(() =>
+      addProfile(movementConfigPath, profile, {
+        private_key: cleanPrivateKey,
+        public_key: account.publicKey.toString(),
+        account: deployerAddress,
+        rest_url: config.rpc,
+      })
+    );
+
+    let scriptOut = "";
+    try {
+      const typeArgsFragment: string[] =
+        options.typeArgs && options.typeArgs.length > 0
+          ? ["--type-args", ...options.typeArgs]
+          : [];
+      const argsFragment: string[] =
+        options.args && options.args.length > 0
+          ? ["--args", ...options.args]
+          : [];
+
+      const result = await runCli(
+        {
+          command: "movement",
+          args: [
+            "move",
+            "run-script",
+            "--profile",
+            safeProfile,
+            "--url",
+            config.rpc,
+            "--assume-yes",
+            scriptFlag,
+            safeScriptPath,
+            ...typeArgsFragment,
+            ...argsFragment,
+          ],
+          timeoutMs: 120000,
+        },
+        { adapter: options.adapter }
+      );
+      scriptOut = result.stdout;
+      if (result.stdout) console.log(result.stdout.trim());
+      if (result.stderr) console.error(result.stderr.trim());
+    } finally {
+      await withYamlLock(() => removeProfile(movementConfigPath, profile)).catch(
+        (err) => {
+          const cleanupMsg = err instanceof Error ? err.message : String(err);
+          logger.warning(
+            `Failed to remove script profile "${profile}" from ${movementConfigPath}: ${cleanupMsg}. ` +
+              `Run 'movement config delete-profile --profile ${profile}' to clean up manually.`
+          );
+        }
+      );
+      cleanupCallbacks.delete(syncCleanup);
+    }
+
+    const txHash = parseTxHash(scriptOut);
+    if (!txHash) {
+      throw new Error(
+        `Could not parse transaction hash from 'move run-script' output. ` +
+          `Captured stdout:\n${scriptOut.slice(0, 1000)}`
+      );
+    }
+
+    const success = parseSuccess(scriptOut);
+    const vmStatus = parseVmStatus(scriptOut);
+
+    logger.success(`Move script executed (tx ${txHash}).`);
+
+    const out: MoveScriptResult = { txHash };
+    if (success !== undefined) out.success = success;
+    if (vmStatus !== undefined) out.vmStatus = vmStatus;
+    return out;
+  } catch (error) {
+    if (error instanceof CliExecutionError) {
+      if (error.stdoutPreview) console.log(error.stdoutPreview);
+      logger.error(`Failed to run Move script: ${error.message}\n${error.stderr}`);
+    } else {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error(`Failed to run Move script: ${err.message}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Best-effort parse of the `"success": true|false` field from
+ * Movement CLI's Result JSON block. Returns `undefined` on no match.
+ */
+function parseSuccess(stdout: string): boolean | undefined {
+  const m = stdout.match(/"success"\s*:\s*(true|false)/);
+  if (!m) return undefined;
+  return m[1] === "true";
+}
+
+/**
+ * Best-effort parse of the `"vm_status"` string. Returns `undefined`
+ * on no match.
+ */
+function parseVmStatus(stdout: string): string | undefined {
+  const m = stdout.match(/"vm_status"\s*:\s*"([^"]*)"/);
+  return m?.[1];
+}

--- a/packages/movehat/src/harness/view.ts
+++ b/packages/movehat/src/harness/view.ts
@@ -1,0 +1,34 @@
+import type { MoveFunctionId } from "@aptos-labs/ts-sdk";
+import type { MovehatRuntime } from "../types/runtime.js";
+import type { RunViewFunctionOptions } from "../types/harness.js";
+
+/**
+ * Execute a Move view function via the Aptos SDK (no CLI invocation).
+ *
+ * Returns the SDK's raw `unknown[]` — the Move boundary may return a
+ * tuple of any arity. Callers destructure:
+ *
+ * ```ts
+ * const [count] = await harness.runViewFunction({
+ *   function: "0xCAFE::counter::get",
+ *   functionArguments: ["0xdeployer"],
+ * });
+ * ```
+ *
+ * Works on all 3 harness modes (createLocal, createFork, createLive) —
+ * view functions read on-chain state without writing.
+ *
+ * @internal — called from `Harness.runViewFunction`.
+ */
+export async function runViewFunction(
+  runtime: MovehatRuntime,
+  options: RunViewFunctionOptions
+): Promise<unknown[]> {
+  return runtime.aptos.view({
+    payload: {
+      function: options.function as MoveFunctionId,
+      typeArguments: options.typeArguments ?? [],
+      functionArguments: (options.functionArguments ?? []) as never[],
+    },
+  });
+}

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -15,3 +15,7 @@ export type { ForkMetadata, AccountState, LedgerInfo, AccountData, AccountResour
 
 // Export custom errors
 export { ModuleAlreadyDeployedError, PostPublishError } from "./errors.js";
+
+// Export Harness (Hardhat-style API — primary public surface from M2 onward)
+export { Harness, HarnessDisposedError } from "./harness/index.js";
+export type { HarnessMode } from "./harness/index.js";

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -2,7 +2,11 @@
 export * from "./helpers/index.js";
 export type { MovehatConfig } from "./types/config.js";
 
-// Export Movehat Runtime Environment
+// Export Movehat Runtime Environment.
+// `getMovehat` is @deprecated as of M2.4 — see runtime.ts JSDoc. Use
+// the Harness.create* factories below for new code.
+// `initRuntime` stays as a public utility but external callers should
+// prefer Harness; it's the construction primitive Harness.createLive uses.
 export { initRuntime, getMovehat } from "./runtime.js";
 export type { MovehatRuntime, NetworkInfo } from "./types/runtime.js";
 

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -3,8 +3,8 @@ export * from "./helpers/index.js";
 export type { MovehatConfig } from "./types/config.js";
 
 // Export Movehat Runtime Environment.
-// `getMovehat` is @deprecated as of M2.4 — see runtime.ts JSDoc. Use
-// the Harness.create* factories below for new code.
+// `getMovehat` is @deprecated since M2.4 (pre-1.0) — see runtime.ts
+// JSDoc. Use the Harness.create* factories below for new code.
 // `initRuntime` stays as a public utility but external callers should
 // prefer Harness; it's the construction primitive Harness.createLive uses.
 export { initRuntime, getMovehat } from "./runtime.js";

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -26,8 +26,18 @@ export interface InitRuntimeOptions {
 }
 
 /**
- * Initialize the Movehat Runtime Environment
- * This function loads the configuration and creates the runtime context
+ * Initialize the Movehat Runtime Environment.
+ *
+ * Lower-level construction utility — loads `movehat.config.ts`, resolves
+ * the active network, and builds a `MovehatRuntime` bound to it. Used
+ * internally by {@link Harness.createLive} (see `harness/Harness.ts`).
+ *
+ * **External callers should prefer the `Harness.create*` factories**
+ * (`Harness.createLocal` / `createFork` / `createLive`) for the Hardhat-
+ * style lifecycle + use-after-cleanup safety. `initRuntime` remains
+ * exported as a public utility for advanced use cases that need to
+ * skip the Harness abstraction (e.g. embedding movehat inside another
+ * framework).
  */
 export async function initRuntime(
   options: InitRuntimeOptions = {}
@@ -150,10 +160,30 @@ export async function initRuntime(
 /**
  * Get the Movehat Runtime Environment.
  *
- * As of M1.5 this is a thin alias of {@link initRuntime} — each call
- * constructs a fresh runtime. The previous module-cached behavior was
- * removed because it leaked state between parallel tests and hid the
- * runtime dependency from script signatures.
+ * @deprecated Since `0.0.0-dev`. Prefer the Hardhat-style `Harness`
+ * factories (`Harness.createLocal` / `createFork` / `createLive`)
+ * which carry explicit lifecycle (`harness.cleanup()`) and
+ * use-after-cleanup safety. `getMovehat()` will be removed in
+ * `0.1.0` (M6 / issue #73).
+ *
+ * Migration:
+ * ```diff
+ * - import { getMovehat } from "movehat";
+ * - const mh = await getMovehat();
+ * - const deployment = await mh.deployContract("counter");
+ * + import { Harness } from "movehat";
+ * + const harness = await Harness.createLive("testnet");
+ * + try {
+ * +   const deployment = await harness.deployCodeObject({ moduleName: "counter" });
+ * +   // ...
+ * + } finally {
+ * +   await harness.cleanup();
+ * + }
+ * ```
+ *
+ * As of M1.5 each call constructs a fresh runtime — the previous
+ * module-cached behavior was removed because it leaked state between
+ * parallel tests and hid the runtime dependency from script signatures.
  */
 export async function getMovehat(): Promise<MovehatRuntime> {
   return initRuntime();

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -160,7 +160,7 @@ export async function initRuntime(
 /**
  * Get the Movehat Runtime Environment.
  *
- * @deprecated Since `0.0.0-dev`. Prefer the Hardhat-style `Harness`
+ * @deprecated since M2.4 (pre-1.0). Prefer the Hardhat-style `Harness`
  * factories (`Harness.createLocal` / `createFork` / `createLive`)
  * which carry explicit lifecycle (`harness.cleanup()`) and
  * use-after-cleanup safety. `getMovehat()` will be removed in

--- a/packages/movehat/src/templates/movehat.config.ts
+++ b/packages/movehat/src/templates/movehat.config.ts
@@ -1,3 +1,14 @@
+// Movehat configuration.
+//
+// Movehat's primary public API is the Hardhat-style `Harness` class
+// (see scripts/deploy-counter.ts and tests/Counter.test.ts in this
+// template). The `Harness.create*` factories read this file via
+// `loadUserConfig` to resolve the active network + accounts.
+//
+// The older `getMovehat()` / `setupTestFixture()` helpers also read
+// the same shape and are still supported (marked `@deprecated` from
+// M2; removal is M6 / 0.1.0).
+
 import dotenv from "dotenv";
 dotenv.config();
 

--- a/packages/movehat/src/templates/scripts/deploy-counter.ts
+++ b/packages/movehat/src/templates/scripts/deploy-counter.ts
@@ -1,48 +1,56 @@
-import { getMovehat, ModuleAlreadyDeployedError } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
   console.log("🚀 Deploying Counter contract...\n");
 
-  // Get the Movehat Runtime Environment
-  const mh = await getMovehat();
+  // Hardhat-style Harness — primary public API since M2.
+  // createLive binds to a real running network (testnet / mainnet / a
+  // custom one defined in movehat.config.ts). No local process spawned.
+  const network = process.env.MOVEHAT_NETWORK ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    console.log(`✅ Runtime initialized on ${harness.runtime.network.name}`);
+    console.log(`   Account: ${harness.runtime.account.accountAddress.toString()}`);
+    console.log(`   RPC: ${harness.runtime.network.rpc}\n`);
 
-  console.log(`✅ Runtime initialized`);
-  console.log(`   Account: ${mh.account.accountAddress.toString()}`);
-  console.log(`   Network: ${mh.network.name}`);
-  console.log(`   RPC: ${mh.network.rpc}\n`);
+    // Deploy as a code object via `movement move deploy-object`. If the
+    // Move.toml's named address differs from the module identifier
+    // (e.g. `module my_pkg::counter` with `[addresses] my_pkg = "_"`),
+    // pass `addressName: "my_pkg"` in addition to `moduleName: "counter"`.
+    //
+    // To redeploy an existing record, set MH_CLI_REDEPLOY=true.
+    const deployment = await harness.deployCodeObject({
+      moduleName: "counter",
+    });
 
-  // Deploy (publish) the module
-  // Automatically checks if already deployed and suggests --redeploy if needed
-  const deployment = await mh.deployContract("counter");
+    console.log(`\n✅ Module deployed at: ${deployment.address}::counter`);
+    if (deployment.txHash) {
+      console.log(`   Transaction: ${deployment.txHash}`);
+    }
 
-  console.log(`\n✅ Module deployed at: ${deployment.address}::counter`);
-  if (deployment.txHash) {
-    console.log(`   Transaction: ${deployment.txHash}`);
+    // Interact with the freshly deployed module via the runtime helper.
+    const counter = harness.runtime.getContract(deployment.address, "counter");
+
+    console.log("\n📝 Incrementing counter...");
+    const txResult = await counter.call(harness.runtime.account, "increment", []);
+    console.log(`✅ Transaction hash: ${txResult.hash}`);
+
+    // Use harness.runViewFunction directly when you have a fully
+    // qualified function id; counter.view<T>(...) is the shorter form.
+    const [value] = await harness.runViewFunction({
+      function: `${deployment.address}::counter::get`,
+      functionArguments: [harness.runtime.account.accountAddress.toString()],
+    });
+    console.log(`\n📊 Counter value: ${value}`);
+  } finally {
+    // Always release the Harness — cleanup() is idempotent and safe to
+    // call on a `createLive` instance even though no local process was
+    // spawned (it just flips the use-after-cleanup poison flag).
+    await harness.cleanup();
   }
-
-  // Get contract instance
-  const counter = mh.getContract(deployment.address, "counter");
-
-  // Initialize the counter
-  console.log("\n📝 Initializing counter...");
-  const txResult = await counter.call(mh.account, "init", []);
-
-  console.log(`✅ Transaction hash: ${txResult.hash}`);
-  console.log(`✅ Counter initialized successfully!`);
-
-  // Verify
-  const value = await counter.view<number>("get", [
-    mh.account.accountAddress.toString()
-  ]);
-
-  console.log(`\n📊 Initial counter value: ${value}`);
 }
 
 main().catch((error) => {
-  // ModuleAlreadyDeployedError is already logged with full details by deployContract()
-  // For other errors, show the message
-  if (!(error instanceof ModuleAlreadyDeployedError)) {
-    console.error("❌ Deployment failed:", error?.message || error);
-  }
+  console.error("❌ Deployment failed:", error?.message || error);
   process.exit(1);
 });

--- a/packages/movehat/src/templates/tests/Counter.test.ts
+++ b/packages/movehat/src/templates/tests/Counter.test.ts
@@ -1,95 +1,87 @@
 // @ts-nocheck - This is a template file, dependencies are installed in user projects
 import { describe, it, before, after } from "mocha";
 import { expect } from "chai";
-import { setupTestFixture, type TestFixture } from "movehat/helpers";
+import { Harness, AccountManager } from "movehat";
 
 describe("Counter Contract", () => {
-  let fixture: TestFixture<'counter'>;
+  let harness;
+  let counter;
+  let deployer, alice, bob;
 
   before(async function () {
     this.timeout(60000); // Allow time for local node startup + deployment
 
-    // Setup local testing environment with auto-deployment
-    // This will:
-    // 1. Start a local Movement blockchain node
-    // 2. Generate and fund test accounts from local faucet
-    // 3. Auto-deploy the counter module
-    // 4. Return everything ready to use
+    // Hardhat-style Harness — primary public API since M2.
+    // createLocal spins up a Movement local node, funds the labeled
+    // accounts from the local faucet, and (via autoDeploy) builds +
+    // publishes the named modules so they're ready to use.
     //
-    // By default uses 'local-node' mode (full blockchain)
-    // For faster tests on existing state, pass { mode: 'fork' }
-    //
-    // Note: Use 'as const' for type inference
-    fixture = await setupTestFixture(['counter'] as const, ['alice', 'bob']);
+    // The setupTestFixture helper still works if you prefer the older
+    // pattern; see `import { setupTestFixture } from "movehat/helpers"`.
+    harness = await Harness.createLocal({
+      accountLabels: ["deployer", "alice", "bob"],
+      autoDeploy: ["counter"],
+    });
+
+    const labeled = AccountManager.getLabeledAccounts();
+    deployer = labeled.deployer;
+    alice = labeled.alice;
+    bob = labeled.bob;
+
+    const counterAddr = harness.runtime.getDeploymentAddress("counter");
+    counter = harness.runtime.getContract(counterAddr, "counter");
 
     console.log(`\n✅ Testing on local blockchain`);
-    console.log(`   Deployer: ${fixture.accounts.deployer.accountAddress.toString()}`);
-    console.log(`   Alice: ${fixture.accounts.alice.accountAddress.toString()}`);
-    console.log(`   Bob: ${fixture.accounts.bob.accountAddress.toString()}\n`);
+    console.log(`   Deployer: ${deployer.accountAddress.toString()}`);
+    console.log(`   Alice: ${alice.accountAddress.toString()}`);
+    console.log(`   Bob: ${bob.accountAddress.toString()}\n`);
   });
 
   describe("Counter functionality", () => {
     it("should initialize counter for deployer", async () => {
-      const counter = fixture.contracts.counter; // Type-safe, no `!` needed
-      const deployer = fixture.accounts.deployer;
-
       // Initialize counter for deployer (required before get/increment)
       const tx = await counter.call(deployer, "init", []);
       console.log(`   Init transaction: ${tx.hash}`);
 
-      // Read counter value (returns string from view function)
-      const value = await counter.view<string>("get", [
-        deployer.accountAddress.toString()
-      ]);
+      // Read counter value via harness.runViewFunction (new in M2)
+      const [value] = await harness.runViewFunction({
+        function: `${counter.moduleAddress}::counter::get`,
+        functionArguments: [deployer.accountAddress.toString()],
+      });
 
       console.log(`   Counter value: ${value}`);
-
-      // Assert the counter is 0 (note: values from view are strings)
       expect(parseInt(value)).to.equal(0);
     });
 
     it("should increment counter", async () => {
-      const counter = fixture.contracts.counter;
-      const deployer = fixture.accounts.deployer;
-
-      // Increment the counter
       const tx = await counter.call(deployer, "increment", []);
       console.log(`   Transaction: ${tx.hash}`);
 
-      // Read new value
+      // counter.view is the shorter form when you already have the contract.
       const value = await counter.view<string>("get", [
-        deployer.accountAddress.toString()
+        deployer.accountAddress.toString(),
       ]);
 
       console.log(`   New counter value: ${value}`);
-
-      // Should be 1 now
       expect(parseInt(value)).to.equal(1);
     });
 
     it("alice can initialize and increment her counter", async () => {
-      const counter = fixture.contracts.counter;
-      const alice = fixture.accounts.alice;
-
-      // Alice must initialize her counter first
       const initTx = await counter.call(alice, "init", []);
       console.log(`   Alice init transaction: ${initTx.hash}`);
 
-      // Alice increments her own counter
       const tx = await counter.call(alice, "increment", []);
       console.log(`   Alice's increment transaction: ${tx.hash}`);
 
-      // Read counter value for Alice (each user has their own counter)
       const aliceValue = await counter.view<string>("get", [
-        alice.accountAddress.toString()
+        alice.accountAddress.toString(),
       ]);
 
       console.log(`   Alice's counter value: ${aliceValue}`);
       expect(parseInt(aliceValue)).to.equal(1);
 
-      // Deployer's counter should still be 1 (unchanged)
       const deployerValue = await counter.view<string>("get", [
-        fixture.accounts.deployer.accountAddress.toString()
+        deployer.accountAddress.toString(),
       ]);
 
       console.log(`   Deployer's counter value: ${deployerValue}`);
@@ -97,20 +89,14 @@ describe("Counter Contract", () => {
     });
 
     it("bob can initialize and increment his counter", async () => {
-      const counter = fixture.contracts.counter;
-      const bob = fixture.accounts.bob;
-
-      // Bob must initialize his counter first
       const initTx = await counter.call(bob, "init", []);
       console.log(`   Bob init transaction: ${initTx.hash}`);
 
-      // Bob increments his own counter
       const tx = await counter.call(bob, "increment", []);
       console.log(`   Bob's increment transaction: ${tx.hash}`);
 
-      // Read counter value for Bob (each user has their own counter)
       const bobValue = await counter.view<string>("get", [
-        bob.accountAddress.toString()
+        bob.accountAddress.toString(),
       ]);
 
       console.log(`   Bob's counter value: ${bobValue}`);
@@ -119,7 +105,9 @@ describe("Counter Contract", () => {
   });
 
   after(async () => {
-    // Cleanup: Stop local node
-    await fixture.teardown();
+    // harness.cleanup() stops the local node and poisons the harness —
+    // any further method call (other than cleanup itself) throws
+    // HarnessDisposedError synchronously.
+    await harness.cleanup();
   });
 });

--- a/packages/movehat/src/types/harness.ts
+++ b/packages/movehat/src/types/harness.ts
@@ -1,0 +1,74 @@
+import type { DeploymentInfo } from "../core/deployments.js";
+import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
+
+/**
+ * Options for `harness.deployCodeObject(options)`.
+ *
+ * Wraps `movement move deploy-object`. The Movement CLI derives the
+ * destination object address from the signing account; that address is
+ * bound to `moduleName` (passed as `--address-name`) at compile time.
+ * Callers retrieve the resulting object address via the returned
+ * `CodeObjectInfo.address`.
+ */
+export interface DeployCodeObjectOptions {
+  /**
+   * Logical module name. Used as the `--address-name` for `deploy-object`
+   * so the derived object address is bound to this name in the package's
+   * named-addresses at compile time. Also the key under which the
+   * deployment is persisted (`deployments/{network}/{moduleName}.json`).
+   */
+  moduleName: string;
+
+  /**
+   * Extra named-address overrides merged on top of the addresses
+   * auto-detected from `<packageDir>/sources/**.move`. Values here win
+   * for the matching keys; auto-detected names not present here are
+   * still pinned to the deployer address (Publisher convention).
+   */
+  namedAddresses?: Record<string, string>;
+
+  /**
+   * Path to the Move package. Defaults to `config.moveDir` from the
+   * harness's runtime config (usually `./move`).
+   */
+  packageDir?: string;
+
+  /**
+   * Artifact set written into the on-chain package. Mirrors the CLI
+   * flag. Defaults to `'sparse'` (the Movement CLI default).
+   */
+  includedArtifacts?: "none" | "sparse" | "all";
+
+  /**
+   * Test-only override for the child-process adapter. Production callers
+   * leave this undefined so the default spawn-based adapter is used.
+   * @internal
+   */
+  adapter?: ChildProcessAdapter;
+}
+
+/**
+ * Options for `harness.upgradeCodeObject(options)`.
+ *
+ * Wraps `movement move upgrade-object`. The object must already exist
+ * on-chain at `objectAddress` and have been deployed previously (typically
+ * via `deployCodeObject`).
+ */
+export interface UpgradeCodeObjectOptions extends DeployCodeObjectOptions {
+  /** Address of the existing code object to upgrade. Required. */
+  objectAddress: string;
+}
+
+/**
+ * Result of `deployCodeObject` / `upgradeCodeObject`.
+ *
+ * Today this is structurally identical to {@link DeploymentInfo} — the
+ * `address` field holds the derived **object address** (the value
+ * callers pass to `runtime.getContract(...)` to interact with the
+ * modules), and `deployer` is the signing account.
+ *
+ * The alias exists so future iterations can layer additional fields
+ * (e.g. an explicit `kind: 'code-object' | 'publish'` discriminator)
+ * without churning every callsite.
+ */
+export type CodeObjectInfo = DeploymentInfo;

--- a/packages/movehat/src/types/harness.ts
+++ b/packages/movehat/src/types/harness.ts
@@ -72,3 +72,87 @@ export interface UpgradeCodeObjectOptions extends DeployCodeObjectOptions {
  * without churning every callsite.
  */
 export type CodeObjectInfo = DeploymentInfo;
+
+/**
+ * Options for `harness.runViewFunction(options)`.
+ *
+ * Delegates to the Aptos SDK's `aptos.view(...)` — no CLI invocation,
+ * no profile management. Works on `createLocal`, `createFork`, and
+ * `createLive` harnesses (view functions are read-only).
+ */
+export interface RunViewFunctionOptions {
+  /**
+   * Fully qualified Move function id, e.g. `0xCAFE::counter::get`.
+   */
+  function: string;
+
+  /**
+   * Move type-tag arguments, e.g. `['0x1::aptos_coin::AptosCoin']`.
+   */
+  typeArguments?: string[];
+
+  /**
+   * Move function arguments. SDK-validated at the boundary; pass values
+   * matching the Move function signature (strings for `address`,
+   * numbers / bigints for `u8`-`u256`, booleans, etc.).
+   */
+  functionArguments?: unknown[];
+}
+
+/**
+ * Options for `harness.runMoveScript(options)`.
+ *
+ * Wraps `movement move run-script`. The CLI handles compilation
+ * inline when given a `.move` source; the user can also pass a
+ * pre-compiled `.mv` bytecode file.
+ *
+ * Not available on fork-mode harnesses (forks are read-only).
+ */
+export interface RunMoveScriptOptions {
+  /**
+   * Path to the Move script. Extension determines the CLI flag:
+   *   - `.move` → `--script-path` (CLI auto-compiles)
+   *   - `.mv` → `--compiled-script-path` (user pre-compiled)
+   * Other extensions throw synchronously before any CLI call.
+   */
+  scriptPath: string;
+
+  /**
+   * CLI-formatted typed arguments. Movement CLI expects each arg
+   * prefixed by its Move type, e.g. `'address:0x1'`, `'u8:42'`,
+   * `'bool:true'`, `'string:hello'`. See
+   * `movement move run-script --help` for the full grammar.
+   */
+  args?: string[];
+
+  /**
+   * Type-tag arguments for generic scripts, e.g.
+   * `['0x1::aptos_coin::AptosCoin']`.
+   */
+  typeArgs?: string[];
+
+  /**
+   * Optional working directory for compilation. Most callers leave
+   * this undefined — the CLI uses the script's parent directory.
+   */
+  packageDir?: string;
+
+  /**
+   * Test-only override for the child-process adapter.
+   * @internal
+   */
+  adapter?: ChildProcessAdapter;
+}
+
+/**
+ * Result of `harness.runMoveScript`.
+ *
+ * Always carries `txHash` (parser throws if it can't extract one).
+ * `success` and `vmStatus` are best-effort: parsed from the CLI's
+ * JSON `Result` block when present, `undefined` if the parser misses.
+ */
+export interface MoveScriptResult {
+  txHash: string;
+  success?: boolean;
+  vmStatus?: string;
+}

--- a/packages/movehat/src/types/harness.ts
+++ b/packages/movehat/src/types/harness.ts
@@ -12,12 +12,36 @@ import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
  */
 export interface DeployCodeObjectOptions {
   /**
-   * Logical module name. Used as the `--address-name` for `deploy-object`
-   * so the derived object address is bound to this name in the package's
-   * named-addresses at compile time. Also the key under which the
-   * deployment is persisted (`deployments/{network}/{moduleName}.json`).
+   * Logical module identifier (the `name` part of `module addr::name`).
+   * Used as the persistence key (`deployments/{network}/{moduleName}.json`)
+   * and as the `name` arg you'd pass to `runtime.getContract(addr, name)`
+   * after deployment.
+   *
+   * If `addressName` is omitted, `moduleName` is also used as the CLI's
+   * `--address-name` flag (correct when the Move.toml's named address
+   * matches the module identifier). For packages where they differ —
+   * e.g. `module hello_blockchain::counter` (named address
+   * `hello_blockchain`, module `counter`) — set `addressName` explicitly.
    */
   moduleName: string;
+
+  /**
+   * Move.toml named address that the derived object address binds to
+   * at compile time (the `--address-name` flag of `move deploy-object`).
+   *
+   * Defaults to `moduleName`. Set this when the Move.toml's named
+   * address differs from the on-chain module identifier:
+   *
+   * ```ts
+   * // Move source: `module hello_blockchain::counter`
+   * // Move.toml:   `[addresses] hello_blockchain = "_"`
+   * await harness.deployCodeObject({
+   *   moduleName: "counter",            // for getContract + save key
+   *   addressName: "hello_blockchain",  // for --address-name
+   * });
+   * ```
+   */
+  addressName?: string;
 
   /**
    * Extra named-address overrides merged on top of the addresses

--- a/packages/movehat/src/utils/parseCliOutput.ts
+++ b/packages/movehat/src/utils/parseCliOutput.ts
@@ -1,0 +1,27 @@
+/**
+ * Helpers for extracting fields out of Movement CLI stdout / stderr.
+ *
+ * @internal — not exported from `src/index.ts`.
+ */
+
+/**
+ * Extract the transaction hash from a `movement` CLI subcommand's stdout.
+ *
+ * Tries the context-bearing pattern first (`transaction hash: 0x…`,
+ * `txn hash: 0x…`, `hash: 0x…`) and falls back to any 64-char hex
+ * literal in the buffer. Returns `undefined` if no candidate matches.
+ *
+ * Shared by `core/Publisher.ts` (publish), `harness/codeObject.ts`
+ * (deploy-object / upgrade-object), and `harness/script.ts`
+ * (run-script). All three CLI subcommands emit the txHash in the same
+ * shape — keep this helper as the single source of truth so a future
+ * CLI-format change is a one-line fix.
+ */
+export function parseTxHash(stdout: string): string | undefined {
+  const withContext = stdout.match(
+    /(?:transaction\s*(?:hash)?|txn\s*(?:hash)?|hash):\s*(0x[a-fA-F0-9]{64})\b/i
+  );
+  if (withContext?.[1]) return withContext[1];
+  const fallback = stdout.match(/\b(0x[a-fA-F0-9]{64})\b/);
+  return fallback?.[1];
+}


### PR DESCRIPTION
## Summary

Batch PR for **M2 (Hardhat-style Harness API — KPI 1, issue #69)** from `develop` → `main`. Lands the seven-method Harness API and migrates the install-experience surface (templates + example + docs) to it. The legacy `getMovehat` / `setupTestFixture` paths stay exported and functional through M5; removal is M6 (#73).

## Sub-PRs included

| Step | PR | Commits | Focus |
|---|---|---|---|
| M2.1 | [#120](https://github.com/gilbertsahumada/movehat/pull/120) | `d15d4ff` | Harness skeleton + 3 factories + Proxy poisoning + cleanup + HarnessDisposedError (4 methods stubbed) |
| M2.2 | [#121](https://github.com/gilbertsahumada/movehat/pull/121) | `b2a823d` + `f4a1ec6` | Extract `core/movementProfile.ts` (shared with Publisher); implement `deployCodeObject` + `upgradeCodeObject` via `movement move deploy-object` / `upgrade-object` |
| M2.3 | [#122](https://github.com/gilbertsahumada/movehat/pull/122) | `e405cee` + `dfe73c0` | Extract `utils/parseCliOutput.ts` (shared with Publisher + codeObject); implement `runViewFunction` (SDK) + `runMoveScript` (`movement move run-script`, auto-detects `.move` vs `.mv`) |
| M2.4 | [#123](https://github.com/gilbertsahumada/movehat/pull/123) | 5 commits | `@deprecated` `getMovehat`; fix M2.2 `addressName` mismatch; migrate templates + example + 8 docs MDX + new `api/harness.mdx`; ROADMAP closeout |

## What's new for users

```typescript
import { Harness } from "movehat";

// One of: createLocal (real local node), createFork (read-only snapshot), createLive (real RPC)
const harness = await Harness.createLive("testnet");
try {
  // New: deployCodeObject — wraps `movement move deploy-object`
  const deployment = await harness.deployCodeObject({
    moduleName: "counter",
    addressName: "hello_blockchain",  // optional, when Move.toml's named address differs
  });

  // New: runViewFunction — SDK call, returns raw unknown[]
  const [value] = await harness.runViewFunction({
    function: \`\${deployment.address}::counter::get\`,
    functionArguments: [harness.runtime.account.accountAddress.toString()],
  });

  // New: runMoveScript — wraps `movement move run-script`
  const result = await harness.runMoveScript({
    scriptPath: "scripts/init.move",  // .move source or .mv compiled
    args: ["address:0xCAFE", "u64:100"],
  });
} finally {
  // cleanup() is idempotent. Post-cleanup, any method call (other than
  // cleanup itself) throws HarnessDisposedError SYNCHRONOUSLY via a Proxy
  // — `await harness.deployCodeObject(...)` rejects before its body runs.
  await harness.cleanup();
}
```

## DoD recap (per ROADMAP)

**All 17 M2 DoD bullets flipped to `[x]`** in this batch (see `ROADMAP.md` — the table closeout includes shipped-PR and commit-hash columns for all 4 sub-PRs).

## Test plan (per CLAUDE.md §6 — full ladder)

- [x] Tier 1: `pnpm --filter movehat exec tsc --noEmit` — clean
- [x] Tier 1: `pnpm --filter movehat test` — **222/222 passing** (33 new unit tests added across M2.1-M2.4)
- [x] Tier 1: `pnpm check:example` — green
- [x] Tier 1: MDX compilation (`npx next build`) — ✓ Compiled successfully. The full Next.js build fails on a pre-existing missing `lucide-react` in `packages/docs/app/layout.config.tsx`, unrelated to M2. Tracked as a docs follow-up.
- [x] Tier 2: `pnpm test:smoke` — pass (validates the migrated templates ship in the tarball; new exports `Harness`, `HarnessDisposedError`, `HarnessMode`, plus 6 new option/result types are present)
- [x] Tier 2: `pnpm test:example` — **9/9 passing in ~1 min** (3 migrated Counter on Harness + 3 greeting + 3 message on the legacy `setupTestFixture` coexistence demo)
- [x] **Tier 3: `pnpm test:e2e` — 32/32 passing in 32s** (init → install → compile → Move tests → fork create/list — captured on the M2.4 sub-PR; the templates + CLI surface in this batch matches what e2e validates)

## Known follow-ups (not blockers)

- **`Harness.createFork`'s `apiKey` parameter is a silent no-op**: wiring into `MovementApiClient` headers is a TODO from M2.1. Document as a separate issue if a fork harness ever needs authenticated upstream reads.
- **`runMoveScript` `success` + `vmStatus` parsing is speculative**: regex against the CLI's Result JSON block. `txHash` is the only guaranteed field. M4 integration suite validates against real CLI output.
- **`deployCodeObject` object-address parser is speculative**: two regex patterns (free-text + JSON-shape). M4 validates.
- **`api/harness.mdx` is a manual stand-in**: M5 (#72) wires TypeDoc to auto-generate `packages/docs/content/docs/api/` from source.
- **`lucide-react` missing in docs layout** (pre-existing, NOT introduced here): blocks the full Next.js build but not the MDX compile step.

## ROADMAP closeout

M2 milestone line + sub-PR table + every DoD bullet updated in `ROADMAP.md` per CLAUDE.md §7. **M2 status: ✅ shipped via PRs #120 / #121 / #122 / #123 (this batch).** Next milestone on the critical path is M3 (80% unit coverage + Movement CLI cache, issue #70, KPI 1).

Closes #69.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hardhat-style testing/deployment Harness (local, fork, live) with deploy/upgrade, view, and script execution.
  * Code-object deployment/upgrade workflows with recorded deployments and optional redeploy behavior.
  * Synchronous use-after-cleanup safety and explicit lifecycle cleanup semantics.

* **Documentation**
  * Comprehensive docs, guides, examples, and templates updated to the new Harness workflow and CLI behavior.

* **Tests**
  * Extensive new test coverage for harness modes, deploy/upgrade, scripts, views, and cleanup/error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/124)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->