### PR TITLE
docs(coderabbit): address PR #124 batch review (5 fixes, 2 deferrals)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,7 +96,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 | ✅ | M2.1 | [#116](https://github.com/gilbertsahumada/movehat/issues/116) (shipped in PR #120 @ `c44f9cb`) | Harness skeleton + 3 factories + Proxy poisoning + cleanup + HarnessDisposedError (4 methods stubbed) | foundations |
 | ✅ | M2.2 | [#117](https://github.com/gilbertsahumada/movehat/issues/117) (shipped in PR #121 @ `c336077`) | `deployCodeObject` + `upgradeCodeObject` via `movement move deploy-object` / `upgrade-object` + extract `core/movementProfile.ts` | (partial of #69) |
 | ✅ | M2.3 | [#118](https://github.com/gilbertsahumada/movehat/issues/118) (shipped in PR #122 @ `a334991`) | `runViewFunction` + `runMoveScript` + extract `utils/parseCliOutput.ts` | (partial of #69) |
-| ✅ | M2.4 | [#119](https://github.com/gilbertsahumada/movehat/issues/119) | Migrate `examples/counter-example/` + templates + 8 docs MDX + new `api/harness.mdx`; `@deprecated` JSDoc on `getMovehat`; fix M2.2 `addressName` bug | closes #69 |
+| ✅ | M2.4 | [#119](https://github.com/gilbertsahumada/movehat/issues/119) (shipped in PR #123 @ `602cfca`) | Migrate `examples/counter-example/` + templates + 8 docs MDX + new `api/harness.mdx`; `@deprecated` JSDoc on `getMovehat`; fix M2.2 `addressName` bug | closes #69 |
 
 **Definition of Done — API surface**:
 - [x] `import { Harness } from 'movehat'` works from the built package (M2.4 — verified by Tier 2 smoke + Tier 3 e2e on the dev→main batch)
@@ -121,7 +121,7 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `getMovehat()` still exported with `@deprecated` JSDoc tag (M2.4 — full migration snippet inline; `initRuntime` stays public as a low-level utility used by `Harness.createLive`)
 - [x] `pnpm test` green (M2.4 — 222/222 unit tests; Tier 2 `test:example` 9/9 passing in ~1 min)
 
-**M2 status: ✅ ready for `develop → main` batch — all 4 sub-PRs (M2.1 PR #120, M2.2 PR #121, M2.3 PR #122, M2.4 PR #N) merged to develop. Tier 3 `pnpm test:e2e` to be run on the batch PR per CLAUDE.md §6.3.**
+**M2 status: ✅ ready for `develop → main` batch (PR #124) — all 4 sub-PRs (M2.1 PR #120, M2.2 PR #121, M2.3 PR #122, M2.4 PR #123) merged to develop. Tier 3 `pnpm test:e2e` 32/32 captured on M2.4 (PR #123) per CLAUDE.md §6.3.**
 
 ### M3 — 80% unit coverage + Movement CLI cache (~5 days, issue #70) — (KPI 1)
 

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -115,7 +115,7 @@ describe("Counter Contract", () => {
 });
 ```
 
-> **Looking for the older API?** `setupTestFixture` from `movehat/helpers` is still supported — see [`movehat/helpers`](../api/harness) for details on coexistence.
+> **Looking for the older API?** `setupTestFixture` from `movehat/helpers` is still supported — see the [Harness API page](../api/harness) for details on coexistence with the legacy helpers.
 
 **When to use TypeScript tests:**
 - Testing real transaction flows with actual state changes

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -3,8 +3,8 @@ export * from "./helpers/index.js";
 export type { MovehatConfig } from "./types/config.js";
 
 // Export Movehat Runtime Environment.
-// `getMovehat` is @deprecated as of M2.4 — see runtime.ts JSDoc. Use
-// the Harness.create* factories below for new code.
+// `getMovehat` is @deprecated since M2.4 (pre-1.0) — see runtime.ts
+// JSDoc. Use the Harness.create* factories below for new code.
 // `initRuntime` stays as a public utility but external callers should
 // prefer Harness; it's the construction primitive Harness.createLive uses.
 export { initRuntime, getMovehat } from "./runtime.js";

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -160,7 +160,7 @@ export async function initRuntime(
 /**
  * Get the Movehat Runtime Environment.
  *
- * @deprecated Since `0.0.0-dev`. Prefer the Hardhat-style `Harness`
+ * @deprecated since M2.4 (pre-1.0). Prefer the Hardhat-style `Harness`
  * factories (`Harness.createLocal` / `createFork` / `createLive`)
  * which carry explicit lifecycle (`harness.cleanup()`) and
  * use-after-cleanup safety. `getMovehat()` will be removed in


### PR DESCRIPTION
## Summary

Addresses CodeRabbit's review of the M2 \`develop → main\` batch PR (#124). 7 findings total — **5 fixed here**, **2 false positives replied inline on #124 with rationale** (no code change).

## Findings triage

| # | Path:line | Finding | Verdict | Action |
|---|---|---|---|---|
| 1 | \`guides/scripts.mdx:69\` | \`result.success === false\` misses \`undefined\` | False positive — intentional best-effort semantics; \`undefined\` means \"parser missed\", not failure. Treating undefined as failure would alert on genuine successes where Result JSON drifts. M4 integration validates. | Reply inline on #124 |
| 2 | \`guides/testing.mdx:118\` | Link text \`movehat/helpers\` pointed at \`../api/harness\` (mismatch) | True positive | **Fixed** — reworded to \`Harness API page\` |
| 3 | \`src/index.ts:5-9\` | Re-export comment says \"as of M2.4\" but \`runtime.ts\` says \"Since \`0.0.0-dev\`\" | True positive — inconsistency | **Fixed** — aligned both to \`@deprecated since M2.4 (pre-1.0)\` |
| 4 | \`ROADMAP.md:99\` | M2.4 sub-PR row ✅ but missing PR#/commit hash | True positive (I noted this myself as a 🟢 nit in my self-review) | **Fixed** — appended \`(shipped in PR #123 @ 602cfca)\` |
| 5 | \`ROADMAP.md:124\` | Placeholder \`M2.4 PR #N\` in status line | True positive | **Fixed** — \`#N\` → \`#123\` + added Tier 3 evidence pointer |
| 6 | \`runtime.ts:163\` (nitpick) | \`@deprecated Since '0.0.0-dev'\` unconventional (also factually wrong — package is 0.1.9) | True positive | **Fixed** (alongside #3) |
| 7 | \`index.mdx:19\` (nitpick) | \`setupTestFixture\` framed as \"alternative\" without \"deprecated\" | False positive — violates locked plan decision: \`setupTestFixture\` stays non-deprecated; only \`getMovehat\` carries the tag. Helpers coexist. \"Alternative\" is the intended framing. | Reply inline on #124 |

## Files changed (4 files, 6 lines total)

- \`packages/docs/content/docs/guides/testing.mdx\` — link text/href agreement
- \`packages/movehat/src/index.ts\` — comment alignment
- \`packages/movehat/src/runtime.ts\` — JSDoc phrasing
- \`ROADMAP.md\` — 2 line fixes (M2.4 row + status line)

## Test plan

- [x] Tier 1: \`pnpm --filter movehat exec tsc --noEmit\` — clean
- [x] Tier 1: \`pnpm --filter movehat test\` — **222/222 unchanged** (no behavior change)
- [N/A] Tier 2: smoke / example — no surface change
- [N/A] Tier 3: e2e — no template/CLI change

Once this merges to \`develop\`, the M2 batch PR (#124) auto-updates and is ready for final review.