### PR TITLE
feat(harness/fork): wire apiKey end-to-end via Authorization header (M2.1 TODO close)

### DIFF
--- a/packages/movehat/src/__tests__/fork/api.test.ts
+++ b/packages/movehat/src/__tests__/fork/api.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClientRequest, IncomingMessage } from "node:http";
+import { EventEmitter } from "node:events";
+
+/**
+ * Tests for `MovementApiClient` Authorization header injection (M2.4
+ * follow-up — wires the apiKey threading from `Harness.createFork`).
+ *
+ * Strategy: `vi.mock` `node:https` and `node:http` so the test
+ * captures the request options passed to `client.get(url, options, cb)`
+ * without making real network requests. Two assertions:
+ *
+ *   1. When the client is constructed with an apiKey, every `get`
+ *      call carries `Authorization: Bearer <apiKey>` in
+ *      `options.headers`.
+ *   2. When constructed without an apiKey, no Authorization header
+ *      is added (back-compat for unauthenticated public endpoints).
+ */
+
+const httpsGet = vi.fn();
+const httpGet = vi.fn();
+
+vi.mock("https", () => ({
+  default: { get: httpsGet },
+  get: httpsGet,
+}));
+vi.mock("http", () => ({
+  default: { get: httpGet },
+  get: httpGet,
+}));
+
+/**
+ * Build a fake `IncomingMessage`-like emitter that immediately emits
+ * a valid JSON body and ends. The MovementApiClient.get callback
+ * consumes the response via `data` / `end` events.
+ */
+function makeFakeResponse(body: string, statusCode = 200): IncomingMessage {
+  const res = new EventEmitter() as unknown as IncomingMessage;
+  (res as unknown as { statusCode: number }).statusCode = statusCode;
+  // Use setImmediate so the listener attaches before the events fire.
+  setImmediate(() => {
+    (res as unknown as EventEmitter).emit("data", body);
+    (res as unknown as EventEmitter).emit("end");
+  });
+  return res;
+}
+
+/**
+ * Capture the options arg from `client.get(url, options, callback)`
+ * and immediately resolve with a fake successful ledger-info response.
+ * Returns the captured options for assertion.
+ */
+function setupGetCapture(): {
+  captured: { url?: string; options?: { headers?: Record<string, string> } };
+} {
+  const captured: {
+    url?: string;
+    options?: { headers?: Record<string, string> };
+  } = {};
+
+  const handler = (
+    url: string,
+    options:
+      | { headers?: Record<string, string> }
+      | ((res: IncomingMessage) => void),
+    cb?: (res: IncomingMessage) => void
+  ): ClientRequest => {
+    captured.url = url;
+    // Distinguish (url, callback) vs (url, options, callback) overloads.
+    let callback: ((res: IncomingMessage) => void) | undefined;
+    if (typeof options === "function") {
+      callback = options;
+    } else {
+      captured.options = options;
+      callback = cb;
+    }
+
+    const fakeReq = new EventEmitter() as unknown as ClientRequest;
+    (fakeReq as unknown as { end: () => void }).end = () => {};
+
+    if (callback) {
+      const body = JSON.stringify({
+        chain_id: 250,
+        ledger_version: "1",
+        ledger_timestamp: "0",
+        epoch: "0",
+        block_height: "0",
+      });
+      callback(makeFakeResponse(body));
+    }
+    return fakeReq;
+  };
+
+  httpsGet.mockImplementation(handler);
+  httpGet.mockImplementation(handler);
+
+  return { captured };
+}
+
+describe("MovementApiClient — Authorization header (apiKey wiring)", () => {
+  beforeEach(() => {
+    httpsGet.mockReset();
+    httpGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("injects 'Authorization: Bearer <apiKey>' when constructed with an apiKey", async () => {
+    const { captured } = setupGetCapture();
+
+    const { MovementApiClient } = await import("../../fork/api.js");
+    const client = new MovementApiClient(
+      "https://testnet.example.com/v1",
+      "secret-key-123"
+    );
+
+    await client.getLedgerInfo();
+
+    expect(captured.url).toBe("https://testnet.example.com/v1/");
+    expect(captured.options).toBeDefined();
+    expect(captured.options?.headers).toEqual({
+      Authorization: "Bearer secret-key-123",
+    });
+    expect(httpsGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the Authorization header when constructed without an apiKey (back-compat)", async () => {
+    const { captured } = setupGetCapture();
+
+    const { MovementApiClient } = await import("../../fork/api.js");
+    const client = new MovementApiClient("https://testnet.example.com/v1");
+
+    await client.getLedgerInfo();
+
+    expect(captured.url).toBe("https://testnet.example.com/v1/");
+    if (captured.options !== undefined) {
+      expect(captured.options.headers).toBeUndefined();
+    }
+    expect(httpsGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/movehat/src/fork/api.ts
+++ b/packages/movehat/src/fork/api.ts
@@ -5,12 +5,18 @@ import type { LedgerInfo, AccountData, AccountResource } from '../types/fork.js'
 import { normalizeAddressShort } from '../utils/address.js';
 
 /**
- * Client for interacting with Movement L1 JSON API
+ * Client for interacting with Movement L1 JSON API.
+ *
+ * When constructed with an `apiKey`, every outgoing request carries
+ * an `Authorization: Bearer <apiKey>` header. Use this for rate-
+ * limited public endpoints (e.g. Movement testnet under load) or
+ * auth-gated nodes.
  */
 export class MovementApiClient {
   private nodeUrl: string;
+  private readonly apiKey?: string;
 
-  constructor(nodeUrl: string) {
+  constructor(nodeUrl: string, apiKey?: string) {
     // Remove trailing slash
     let normalized = nodeUrl.replace(/\/$/, '');
 
@@ -21,10 +27,16 @@ export class MovementApiClient {
     }
 
     this.nodeUrl = normalized;
+    if (apiKey !== undefined) this.apiKey = apiKey;
   }
 
   /**
-   * Make a GET request to the API
+   * Make a GET request to the API.
+   *
+   * Adds `Authorization: Bearer <apiKey>` when the client was
+   * constructed with an `apiKey`. The header is omitted otherwise
+   * to preserve backwards-compatible behavior for unauthenticated
+   * public endpoints.
    */
   private async get<T>(path: string): Promise<T> {
     const fullUrl = `${this.nodeUrl}${path}`;
@@ -32,8 +44,16 @@ export class MovementApiClient {
     const isHttps = parsedUrl.protocol === 'https:';
     const client = isHttps ? https : http;
 
+    const requestOptions: {
+      method: 'GET';
+      headers?: Record<string, string>;
+    } = { method: 'GET' };
+    if (this.apiKey !== undefined) {
+      requestOptions.headers = { Authorization: `Bearer ${this.apiKey}` };
+    }
+
     return new Promise((resolve, reject) => {
-      const req = client.get(fullUrl, (res) => {
+      const req = client.get(fullUrl, requestOptions, (res) => {
         let data = '';
 
         res.on('data', (chunk) => {

--- a/packages/movehat/src/fork/manager.ts
+++ b/packages/movehat/src/fork/manager.ts
@@ -13,16 +13,49 @@ export class ForkManager {
   private apiClient: MovementApiClient | null = null;
   private metadata: ForkMetadata | null = null;
 
+  /**
+   * Optional API key sent as `Authorization: Bearer <key>` on every
+   * outgoing Movement API request. Not persisted to disk via
+   * {@link ForkMetadata} (keys stay in process memory). For the
+   * load-then-set pattern, call {@link setApiKey} after `load()`.
+   */
+  private apiKey?: string;
+
   constructor(forkPath: string) {
     this.storage = new ForkStorage(forkPath);
   }
 
   /**
-   * Initialize a new fork from a network
+   * Set or update the API key used for upstream Movement API requests.
+   * Reconstructs the internal `MovementApiClient` if one exists.
    */
-  async initialize(nodeUrl: string, networkName: string = 'custom'): Promise<void> {
-    // Create API client
-    this.apiClient = new MovementApiClient(nodeUrl);
+  setApiKey(apiKey: string | undefined): void {
+    if (apiKey === undefined) {
+      delete this.apiKey;
+    } else {
+      this.apiKey = apiKey;
+    }
+    if (this.apiClient && this.metadata) {
+      this.apiClient = new MovementApiClient(this.metadata.nodeUrl, this.apiKey);
+    }
+  }
+
+  /**
+   * Initialize a new fork from a network.
+   *
+   * @param nodeUrl - Upstream JSON-RPC base URL.
+   * @param networkName - Logical network label (defaults to `'custom'`).
+   * @param apiKey - Optional API key for `Authorization: Bearer` header.
+   */
+  async initialize(
+    nodeUrl: string,
+    networkName: string = 'custom',
+    apiKey?: string
+  ): Promise<void> {
+    if (apiKey !== undefined) this.apiKey = apiKey;
+
+    // Create API client (with optional Authorization header)
+    this.apiClient = new MovementApiClient(nodeUrl, this.apiKey);
 
     // Fetch network info
     const ledgerInfo = await this.apiClient.getLedgerInfo();
@@ -48,7 +81,9 @@ export class ForkManager {
   }
 
   /**
-   * Load an existing fork
+   * Load an existing fork. The API key is NOT persisted to disk —
+   * callers needing authenticated upstream reads after `load()` must
+   * call {@link setApiKey} explicitly.
    */
   load(): void {
     if (!this.storage.exists()) {
@@ -56,7 +91,7 @@ export class ForkManager {
     }
 
     this.metadata = this.storage.loadMetadata();
-    this.apiClient = new MovementApiClient(this.metadata.nodeUrl);
+    this.apiClient = new MovementApiClient(this.metadata.nodeUrl, this.apiKey);
   }
 
   /**

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -94,19 +94,24 @@ export class Harness {
   /**
    * Create a fork-mode Harness reading from a snapshot of `network`.
    *
-   * Fork mode is read-only: `deployCodeObject`, `upgradeCodeObject`, and
-   * `runMoveScript` will throw with a message pointing at `createLocal`
-   * once their real bodies land in M2.2/M2.3. `runViewFunction` works.
+   * Fork mode is read-only: `deployCodeObject`, `upgradeCodeObject`,
+   * and `runMoveScript` throw with a message pointing at `createLocal`.
+   * `runViewFunction` works (read-only path).
    *
    * @param network - Network to fork (e.g. `"testnet"`).
-   * @param _apiKey - Reserved for M2.2; if non-undefined a TODO will fire.
+   * @param apiKey - Optional Movement API key. When set, every upstream
+   *   request from the fork's `MovementApiClient` carries
+   *   `Authorization: Bearer <apiKey>`. Use for rate-limited public
+   *   endpoints or auth-gated nodes. The key stays in process memory
+   *   (not persisted to the fork's on-disk metadata).
    */
-  static async createFork(network: string, _apiKey?: string): Promise<Harness> {
-    if (_apiKey !== undefined) {
-      // TODO(M2.2): plumb into MovementApiClient headers when the
-      // fork manager needs authenticated upstream reads.
-    }
-    const ctx = await setupLocalTesting({ mode: "fork", forkNetwork: network });
+  static async createFork(network: string, apiKey?: string): Promise<Harness> {
+    const setupOpts: import("../types/config.js").LocalTestOptions = {
+      mode: "fork",
+      forkNetwork: network,
+    };
+    if (apiKey !== undefined) setupOpts.forkApiKey = apiKey;
+    const ctx = await setupLocalTesting(setupOpts);
     const init: HarnessInit = {
       mode: "fork",
       runtime: ctx.runtime,

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -266,11 +266,17 @@ async function setupWithFork(
   if (!forkExists) {
     logger.step(`Creating fork from ${forkNetwork}...`);
     const testnetRpc = "https://testnet.movementnetwork.xyz/v1";
-    await forkManager.initialize(testnetRpc, forkNetwork);
+    await forkManager.initialize(testnetRpc, forkNetwork, options.forkApiKey);
     logger.success(`Fork created at ${forkPath}`);
     logger.newline();
   } else {
     logger.success(`Loading existing fork from ${forkPath}`);
+    // setApiKey BEFORE load() so the reconstructed MovementApiClient
+    // picks up the header. load() rebuilds the client using current
+    // apiKey state.
+    if (options.forkApiKey !== undefined) {
+      forkManager.setApiKey(options.forkApiKey);
+    }
     forkManager.load();
 
     if (forkResetState) {

--- a/packages/movehat/src/types/config.ts
+++ b/packages/movehat/src/types/config.ts
@@ -59,6 +59,14 @@ export interface LocalTestOptions {
     forkName?: string;                  // Name for the fork (default: 'test-local')
     forkPort?: number;                  // Fork server port (default: 8080)
     forkResetState?: boolean;           // Clear fork state before tests (default: true)
+    /**
+     * Optional API key sent as `Authorization: Bearer <key>` on every
+     * outgoing Movement API request made by the fork's
+     * `MovementApiClient`. Use for rate-limited public endpoints or
+     * auth-gated nodes. The key stays in process memory only — not
+     * persisted to the fork's on-disk metadata.
+     */
+    forkApiKey?: string;
 
     // Common options (both modes)
     autoFund?: boolean;                 // Auto-fund accounts (default: true)


### PR DESCRIPTION
## Summary

Closes the M2.1 TODO: \`Harness.createFork(network, apiKey?)\` accepted the param but did nothing with it. Now wired through 5 layers so every Movement API request from the fork's \`MovementApiClient\` carries \`Authorization: Bearer <apiKey>\`.

## What changed

| Layer | Change |
|---|---|
| \`fork/api.ts\` | \`MovementApiClient\` ctor takes optional \`apiKey?\`; \`get<T>()\` switches to the \`(url, options, cb)\` overload of \`https.get\`/\`http.get\` and adds the Authorization header when set. Header omitted when \`apiKey\` is undefined (back-compat for public endpoints). |
| \`fork/manager.ts\` | \`ForkManager\` gains private \`apiKey\` state. \`initialize(nodeUrl, networkName, apiKey?)\` stores it. \`load()\` reuses stored apiKey when reconstructing the client. New \`setApiKey(key)\` for the load-then-set pattern. Key is NOT persisted to disk (stays in process memory). |
| \`types/config.ts\` | \`LocalTestOptions\` gains \`forkApiKey?: string\`. |
| \`helpers/setupLocalTesting.ts\` | \`setupWithFork\` threads \`options.forkApiKey\` to \`forkManager.initialize()\` on the fresh-fork path and \`forkManager.setApiKey()\` before \`load()\` on the existing-fork path. |
| \`harness/Harness.ts\` | \`createFork\` drops the \`_apiKey\` underscore + TODO block; passes the param through. JSDoc updated. |

## New test

\`packages/movehat/src/__tests__/fork/api.test.ts\` uses \`vi.mock('https')\` + \`vi.mock('http')\` to capture request options without making real network calls. 2 cases:

1. **With apiKey:** \`'Authorization: Bearer <key>'\` present in captured options.headers
2. **Without apiKey:** Authorization header absent (back-compat for unauthenticated endpoints)

## Test plan

- [x] Tier 1: \`pnpm --filter movehat exec tsc --noEmit\` — clean
- [x] Tier 1: \`pnpm --filter movehat test\` — **224/224 passing** (222 prior + 2 new)
- [x] Tier 1: \`pnpm check:example\` — green
- [N/A] Tier 2: no template / smoke surface change (Harness JSDoc-only update; no new public type exports)
- [N/A] Tier 3: no install-experience change

## Out of scope

- **Movement testnet rate-limit testing** — this PR plumbs the header; whether the upstream actually honors it for rate-limit elevation is a deployment concern, not a code concern. M4 (#71) integration suite will validate against a real authenticated endpoint when applicable.
- **Sibling \`Harness.createLive(network, faucetUrl?)\` faucetUrl wiring** — still a silent no-op (its semantics are different: faucet URL drives auto-fund flow on testnets that have one). Separate follow-up if a real use case surfaces.

Tracks the M2 batch "Known follow-ups" section. Standalone chore, no milestone gating.