### PR TITLE
refactor(harness/tests): extract shared fixture helper (no behavior change)

### DIFF
--- a/packages/movehat/src/__tests__/harness/Harness.createLive.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.createLive.test.ts
@@ -1,60 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 import { Harness } from "../../harness/index.js";
-import { _resetConfigCache } from "../../core/config.js";
+import { setupHarnessTestFixture, type HarnessTestFixture } from "./_fixture.js";
 
 describe("Harness.createLive", () => {
-  let tmpCwd: string;
-  let origCwd: string;
+  let fixture: HarnessTestFixture;
 
   beforeEach(() => {
-    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-harness-live-"));
-    writeFileSync(
-      join(tmpCwd, "movehat.config.js"),
-      `export default {
-  defaultNetwork: "testnet",
-  networks: {
-    testnet: {
-      url: "https://testnet.movementnetwork.xyz/v1",
-      chainId: "testnet"
-    },
-    custom: {
-      url: "https://custom.example.com/v1",
-      chainId: "custom",
-      accounts: ["0x${"a".repeat(64)}"]
-    }
-  }
-};
-`
-    );
-    const moveDir = join(tmpCwd, "move");
-    mkdirSync(join(moveDir, "sources"), { recursive: true });
-    writeFileSync(
-      join(moveDir, "Move.toml"),
-      `[package]
-name = "dummy"
-version = "0.0.1"
-
-[addresses]
-`
-    );
-    writeFileSync(join(moveDir, "sources", "dummy.move"), "// intentionally empty\n");
-
-    origCwd = process.cwd();
-    process.chdir(tmpCwd);
-    _resetConfigCache();
+    fixture = setupHarnessTestFixture({
+      extraNetworks: {
+        custom: {
+          url: "https://custom.example.com/v1",
+          chainId: "custom",
+          accounts: ["0x" + "a".repeat(64)],
+        },
+      },
+    });
   });
 
   afterEach(() => {
-    try {
-      process.chdir(origCwd);
-    } finally {
-      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
-      _resetConfigCache();
-    }
+    fixture.teardown();
   });
 
   it("returns a Harness bound to the requested network with mode='live'", async () => {

--- a/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 import { Harness, HarnessDisposedError } from "../../harness/index.js";
-import { _resetConfigCache } from "../../core/config.js";
+import { setupHarnessTestFixture, type HarnessTestFixture } from "./_fixture.js";
 
 /**
  * Proxy poisoning is the load-bearing safety guarantee of M2: once a
@@ -20,49 +17,14 @@ import { _resetConfigCache } from "../../core/config.js";
  * node is acceptable.
  */
 describe("Harness — proxy poisoning", () => {
-  let tmpCwd: string;
-  let origCwd: string;
+  let fixture: HarnessTestFixture;
 
   beforeEach(() => {
-    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-harness-test-"));
-    writeFileSync(
-      join(tmpCwd, "movehat.config.js"),
-      `export default {
-  defaultNetwork: "testnet",
-  networks: {
-    testnet: {
-      url: "https://testnet.movementnetwork.xyz/v1",
-      chainId: "testnet"
-    }
-  }
-};
-`
-    );
-    const moveDir = join(tmpCwd, "move");
-    mkdirSync(join(moveDir, "sources"), { recursive: true });
-    writeFileSync(
-      join(moveDir, "Move.toml"),
-      `[package]
-name = "dummy"
-version = "0.0.1"
-
-[addresses]
-`
-    );
-    writeFileSync(join(moveDir, "sources", "dummy.move"), "// intentionally empty\n");
-
-    origCwd = process.cwd();
-    process.chdir(tmpCwd);
-    _resetConfigCache();
+    fixture = setupHarnessTestFixture();
   });
 
   afterEach(() => {
-    try {
-      process.chdir(origCwd);
-    } finally {
-      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
-      _resetConfigCache();
-    }
+    fixture.teardown();
   });
 
   it("cleanup() flips poisoned to true", async () => {

--- a/packages/movehat/src/__tests__/harness/_fixture.ts
+++ b/packages/movehat/src/__tests__/harness/_fixture.ts
@@ -1,0 +1,131 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _resetConfigCache } from "../../core/config.js";
+
+/**
+ * Shared test fixture for Harness tests.
+ *
+ * Six test files in `__tests__/harness/` all needed the same setup
+ * boilerplate (~30 LoC each) before this helper landed: tmpdir for
+ * cwd, write a `movehat.config.js`, write a minimal Move package
+ * (`move/Move.toml` + `move/sources/dummy.move`), chdir, reset the
+ * mtime-based config cache, manage HOME for tests that exercise
+ * `~/.aptos/config.yaml` profile management. Extracted as a single
+ * helper to eliminate the drift surface across siblings.
+ *
+ * The defaults match the most common test shape: a single `testnet`
+ * network and no HOME management. Tests that need more (a `custom`
+ * network for switching, an isolated HOME for profile tests) opt in
+ * via the options.
+ *
+ * @internal — not exported from `src/index.ts`. Test-only.
+ */
+
+/**
+ * Additional networks to merge into the fixture's `movehat.config.js`.
+ * Keyed by network name. Each network needs `url` + `chainId` at
+ * minimum; pass `accounts` when the test exercises a code path that
+ * requires explicit account configuration (e.g. mainnet-like security
+ * checks in `resolveNetworkConfig`).
+ */
+export interface ExtraNetwork {
+  url: string;
+  chainId: string;
+  accounts?: string[];
+}
+
+export interface HarnessTestFixtureOptions {
+  /** Additional networks merged on top of the default `testnet` entry. */
+  extraNetworks?: Record<string, ExtraNetwork>;
+
+  /**
+   * When `true`, manage a separate `process.env.HOME` directory for
+   * the test. Used by tests that exercise `~/.aptos/config.yaml`
+   * profile writes (codeObject.* and script.* test suites).
+   */
+  withTmpHome?: boolean;
+}
+
+export interface HarnessTestFixture {
+  /** Fresh per-test cwd. The test is chdir'd here. */
+  tmpCwd: string;
+  /** Fresh per-test HOME, only set when `withTmpHome: true`. */
+  tmpHome?: string;
+  /** Restore cwd + HOME, remove the tmp dirs, and reset config cache. */
+  teardown: () => void;
+}
+
+/**
+ * Build a fresh per-test fixture. Call from `beforeEach`, capture the
+ * returned object, and call `fixture.teardown()` in `afterEach`.
+ */
+export function setupHarnessTestFixture(
+  options: HarnessTestFixtureOptions = {}
+): HarnessTestFixture {
+  const tmpCwd = mkdtempSync(join(tmpdir(), "movehat-harness-test-"));
+  const tmpHome = options.withTmpHome
+    ? mkdtempSync(join(tmpdir(), "movehat-harness-home-"))
+    : undefined;
+
+  // Build the network map. Default `testnet` + caller's extras.
+  const networks: Record<string, ExtraNetwork> = {
+    testnet: {
+      url: "https://testnet.movementnetwork.xyz/v1",
+      chainId: "testnet",
+    },
+    ...(options.extraNetworks ?? {}),
+  };
+
+  writeFileSync(
+    join(tmpCwd, "movehat.config.js"),
+    `export default {
+  defaultNetwork: "testnet",
+  networks: ${JSON.stringify(networks, null, 2)}
+};
+`
+  );
+
+  // Minimal Move package — `extractNamedAddresses` reads from
+  // `<moveDir>/sources/*.move`; an empty file yields an empty Set.
+  const moveDir = join(tmpCwd, "move");
+  mkdirSync(join(moveDir, "sources"), { recursive: true });
+  writeFileSync(
+    join(moveDir, "Move.toml"),
+    `[package]
+name = "dummy"
+version = "0.0.1"
+
+[addresses]
+`
+  );
+  writeFileSync(join(moveDir, "sources", "dummy.move"), "// intentionally empty\n");
+
+  const origCwd = process.cwd();
+  const origHome = process.env.HOME;
+  process.chdir(tmpCwd);
+  if (tmpHome !== undefined) process.env.HOME = tmpHome;
+  _resetConfigCache();
+
+  const teardown = () => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (options.withTmpHome) {
+        if (origHome === undefined) delete process.env.HOME;
+        else process.env.HOME = origHome;
+        if (tmpHome !== undefined && existsSync(tmpHome)) {
+          rmSync(tmpHome, { recursive: true, force: true });
+        }
+      }
+      if (existsSync(tmpCwd)) {
+        rmSync(tmpCwd, { recursive: true, force: true });
+      }
+      _resetConfigCache();
+    }
+  };
+
+  const fixture: HarnessTestFixture = { tmpCwd, teardown };
+  if (tmpHome !== undefined) fixture.tmpHome = tmpHome;
+  return fixture;
+}

--- a/packages/movehat/src/__tests__/harness/codeObject.deploy.test.ts
+++ b/packages/movehat/src/__tests__/harness/codeObject.deploy.test.ts
@@ -1,17 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { Harness, HarnessDisposedError } from "../../harness/index.js";
-import { _resetConfigCache } from "../../core/config.js";
 import {
   CliExecutionError,
   ModuleAlreadyDeployedError,
@@ -22,6 +13,7 @@ import type {
   RunInput,
   RunResult,
 } from "../../utils/childProcessAdapter.js";
+import { setupHarnessTestFixture, type HarnessTestFixture } from "./_fixture.js";
 
 /**
  * Tests for `Harness.deployCodeObject` — exercises the new
@@ -32,62 +24,18 @@ import type {
  * `__tests__/deployContract.test.ts`. No real Movement CLI calls.
  */
 describe("Harness.deployCodeObject", () => {
-  let tmpHome: string;
-  let tmpCwd: string;
-  let origHome: string | undefined;
-  let origCwd: string;
+  let fixture: HarnessTestFixture;
 
   const OBJECT_ADDRESS = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
   const TX_HASH = "0x1111111111111111111111111111111111111111111111111111111111111111";
 
   beforeEach(() => {
-    tmpHome = mkdtempSync(join(tmpdir(), "movehat-codeobj-home-"));
-    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-codeobj-cwd-"));
-
-    writeFileSync(
-      join(tmpCwd, "movehat.config.js"),
-      `export default {
-  defaultNetwork: "testnet",
-  networks: {
-    testnet: {
-      url: "https://testnet.movementnetwork.xyz/v1",
-      chainId: "testnet"
-    }
-  }
-};
-`
-    );
-    const moveDir = join(tmpCwd, "move");
-    mkdirSync(join(moveDir, "sources"), { recursive: true });
-    writeFileSync(
-      join(moveDir, "Move.toml"),
-      `[package]
-name = "dummy"
-version = "0.0.1"
-
-[addresses]
-`
-    );
-    writeFileSync(join(moveDir, "sources", "dummy.move"), "// empty\n");
-
-    origHome = process.env.HOME;
-    process.env.HOME = tmpHome;
-    origCwd = process.cwd();
-    process.chdir(tmpCwd);
-    _resetConfigCache();
+    fixture = setupHarnessTestFixture({ withTmpHome: true });
   });
 
   afterEach(() => {
-    try {
-      process.chdir(origCwd);
-    } finally {
-      if (origHome === undefined) delete process.env.HOME;
-      else process.env.HOME = origHome;
-      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
-      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
-      delete process.env.MH_CLI_REDEPLOY;
-      _resetConfigCache();
-    }
+    fixture.teardown();
+    delete process.env.MH_CLI_REDEPLOY;
   });
 
   function makeAdapter(steps: {
@@ -144,7 +92,7 @@ version = "0.0.1"
       expect(result.timestamp).toBeGreaterThan(0);
 
       // Deployment file written to deployments/testnet/counter.json
-      const deploymentPath = join(tmpCwd, "deployments", "testnet", "counter.json");
+      const deploymentPath = join(fixture.tmpCwd, "deployments", "testnet", "counter.json");
       expect(existsSync(deploymentPath)).toBe(true);
       const saved = JSON.parse(readFileSync(deploymentPath, "utf-8"));
       expect(saved.address).toBe(OBJECT_ADDRESS);
@@ -247,7 +195,7 @@ version = "0.0.1"
       expect(caught).toBeInstanceOf(CliExecutionError);
       // The profile-write happens AFTER build, so build failure should
       // never have touched ~/.aptos/config.yaml.
-      expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+      expect(existsSync(join(fixture.tmpHome!, ".aptos", "config.yaml"))).toBe(false);
     } finally {
       await harness.cleanup();
     }
@@ -270,7 +218,7 @@ version = "0.0.1"
       expect(caught).toBeInstanceOf(CliExecutionError);
       // The finally block must have cleaned the temp profile — file
       // unlinked because we wrote a fresh profile-only yaml.
-      expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+      expect(existsSync(join(fixture.tmpHome!, ".aptos", "config.yaml"))).toBe(false);
     } finally {
       await harness.cleanup();
     }
@@ -324,7 +272,7 @@ version = "0.0.1"
 
       // Save record + return value use moduleName (not addressName).
       expect(result.moduleName).toBe("counter");
-      const deploymentPath = join(tmpCwd, "deployments", "testnet", "counter.json");
+      const deploymentPath = join(fixture.tmpCwd, "deployments", "testnet", "counter.json");
       expect(existsSync(deploymentPath)).toBe(true);
       const saved = JSON.parse(readFileSync(deploymentPath, "utf-8"));
       expect(saved.moduleName).toBe("counter");

--- a/packages/movehat/src/__tests__/harness/codeObject.upgrade.test.ts
+++ b/packages/movehat/src/__tests__/harness/codeObject.upgrade.test.ts
@@ -1,29 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { Harness } from "../../harness/index.js";
-import { _resetConfigCache } from "../../core/config.js";
 import { CliExecutionError } from "../../errors.js";
 import type {
   ChildProcessAdapter,
   RunInput,
   RunResult,
 } from "../../utils/childProcessAdapter.js";
+import { setupHarnessTestFixture, type HarnessTestFixture } from "./_fixture.js";
 
 describe("Harness.upgradeCodeObject", () => {
-  let tmpHome: string;
-  let tmpCwd: string;
-  let origHome: string | undefined;
-  let origCwd: string;
+  let fixture: HarnessTestFixture;
 
   const EXISTING_OBJECT =
     "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
@@ -31,52 +20,11 @@ describe("Harness.upgradeCodeObject", () => {
     "0x2222222222222222222222222222222222222222222222222222222222222222";
 
   beforeEach(() => {
-    tmpHome = mkdtempSync(join(tmpdir(), "movehat-codeobj-upg-home-"));
-    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-codeobj-upg-cwd-"));
-
-    writeFileSync(
-      join(tmpCwd, "movehat.config.js"),
-      `export default {
-  defaultNetwork: "testnet",
-  networks: {
-    testnet: {
-      url: "https://testnet.movementnetwork.xyz/v1",
-      chainId: "testnet"
-    }
-  }
-};
-`
-    );
-    const moveDir = join(tmpCwd, "move");
-    mkdirSync(join(moveDir, "sources"), { recursive: true });
-    writeFileSync(
-      join(moveDir, "Move.toml"),
-      `[package]
-name = "dummy"
-version = "0.0.1"
-
-[addresses]
-`
-    );
-    writeFileSync(join(moveDir, "sources", "dummy.move"), "// empty\n");
-
-    origHome = process.env.HOME;
-    process.env.HOME = tmpHome;
-    origCwd = process.cwd();
-    process.chdir(tmpCwd);
-    _resetConfigCache();
+    fixture = setupHarnessTestFixture({ withTmpHome: true });
   });
 
   afterEach(() => {
-    try {
-      process.chdir(origCwd);
-    } finally {
-      if (origHome === undefined) delete process.env.HOME;
-      else process.env.HOME = origHome;
-      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
-      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
-      _resetConfigCache();
-    }
+    fixture.teardown();
   });
 
   function makeAdapter(steps: { build: RunResult; upgrade: RunResult }): {
@@ -126,7 +74,7 @@ version = "0.0.1"
       expect(result.moduleName).toBe("counter");
 
       // Saved deployment record reflects the new state.
-      const deploymentPath = join(tmpCwd, "deployments", "testnet", "counter.json");
+      const deploymentPath = join(fixture.tmpCwd, "deployments", "testnet", "counter.json");
       expect(existsSync(deploymentPath)).toBe(true);
       const saved = JSON.parse(readFileSync(deploymentPath, "utf-8"));
       expect(saved.address).toBe(EXISTING_OBJECT);
@@ -200,7 +148,7 @@ version = "0.0.1"
       }
       expect(caught).toBeInstanceOf(CliExecutionError);
       // Temp profile cleaned up in finally.
-      expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+      expect(existsSync(join(fixture.tmpHome!, ".aptos", "config.yaml"))).toBe(false);
     } finally {
       await harness.cleanup();
     }

--- a/packages/movehat/src/__tests__/harness/script.test.ts
+++ b/packages/movehat/src/__tests__/harness/script.test.ts
@@ -1,74 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { Harness } from "../../harness/index.js";
-import { _resetConfigCache } from "../../core/config.js";
 import { CliExecutionError } from "../../errors.js";
 import type {
   ChildProcessAdapter,
   RunInput,
   RunResult,
 } from "../../utils/childProcessAdapter.js";
+import { setupHarnessTestFixture, type HarnessTestFixture } from "./_fixture.js";
 
 describe("Harness.runMoveScript", () => {
-  let tmpHome: string;
-  let tmpCwd: string;
-  let origHome: string | undefined;
-  let origCwd: string;
+  let fixture: HarnessTestFixture;
 
   const TX_HASH =
     "0x9999999999999999999999999999999999999999999999999999999999999999";
 
   beforeEach(() => {
-    tmpHome = mkdtempSync(join(tmpdir(), "movehat-script-home-"));
-    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-script-cwd-"));
-
-    writeFileSync(
-      join(tmpCwd, "movehat.config.js"),
-      `export default {
-  defaultNetwork: "testnet",
-  networks: {
-    testnet: {
-      url: "https://testnet.movementnetwork.xyz/v1",
-      chainId: "testnet"
-    }
-  }
-};
-`
-    );
-    const moveDir = join(tmpCwd, "move");
-    mkdirSync(join(moveDir, "sources"), { recursive: true });
-    writeFileSync(
-      join(moveDir, "Move.toml"),
-      `[package]\nname = "dummy"\nversion = "0.0.1"\n\n[addresses]\n`
-    );
-    writeFileSync(join(moveDir, "sources", "dummy.move"), "// empty\n");
-
-    origHome = process.env.HOME;
-    process.env.HOME = tmpHome;
-    origCwd = process.cwd();
-    process.chdir(tmpCwd);
-    _resetConfigCache();
+    fixture = setupHarnessTestFixture({ withTmpHome: true });
   });
 
   afterEach(() => {
-    try {
-      process.chdir(origCwd);
-    } finally {
-      if (origHome === undefined) delete process.env.HOME;
-      else process.env.HOME = origHome;
-      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
-      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
-      _resetConfigCache();
-    }
+    fixture.teardown();
   });
 
   function makeAdapter(result: RunResult): {
@@ -97,8 +51,8 @@ describe("Harness.runMoveScript", () => {
   }
 
   it("happy path with .move source: uses --script-path and returns parsed MoveScriptResult", async () => {
-    const scriptPath = join(tmpCwd, "scripts", "init.move");
-    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    const scriptPath = join(fixture.tmpCwd, "scripts", "init.move");
+    mkdirSync(join(fixture.tmpCwd, "scripts"), { recursive: true });
     writeFileSync(scriptPath, "// dummy move script\n");
 
     const { adapter, calls } = makeAdapter({
@@ -137,8 +91,8 @@ describe("Harness.runMoveScript", () => {
   });
 
   it("happy path with .mv compiled: uses --compiled-script-path", async () => {
-    const scriptPath = join(tmpCwd, "build", "init.mv");
-    mkdirSync(join(tmpCwd, "build"), { recursive: true });
+    const scriptPath = join(fixture.tmpCwd, "build", "init.mv");
+    mkdirSync(join(fixture.tmpCwd, "build"), { recursive: true });
     writeFileSync(scriptPath, "compiled bytecode placeholder");
 
     const { adapter, calls } = makeAdapter({
@@ -161,7 +115,7 @@ describe("Harness.runMoveScript", () => {
   });
 
   it("unsupported extension throws synchronously before any CLI call", async () => {
-    const scriptPath = join(tmpCwd, "notes.txt");
+    const scriptPath = join(fixture.tmpCwd, "notes.txt");
     writeFileSync(scriptPath, "not a script");
 
     const { adapter, calls } = makeAdapter({
@@ -187,7 +141,7 @@ describe("Harness.runMoveScript", () => {
   });
 
   it("missing script file throws before any CLI call", async () => {
-    const scriptPath = join(tmpCwd, "scripts", "missing.move");
+    const scriptPath = join(fixture.tmpCwd, "scripts", "missing.move");
     const { adapter, calls } = makeAdapter({
       exitCode: 0,
       stdout: successStdout(),
@@ -211,8 +165,8 @@ describe("Harness.runMoveScript", () => {
   });
 
   it("CLI failure rethrows CliExecutionError and removes the temp profile", async () => {
-    const scriptPath = join(tmpCwd, "scripts", "fail.move");
-    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    const scriptPath = join(fixture.tmpCwd, "scripts", "fail.move");
+    mkdirSync(join(fixture.tmpCwd, "scripts"), { recursive: true });
     writeFileSync(scriptPath, "// dummy\n");
 
     const { adapter } = makeAdapter({
@@ -231,15 +185,15 @@ describe("Harness.runMoveScript", () => {
       }
       expect(caught).toBeInstanceOf(CliExecutionError);
       // Temp profile cleaned up in finally.
-      expect(existsSync(join(tmpHome, ".aptos", "config.yaml"))).toBe(false);
+      expect(existsSync(join(fixture.tmpHome!, ".aptos", "config.yaml"))).toBe(false);
     } finally {
       await harness.cleanup();
     }
   });
 
   it("CLI succeeded but output has no txHash: throws clear non-CliExecutionError", async () => {
-    const scriptPath = join(tmpCwd, "scripts", "weird.move");
-    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    const scriptPath = join(fixture.tmpCwd, "scripts", "weird.move");
+    mkdirSync(join(fixture.tmpCwd, "scripts"), { recursive: true });
     writeFileSync(scriptPath, "// dummy\n");
 
     const { adapter } = makeAdapter({
@@ -265,8 +219,8 @@ describe("Harness.runMoveScript", () => {
   });
 
   it("`success: false` in Result JSON surfaces in MoveScriptResult.success", async () => {
-    const scriptPath = join(tmpCwd, "scripts", "bad.move");
-    mkdirSync(join(tmpCwd, "scripts"), { recursive: true });
+    const scriptPath = join(fixture.tmpCwd, "scripts", "bad.move");
+    mkdirSync(join(fixture.tmpCwd, "scripts"), { recursive: true });
     writeFileSync(scriptPath, "// dummy\n");
 
     const { adapter } = makeAdapter({

--- a/packages/movehat/src/__tests__/harness/view.test.ts
+++ b/packages/movehat/src/__tests__/harness/view.test.ts
@@ -1,16 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 import { Harness } from "../../harness/index.js";
-import { _resetConfigCache } from "../../core/config.js";
+import { setupHarnessTestFixture, type HarnessTestFixture } from "./_fixture.js";
 
 /**
  * Tests for `Harness.runViewFunction` — the SDK delegation path.
@@ -21,44 +12,14 @@ import { _resetConfigCache } from "../../core/config.js";
  * that only forwards options.
  */
 describe("Harness.runViewFunction", () => {
-  let tmpCwd: string;
-  let origCwd: string;
+  let fixture: HarnessTestFixture;
 
   beforeEach(() => {
-    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-view-"));
-    writeFileSync(
-      join(tmpCwd, "movehat.config.js"),
-      `export default {
-  defaultNetwork: "testnet",
-  networks: {
-    testnet: {
-      url: "https://testnet.movementnetwork.xyz/v1",
-      chainId: "testnet"
-    }
-  }
-};
-`
-    );
-    const moveDir = join(tmpCwd, "move");
-    mkdirSync(join(moveDir, "sources"), { recursive: true });
-    writeFileSync(
-      join(moveDir, "Move.toml"),
-      `[package]\nname = "dummy"\nversion = "0.0.1"\n\n[addresses]\n`
-    );
-    writeFileSync(join(moveDir, "sources", "dummy.move"), "// empty\n");
-
-    origCwd = process.cwd();
-    process.chdir(tmpCwd);
-    _resetConfigCache();
+    fixture = setupHarnessTestFixture();
   });
 
   afterEach(() => {
-    try {
-      process.chdir(origCwd);
-    } finally {
-      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
-      _resetConfigCache();
-    }
+    fixture.teardown();
   });
 
   it("happy path: forwards correct payload to aptos.view and returns the raw result array", async () => {


### PR DESCRIPTION
## Summary

Six \`__tests__/harness/\` files duplicated the same \`beforeEach\`/\`afterEach\` boilerplate (~30 LoC each): tmpdir cwd, write \`movehat.config.js\` + Move package, chdir, \`_resetConfigCache\`, plus optional HOME management for tests exercising \`~/.aptos/config.yaml\` profile writes. Identified as a 🟢 nit in the M2.1 self-review; triggered when M2.2/M2.3/M2.4 added more variants without consolidating.

## What changed

**New:** \`packages/movehat/src/__tests__/harness/_fixture.ts\` — exports \`setupHarnessTestFixture({ extraNetworks?, withTmpHome? })\` returning \`{ tmpCwd, tmpHome?, teardown() }\`. Defaults match the common shape (single \`testnet\` network, no HOME management). Two opt-ins cover the variant cases:

- \`extraNetworks\` — \`Harness.createLive.test.ts\` needs a \`custom\` network for the network-switch test.
- \`withTmpHome\` — \`codeObject.{deploy,upgrade}.test.ts\` + \`script.test.ts\` need isolated HOME for profile-write tests.

**Migrated 6 files:**
- \`Harness.proxy.test.ts\` — default fixture
- \`Harness.createLive.test.ts\` — default + extra \`custom\` network
- \`codeObject.deploy.test.ts\` — \`withTmpHome: true\` + separate \`delete process.env.MH_CLI_REDEPLOY\` cleanup
- \`codeObject.upgrade.test.ts\` — \`withTmpHome: true\`
- \`script.test.ts\` — \`withTmpHome: true\`
- \`view.test.ts\` — default fixture

## vitest pickup

\`vitest.config.ts\` include pattern is \`src/**/__tests__/**/*.test.ts\` — \`_fixture.ts\` is not picked up (no \`.test\` suffix). The file is test-only, not re-exported from \`src/index.ts\`.

## Net diff

\`-262\` LoC across 6 test files + \`+140\` LoC new helper = **net ~-120 LoC** and DRY-er. Drift surface goes from 6 copies to 1.

## Test plan

- [x] Tier 1: \`pnpm --filter movehat exec tsc --noEmit\` — clean
- [x] Tier 1: \`pnpm --filter movehat test\` — **224/224 unchanged** (no behavior change)
- [x] Tier 1: \`pnpm check:example\` — green
- [N/A] Tier 2/3: pure test-infra refactor; no public surface, no template, no CLI change

Standalone refactor chore. No milestone gating.