### PR TITLE
fix(docs/raw): split optional catch-all into static index + required catch-all (EISDIR)

### DIFF
--- a/packages/docs/app/docs/[[...slug]]/_components/llm-actions.tsx
+++ b/packages/docs/app/docs/[[...slug]]/_components/llm-actions.tsx
@@ -38,7 +38,13 @@ const GeminiIcon = () => (
 export function LLMActions({ slug }: { slug: string[] }) {
   const [copied, setCopied] = useState(false);
   const slugPath = slug.length === 0 ? '' : `/${slug.join('/')}`;
-  const rawUrl = `/raw${slugPath}`;
+  // The /raw/ route family is split: empty-slug → /raw/index (static
+  // handler), deep slugs → /raw/<slug>/... (catch-all). The empty-slug
+  // case can't live at /raw alone because Next.js static export
+  // collides `out/raw` (file) with `out/raw/` (directory of deep
+  // matches). See packages/docs/app/raw/index/route.ts for the full
+  // EISDIR explanation.
+  const rawUrl = slug.length === 0 ? '/raw/index' : `/raw${slugPath}`;
   const docUrl = `${SITE_URL}/docs${slugPath}`;
 
   async function copy() {

--- a/packages/docs/app/raw/[...slug]/route.ts
+++ b/packages/docs/app/raw/[...slug]/route.ts
@@ -4,13 +4,19 @@ import path from 'node:path';
 
 export const dynamic = 'force-static';
 
+/**
+ * Deep-path handler — required catch-all (`[...slug]`, not optional
+ * `[[...slug]]`) so the empty-slug case is delegated to the sibling
+ * `app/raw/route.ts` static handler. See that file for the rationale
+ * (EISDIR collision during `output: 'export'`).
+ */
 export function generateStaticParams() {
-  return source.generateParams();
+  return source.generateParams().filter((p) => p.slug.length > 0);
 }
 
 export async function GET(
   _req: Request,
-  { params }: { params: Promise<{ slug?: string[] }> },
+  { params }: { params: Promise<{ slug: string[] }> },
 ) {
   const { slug } = await params;
   const page = source.getPage(slug);

--- a/packages/docs/app/raw/index/route.ts
+++ b/packages/docs/app/raw/index/route.ts
@@ -1,0 +1,34 @@
+import { source } from '@/lib/source';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const dynamic = 'force-static';
+
+/**
+ * Index handler — serves the docs root (`content/docs/index.mdx`) as
+ * raw markdown via `/raw/index`.
+ *
+ * Sibling `app/raw/[...slug]/route.ts` handles every deep path. We put
+ * the index INSIDE the `/raw/` directory (not at `/raw` directly)
+ * because Next.js static export can't have both:
+ *   - `out/raw`  (a file produced by a base-level route)
+ *   - `out/raw/` (a directory for child-route files)
+ * The collision manifests as `EISDIR` during the export step. Hosting
+ * the index at `/raw/index` keeps everything safely inside `out/raw/`
+ * as a directory.
+ *
+ * Consumed by `app/docs/[[...slug]]/_components/llm-actions.tsx` —
+ * when the current docs page has an empty slug, that component
+ * requests `/raw/index` instead of `/raw`.
+ */
+export async function GET() {
+  const page = source.getPage([]);
+  if (!page) {
+    return new Response('Not found', { status: 404 });
+  }
+  const filePath = path.join(process.cwd(), 'content/docs', page.file.path);
+  const raw = await fs.readFile(filePath, 'utf8');
+  return new Response(raw, {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the EISDIR build failure surfaced during M2.4 verification. The docs site's static export (\`output: 'export'\`) was crashing on the post-export copyfile step:

\`\`\`
EISDIR: illegal operation on a directory, copyfile
  '.next/server/app/raw.body' -> 'out/raw'
\`\`\`

## Root cause

\`app/raw/[[...slug]]/route.ts\` was an **optional** catch-all (\`[[...slug]]\`), matching both \`/raw\` (empty slug) AND \`/raw/<deep>\`. The two cases produced incompatible build artifacts:

- Empty match → \`out/raw.body\` → copied to \`out/raw\` (a **file**)
- Deep matches → \`out/raw/<slug>.body\` → \`out/raw/\` is a **directory** containing the files

Next.js static export can't have both \`out/raw\` (file) and \`out/raw/\` (directory) at the same path. Page components (\`page.tsx\`) sidestep this because they output \`.html\` files (base match → \`out/raw/index.html\`), but route handlers output \`.body\` files which collide.

## Fix

Move the index endpoint INSIDE \`out/raw/\`:

| Before | After |
|---|---|
| \`app/raw/[[...slug]]/route.ts\` (optional catch-all, handles both cases) | \`app/raw/index/route.ts\` (NEW — static handler for docs root) |
|  | \`app/raw/[...slug]/route.ts\` (required catch-all — \`generateStaticParams\` filters empty slug) |
| Frontend: \`rawUrl = \`/raw\${slugPath}\`\` (empty slug → \`/raw\`) | Frontend: empty slug → \`/raw/index\`, deep slug → \`/raw/<slug>\` |

Result: \`out/raw/\` is a clean directory containing \`out/raw/index\` (the docs root) + \`out/raw/<slug>\` files for every deep page. No EISDIR.

## Files

| File | Change |
|---|---|
| \`packages/docs/app/raw/index/route.ts\` | **NEW** — static handler for the docs index (\`source.getPage([])\`) |
| \`packages/docs/app/raw/[[...slug]]/route.ts\` → \`[...slug]/route.ts\` | **Renamed** (optional → required catch-all); \`generateStaticParams\` filters out the empty-slug entry |
| \`packages/docs/app/docs/[[...slug]]/_components/llm-actions.tsx\` | When current docs page has empty slug, fetches \`/raw/index\` instead of \`/raw\` |

## Test plan

- [x] \`cd packages/docs && rm -rf out .next && npx next build\` — completes end-to-end (was failing at Export step)
- [x] Both endpoints produce correct markdown:
  - \`out/raw/index\` → \`content/docs/index.mdx\` ✓
  - \`out/raw/getting-started/quickstart\` → \`content/docs/getting-started/quickstart.mdx\` ✓
  - +14 other deep paths
- [N/A] Unit tests — no movehat workspace surface touched

Standalone docs chore. No milestone gating; not blocking M3.