### PR TITLE
test(fork/node): cover ForkManager + LocalNodeManager lifecycles to ≥80% (M3.3)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -131,8 +131,8 @@ Each milestone below lists **explicit, mechanically verifiable** acceptance crit
 - [x] `packages/movehat/src/runtime.ts` (M3.2 — 100% stmts via `src/__tests__/runtime.test.ts`, 13 cases)
 - [x] `packages/movehat/src/core/config.ts` (M3.2 — 88.7% stmts; +20 cases on resolveNetworkConfig)
 - [x] `packages/movehat/src/core/AccountManager.ts` (M3.2 — 97.4% stmts; +23 cases across create/lookup/load/export)
-- [ ] `packages/movehat/src/fork/manager.ts`
-- [ ] `packages/movehat/src/node/LocalNodeManager.ts`
+- [x] `packages/movehat/src/fork/manager.ts` (M3.3 — 97.1% stmts via `src/fork/__tests__/manager.test.ts`, 24 cases)
+- [x] `packages/movehat/src/node/LocalNodeManager.ts` (M3.3 — 94.4% stmts via `src/node/__tests__/LocalNodeManager.test.ts`, 20 cases)
 - [ ] `packages/movehat/src/commands/compile.ts`
 - [ ] `packages/movehat/src/commands/init.ts`
 - [ ] `packages/movehat/src/commands/run.ts`

--- a/packages/movehat/src/fork/__tests__/manager.test.ts
+++ b/packages/movehat/src/fork/__tests__/manager.test.ts
@@ -1,0 +1,385 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Tests for `ForkManager` (M3.3). Strategy:
+ *   - `vi.mock` the upstream `MovementApiClient` (network layer) so
+ *     tests stay offline and deterministic.
+ *   - Use a REAL `ForkStorage` against a tmpdir (storage is already
+ *     covered at ~85% by its own suite; we treat it as a trusted
+ *     dependency here and assert the manager's lifecycle on top of it).
+ */
+
+// Module-scoped fakes — populated per test via setMockApi() below.
+const fakeApi = {
+  getLedgerInfo: vi.fn(),
+  getAccount: vi.fn(),
+  getAccountResource: vi.fn(),
+  getAccountResources: vi.fn(),
+};
+
+// Track the (nodeUrl, apiKey) pair every constructor call sees, so we
+// can assert setApiKey reconstructs the client.
+const apiCtorCalls: Array<{ nodeUrl: string; apiKey?: string | undefined }> = [];
+
+vi.mock("../api.js", () => ({
+  MovementApiClient: class {
+    constructor(nodeUrl: string, apiKey?: string) {
+      apiCtorCalls.push({ nodeUrl, apiKey });
+    }
+    getLedgerInfo = fakeApi.getLedgerInfo;
+    getAccount = fakeApi.getAccount;
+    getAccountResource = fakeApi.getAccountResource;
+    getAccountResources = fakeApi.getAccountResources;
+  },
+}));
+
+// Static import after the mock declaration — vi hoists vi.mock calls.
+import { ForkManager } from "../manager.js";
+
+const TEST_NODE_URL = "https://testnet.movementnetwork.xyz/v1";
+const TEST_ADDR = "0x" + "a".repeat(64);
+const COIN_TYPE = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
+
+function ledgerInfoFixture() {
+  return {
+    chain_id: 27,
+    ledger_version: "100",
+    ledger_timestamp: "1234567890",
+    epoch: "5",
+    block_height: "42",
+  };
+}
+
+describe("ForkManager — initialize / load", () => {
+  let tmpDir: string;
+  let forkPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "movehat-forkmgr-"));
+    forkPath = join(tmpDir, "fork");
+    apiCtorCalls.length = 0;
+    fakeApi.getLedgerInfo.mockReset();
+    fakeApi.getAccount.mockReset();
+    fakeApi.getAccountResource.mockReset();
+    fakeApi.getAccountResources.mockReset();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("initialize writes metadata and constructs an API client without apiKey by default", async () => {
+    fakeApi.getLedgerInfo.mockResolvedValue(ledgerInfoFixture());
+    const mgr = new ForkManager(forkPath);
+
+    await mgr.initialize(TEST_NODE_URL);
+
+    expect(apiCtorCalls).toHaveLength(1);
+    expect(apiCtorCalls[0]?.nodeUrl).toBe(TEST_NODE_URL);
+    expect(apiCtorCalls[0]?.apiKey).toBeUndefined();
+
+    const meta = mgr.getMetadata();
+    expect(meta.network).toBe("custom");
+    expect(meta.nodeUrl).toBe(TEST_NODE_URL);
+    expect(meta.chainId).toBe(27);
+    expect(meta.ledgerVersion).toBe("100");
+  });
+
+  it("initialize passes apiKey through to the API client", async () => {
+    fakeApi.getLedgerInfo.mockResolvedValue(ledgerInfoFixture());
+    const mgr = new ForkManager(forkPath);
+
+    await mgr.initialize(TEST_NODE_URL, "testnet", "secret-key");
+
+    expect(apiCtorCalls).toHaveLength(1);
+    expect(apiCtorCalls[0]?.apiKey).toBe("secret-key");
+  });
+
+  it("initialize labels the fork with the provided networkName", async () => {
+    fakeApi.getLedgerInfo.mockResolvedValue(ledgerInfoFixture());
+    const mgr = new ForkManager(forkPath);
+
+    await mgr.initialize(TEST_NODE_URL, "bardock-testnet");
+
+    expect(mgr.getMetadata().network).toBe("bardock-testnet");
+  });
+
+  it("load throws when the fork directory doesn't exist", () => {
+    const mgr = new ForkManager(forkPath);
+    expect(() => mgr.load()).toThrow(/Fork does not exist/);
+  });
+
+  it("load restores metadata from disk and reconstructs the API client", async () => {
+    fakeApi.getLedgerInfo.mockResolvedValue(ledgerInfoFixture());
+    const first = new ForkManager(forkPath);
+    await first.initialize(TEST_NODE_URL);
+
+    apiCtorCalls.length = 0;
+
+    const reloaded = new ForkManager(forkPath);
+    reloaded.load();
+
+    expect(apiCtorCalls).toHaveLength(1);
+    expect(reloaded.getMetadata().nodeUrl).toBe(TEST_NODE_URL);
+  });
+
+  it("setApiKey reconstructs the API client when one already exists", async () => {
+    fakeApi.getLedgerInfo.mockResolvedValue(ledgerInfoFixture());
+    const mgr = new ForkManager(forkPath);
+    await mgr.initialize(TEST_NODE_URL);
+
+    apiCtorCalls.length = 0;
+    mgr.setApiKey("new-key");
+
+    expect(apiCtorCalls).toHaveLength(1);
+    expect(apiCtorCalls[0]?.apiKey).toBe("new-key");
+  });
+
+  it("setApiKey(undefined) clears the key on the next reconstruction", async () => {
+    fakeApi.getLedgerInfo.mockResolvedValue(ledgerInfoFixture());
+    const mgr = new ForkManager(forkPath);
+    await mgr.initialize(TEST_NODE_URL, "custom", "key");
+
+    apiCtorCalls.length = 0;
+    mgr.setApiKey(undefined);
+
+    expect(apiCtorCalls).toHaveLength(1);
+    expect(apiCtorCalls[0]?.apiKey).toBeUndefined();
+  });
+
+  it("setApiKey is a no-op before initialize/load (no client yet)", () => {
+    const mgr = new ForkManager(forkPath);
+    apiCtorCalls.length = 0;
+    mgr.setApiKey("key");
+    expect(apiCtorCalls).toHaveLength(0);
+  });
+});
+
+describe("ForkManager — account + resource fetch", () => {
+  let tmpDir: string;
+  let forkPath: string;
+  let mgr: ForkManager;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "movehat-forkmgr-"));
+    forkPath = join(tmpDir, "fork");
+    apiCtorCalls.length = 0;
+    fakeApi.getLedgerInfo.mockResolvedValue(ledgerInfoFixture());
+    fakeApi.getAccount.mockReset();
+    fakeApi.getAccountResource.mockReset();
+    fakeApi.getAccountResources.mockReset();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    mgr = new ForkManager(forkPath);
+    await mgr.initialize(TEST_NODE_URL);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("getAccount fetches from API and caches in storage on first call", async () => {
+    fakeApi.getAccount.mockResolvedValue({
+      sequence_number: "7",
+      authentication_key: "0xabc",
+    });
+
+    const state = await mgr.getAccount(TEST_ADDR);
+    expect(state.sequenceNumber).toBe("7");
+    expect(state.authenticationKey).toBe("0xabc");
+    expect(fakeApi.getAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("getAccount returns the cached state on second call (no extra API hit)", async () => {
+    fakeApi.getAccount.mockResolvedValue({
+      sequence_number: "7",
+      authentication_key: "0xabc",
+    });
+
+    await mgr.getAccount(TEST_ADDR);
+    await mgr.getAccount(TEST_ADDR);
+
+    expect(fakeApi.getAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("getAccount throws if the manager was never initialized/loaded", async () => {
+    const fresh = new ForkManager(join(tmpDir, "uninitialized"));
+    await expect(fresh.getAccount(TEST_ADDR)).rejects.toThrow(
+      /Fork not initialized/
+    );
+  });
+
+  it("getResource fetches and caches by resource type", async () => {
+    fakeApi.getAccountResource.mockResolvedValue({
+      data: { value: "42" },
+    });
+
+    const r1 = await mgr.getResource(TEST_ADDR, "0x1::counter::Counter");
+    expect(r1).toEqual({ value: "42" });
+    const r2 = await mgr.getResource(TEST_ADDR, "0x1::counter::Counter");
+    expect(r2).toEqual({ value: "42" });
+    expect(fakeApi.getAccountResource).toHaveBeenCalledTimes(1);
+  });
+
+  it("getResource rethrows a clean 'not found' for upstream 404 errors", async () => {
+    fakeApi.getAccountResource.mockRejectedValue(new Error("HTTP 404: not found"));
+    await expect(
+      mgr.getResource(TEST_ADDR, "0x1::missing::Resource")
+    ).rejects.toThrow(/Resource .* not found for account/);
+  });
+
+  it("getResource rethrows other errors unchanged", async () => {
+    fakeApi.getAccountResource.mockRejectedValue(new Error("connection refused"));
+    await expect(
+      mgr.getResource(TEST_ADDR, "0x1::missing::Resource")
+    ).rejects.toThrow(/connection refused/);
+  });
+
+  it("getAllResources fetches the whole list once, caches, and returns by type", async () => {
+    fakeApi.getAccountResources.mockResolvedValue([
+      { type: "0x1::a::A", data: { x: 1 } },
+      { type: "0x1::b::B", data: { y: 2 } },
+    ]);
+
+    const first = await mgr.getAllResources(TEST_ADDR);
+    expect(Object.keys(first).sort()).toEqual(["0x1::a::A", "0x1::b::B"]);
+    expect(first["0x1::a::A"]).toEqual({ x: 1 });
+
+    // Second call should hit cache (API call count stays at 1).
+    await mgr.getAllResources(TEST_ADDR);
+    expect(fakeApi.getAccountResources).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ForkManager — fundAccount / setResource / list / getOrCreateAccount", () => {
+  let tmpDir: string;
+  let forkPath: string;
+  let mgr: ForkManager;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "movehat-forkmgr-"));
+    forkPath = join(tmpDir, "fork");
+    apiCtorCalls.length = 0;
+    fakeApi.getLedgerInfo.mockResolvedValue(ledgerInfoFixture());
+    fakeApi.getAccount.mockReset();
+    fakeApi.getAccountResource.mockReset();
+    fakeApi.getAccountResources.mockReset();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    mgr = new ForkManager(forkPath);
+    await mgr.initialize(TEST_NODE_URL);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("fundAccount creates a fresh CoinStore when none exists upstream", async () => {
+    fakeApi.getAccountResource.mockRejectedValue(new Error("HTTP 404: not found"));
+
+    await mgr.fundAccount(TEST_ADDR, 1_000);
+
+    // Now the resource should be in cache — read it back without another API hit.
+    fakeApi.getAccountResource.mockClear();
+    const stored = await mgr.getResource(TEST_ADDR, COIN_TYPE);
+    expect(stored).toBeDefined();
+    expect(stored.coin.value).toBe("1000");
+    expect(fakeApi.getAccountResource).not.toHaveBeenCalled();
+  });
+
+  it("fundAccount adds to existing balance on a second call (accumulates)", async () => {
+    fakeApi.getAccountResource.mockRejectedValue(new Error("HTTP 404: not found"));
+    await mgr.fundAccount(TEST_ADDR, 1_000);
+    await mgr.fundAccount(TEST_ADDR, 500);
+
+    const stored = await mgr.getResource(TEST_ADDR, COIN_TYPE);
+    expect(stored.coin.value).toBe("1500");
+  });
+
+  it("fundAccount rethrows non-404 errors from getResource", async () => {
+    fakeApi.getAccountResource.mockRejectedValue(new Error("upstream is angry"));
+    await expect(mgr.fundAccount(TEST_ADDR, 100)).rejects.toThrow(/upstream is angry/);
+  });
+
+  it("fundMultipleAccounts funds every address in the list", async () => {
+    fakeApi.getAccountResource.mockRejectedValue(new Error("HTTP 404: not found"));
+
+    const addrs = [
+      "0x" + "1".repeat(64),
+      "0x" + "2".repeat(64),
+      "0x" + "3".repeat(64),
+    ];
+    await mgr.fundMultipleAccounts(addrs, 500);
+
+    // Each address now has a 500-balance CoinStore in cache.
+    fakeApi.getAccountResource.mockClear();
+    for (const addr of addrs) {
+      const stored = await mgr.getResource(addr, COIN_TYPE);
+      expect(stored.coin.value).toBe("500");
+    }
+    expect(fakeApi.getAccountResource).not.toHaveBeenCalled();
+  });
+
+  it("setResource overwrites a cached resource", async () => {
+    await mgr.setResource(TEST_ADDR, "0x1::custom::Resource", { value: 1 });
+    await mgr.setResource(TEST_ADDR, "0x1::custom::Resource", { value: 2 });
+    const stored = await mgr.getResource(TEST_ADDR, "0x1::custom::Resource");
+    expect(stored).toEqual({ value: 2 });
+  });
+
+  it("listAccounts returns the cached account list", async () => {
+    fakeApi.getAccountResource.mockRejectedValue(new Error("HTTP 404: not found"));
+    await mgr.fundAccount(TEST_ADDR, 100);
+    const list = mgr.listAccounts();
+    expect(list.length).toBeGreaterThan(0);
+  });
+
+  it("getOrCreateAccount returns the existing account when one is cached", async () => {
+    fakeApi.getAccount.mockResolvedValue({
+      sequence_number: "0",
+      authentication_key: "0xabc",
+    });
+    await mgr.getAccount(TEST_ADDR);
+    fakeApi.getAccount.mockClear();
+
+    const result = await mgr.getOrCreateAccount(TEST_ADDR);
+    expect(result.authenticationKey).toBe("0xabc");
+    expect(fakeApi.getAccount).not.toHaveBeenCalled();
+  });
+
+  it("getOrCreateAccount synthesizes a minimal account when the upstream lookup fails", async () => {
+    // Force the storage cache miss AND the API throw, exercising the
+    // catch arm that creates the account locally.
+    fakeApi.getAccount.mockRejectedValue(new Error("HTTP 404: not found"));
+
+    const result = await mgr.getOrCreateAccount(TEST_ADDR);
+    expect(result.sequenceNumber).toBe("0");
+    expect(result.authenticationKey).toHaveLength(66);
+  });
+
+  it("resetState clears cached accounts and resources", async () => {
+    fakeApi.getAccount.mockResolvedValue({
+      sequence_number: "5",
+      authentication_key: "0xabc",
+    });
+    await mgr.getAccount(TEST_ADDR);
+
+    await mgr.resetState();
+
+    fakeApi.getAccount.mockClear();
+    fakeApi.getAccount.mockResolvedValue({
+      sequence_number: "5",
+      authentication_key: "0xabc",
+    });
+    // After reset, fetching again should hit the API (not the cache).
+    await mgr.getAccount(TEST_ADDR);
+    expect(fakeApi.getAccount).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/movehat/src/node/__tests__/LocalNodeManager.test.ts
+++ b/packages/movehat/src/node/__tests__/LocalNodeManager.test.ts
@@ -1,0 +1,452 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { mkdtempSync, rmSync, existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { LocalNodeManager } from "../LocalNodeManager.js";
+import type {
+  ChildProcessAdapter,
+  SpawnInput,
+  SpawnedProcess,
+} from "../../utils/childProcessAdapter.js";
+
+/**
+ * Tests for `LocalNodeManager` (M3.3).
+ *
+ * Strategy:
+ *   - Inject a fake `ChildProcessAdapter` so we control the spawn
+ *     handle (stdout/stderr streams, kill semantics, exit promise).
+ *   - Stub global `fetch` so the ready/faucet endpoints return
+ *     controllable responses without real HTTP.
+ *
+ * What we DON'T test here:
+ *   - The 60-second ready timeout in real-time (would block the suite).
+ *     Instead we either stub fetch to succeed on first call, or for the
+ *     timeout-path test we shrink the timeout via a wrapper that bypasses
+ *     `start()` and calls a faster path. The timeout error message is
+ *     verified by exercising `start()` with a never-ready fetch and
+ *     fake timers.
+ */
+
+interface FakeSpawnedProcess extends SpawnedProcess {
+  /** Test helper — manually trigger the "exited" promise resolution. */
+  __exit: (code: number | null, signal: NodeJS.Signals | null) => void;
+}
+
+function buildFakeSpawned(): FakeSpawnedProcess {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough();
+  let exitResolve!: (v: { code: number | null; signal: NodeJS.Signals | null }) => void;
+  const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve) => {
+      exitResolve = resolve;
+    }
+  );
+  let killed = false;
+  const proc: FakeSpawnedProcess = {
+    pid: 4242,
+    stdout,
+    stderr,
+    stdin,
+    kill: (_signal?: NodeJS.Signals) => {
+      if (killed) return false;
+      killed = true;
+      // Resolve `exited` shortly after kill so `stop()` doesn't hang.
+      setImmediate(() => exitResolve({ code: null, signal: _signal ?? "SIGTERM" }));
+      return true;
+    },
+    exited,
+    __exit: (code, signal) => exitResolve({ code, signal }),
+  };
+  return proc;
+}
+
+function buildFakeAdapter(): {
+  adapter: ChildProcessAdapter;
+  calls: SpawnInput[];
+  spawned: FakeSpawnedProcess[];
+} {
+  const calls: SpawnInput[] = [];
+  const spawned: FakeSpawnedProcess[] = [];
+  const adapter: ChildProcessAdapter = {
+    run: vi.fn(),
+    spawn: (input) => {
+      calls.push(input);
+      const proc = buildFakeSpawned();
+      spawned.push(proc);
+      return proc;
+    },
+  };
+  return { adapter, calls, spawned };
+}
+
+function stubFetchOnce(response: { ok: boolean; text?: () => Promise<string>; json?: () => Promise<unknown> }) {
+  const fn = vi.fn().mockResolvedValueOnce(response);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+function stubFetchAlwaysOk() {
+  const fn = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+describe("LocalNodeManager — start / stop / lifecycle", () => {
+  let tmpDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "movehat-localnode-"));
+    // The logger prints to stdout/stderr; silence the noise for cleaner test output.
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("constructs with sensible defaults from getNodeInfo", () => {
+    const { adapter } = buildFakeAdapter();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
+
+    const info = mgr.getNodeInfo();
+    expect(info.rpcUrl).toBe("http://127.0.0.1:8080");
+    expect(info.faucetUrl).toBe("http://127.0.0.1:8081");
+    expect(info.readyUrl).toBe("http://127.0.0.1:8070");
+    expect(info.testDir).toBe(tmpDir);
+  });
+
+  it("honors custom ports from constructor options", () => {
+    const { adapter } = buildFakeAdapter();
+    const mgr = new LocalNodeManager({
+      adapter,
+      testDir: tmpDir,
+      apiPort: 9000,
+      faucetPort: 9001,
+      readyPort: 9002,
+    });
+    const info = mgr.getNodeInfo();
+    expect(info.rpcUrl).toContain(":9000");
+    expect(info.faucetUrl).toContain(":9001");
+    expect(info.readyUrl).toContain(":9002");
+  });
+
+  it("isRunning reports false before start", () => {
+    const { adapter } = buildFakeAdapter();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
+    expect(mgr.isRunning()).toBe(false);
+  });
+
+  it("start spawns 'movement node run-localnet' with the expected args", async () => {
+    const { adapter, calls } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+
+    await mgr.start();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toBe("movement");
+    const args = calls[0]?.args ?? [];
+    expect(args.slice(0, 2)).toEqual(["node", "run-localnet"]);
+    expect(args).toContain("--test-dir");
+    expect(args).toContain(tmpDir);
+    expect(args).toContain("--faucet-port");
+    expect(args).toContain("8081");
+    expect(args).toContain("--assume-yes");
+    expect(mgr.isRunning()).toBe(true);
+  });
+
+  it("start in silent mode does not wire stdout/stderr listeners", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+
+    await mgr.start();
+
+    // The PassThrough streams should have no `data` listeners attached
+    // when `silent: true` is set.
+    const proc = spawned[0]!;
+    expect(proc.stdout!.listenerCount("data")).toBe(0);
+    expect(proc.stderr!.listenerCount("data")).toBe(0);
+  });
+
+  it("start in non-silent mode wires stdout/stderr listeners that log events", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: false });
+
+    await mgr.start();
+
+    const proc = spawned[0]!;
+    expect(proc.stdout!.listenerCount("data")).toBeGreaterThan(0);
+    expect(proc.stderr!.listenerCount("data")).toBeGreaterThan(0);
+
+    // Drive a line through stdout — the manager's listener forwards to console.log.
+    proc.stdout!.emit("data", Buffer.from("local node ready\n"));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("local node ready"));
+
+    // stderr non-WARN line goes through console.error.
+    proc.stderr!.emit("data", Buffer.from("real error\n"));
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("real error"));
+
+    // stderr WARN line should be filtered (no error log).
+    errSpy.mockClear();
+    proc.stderr!.emit("data", Buffer.from("WARN something\n"));
+    expect(errSpy).not.toHaveBeenCalledWith(expect.stringContaining("WARN"));
+  });
+
+  it("force-restart cleans the test directory before spawn", async () => {
+    const { adapter } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const planted = join(tmpDir, "stale-file.txt");
+    // Create a stale file to prove the cleanup actually removes it.
+    mkdirSync(tmpDir, { recursive: true });
+    require("node:fs").writeFileSync(planted, "stale");
+    expect(existsSync(planted)).toBe(true);
+
+    const mgr = new LocalNodeManager({
+      adapter,
+      testDir: tmpDir,
+      forceRestart: true,
+      silent: true,
+    });
+
+    await mgr.start();
+    expect(existsSync(planted)).toBe(false);
+  });
+
+  it("force-restart appends --force-restart to the CLI args", async () => {
+    const { adapter, calls } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({
+      adapter,
+      testDir: tmpDir,
+      forceRestart: true,
+      silent: true,
+    });
+    await mgr.start();
+    expect(calls[0]?.args).toContain("--force-restart");
+  });
+
+  it("calling start twice returns the same node info (idempotent)", async () => {
+    const { adapter, calls } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+
+    const info1 = await mgr.start();
+    const info2 = await mgr.start();
+    expect(info2).toEqual(info1);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("stop signals SIGTERM and clears the spawned handle", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+    await mgr.start();
+
+    const killSpy = vi.spyOn(spawned[0]!, "kill");
+    await mgr.stop();
+
+    expect(killSpy).toHaveBeenCalledWith("SIGTERM");
+    expect(mgr.isRunning()).toBe(false);
+  });
+
+  it("stop is a no-op when no node is running", async () => {
+    const { adapter } = buildFakeAdapter();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
+    // Should not throw.
+    await mgr.stop();
+    expect(mgr.isRunning()).toBe(false);
+  });
+
+  it("clean refuses while the node is running", async () => {
+    const { adapter } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+    await mgr.start();
+
+    await expect(mgr.clean()).rejects.toThrow(/Cannot clean while node is running/);
+  });
+
+  it("clean removes the test directory after stop", async () => {
+    const { adapter } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+    await mgr.start();
+    await mgr.stop();
+
+    expect(existsSync(tmpDir)).toBe(true);
+    await mgr.clean();
+    expect(existsSync(tmpDir)).toBe(false);
+  });
+
+  it("clean is a no-op when the test directory doesn't exist", async () => {
+    const { adapter } = buildFakeAdapter();
+    const missing = join(tmpDir, "never-created");
+    const mgr = new LocalNodeManager({ adapter, testDir: missing });
+    // Should not throw.
+    await mgr.clean();
+  });
+});
+
+describe("LocalNodeManager — start failure paths", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "movehat-localnode-"));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("waitForReady timeout surfaces a clear error AND cleans up the spawn", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    // Always-failing fetch — node never becomes ready.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED"))
+    );
+
+    vi.useFakeTimers();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+
+    // Attach the .catch handler synchronously so the eventual rejection
+    // never lands as an unhandled promise. vi.advanceTimersByTimeAsync
+    // drives the waitForReady loop forward; we then await the captured
+    // error and assert on it.
+    let captured: unknown;
+    const startPromise = mgr.start().catch((e) => {
+      captured = e;
+    });
+
+    // Drive the 60s timeout forward — each loop iteration does fetch +
+    // sleep(1000). Advance well past 60 000 ms.
+    await vi.advanceTimersByTimeAsync(61_000);
+    await startPromise;
+
+    expect(captured).toBeInstanceOf(Error);
+    expect((captured as Error).message).toMatch(/did not become ready/);
+    // The spawn handle must have been killed in the catch arm.
+    expect(spawned[0]).toBeDefined();
+    expect(mgr.isRunning()).toBe(false);
+    vi.useRealTimers();
+  });
+});
+
+describe("LocalNodeManager — fundAccount", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "movehat-localnode-"));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects when called before the node is running", async () => {
+    const { adapter } = buildFakeAdapter();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
+    await expect(mgr.fundAccount("0xabc", 100)).rejects.toThrow(
+      /Local node is not running/
+    );
+  });
+
+  it("posts to the faucet endpoint and returns the parsed JSON on success", async () => {
+    const { adapter } = buildFakeAdapter();
+    // First fetch = ready check; subsequent = faucet mint.
+    const fetchFn = vi.fn();
+    fetchFn.mockResolvedValueOnce({ ok: true }); // waitForReady
+    fetchFn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ txn_hashes: ["0xdeadbeef"] }),
+    }); // faucet
+    vi.stubGlobal("fetch", fetchFn);
+
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+    await mgr.start();
+
+    const addr = "0x" + "1".repeat(64);
+    const result = await mgr.fundAccount(addr, 12345);
+
+    expect(result).toEqual({ txn_hashes: ["0xdeadbeef"] });
+    const faucetCall = fetchFn.mock.calls[1]!;
+    expect(faucetCall[0]).toContain("/mint?amount=12345&address=" + addr);
+    expect(faucetCall[1]?.method).toBe("POST");
+  });
+
+  it("rethrows a clear error when the faucet returns non-ok", async () => {
+    const { adapter } = buildFakeAdapter();
+    const fetchFn = vi.fn();
+    fetchFn.mockResolvedValueOnce({ ok: true }); // waitForReady
+    fetchFn.mockResolvedValueOnce({
+      ok: false,
+      text: async () => "out of funds",
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchFn);
+
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+    await mgr.start();
+
+    await expect(mgr.fundAccount("0xabc", 100)).rejects.toThrow(
+      /Failed to fund account.*out of funds/
+    );
+  });
+
+  it("fundAccount accepts an Account-like object by reading accountAddress.toString()", async () => {
+    const { adapter } = buildFakeAdapter();
+    const fetchFn = vi.fn();
+    fetchFn.mockResolvedValueOnce({ ok: true }); // waitForReady
+    fetchFn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchFn);
+
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+    await mgr.start();
+
+    const fakeAccount = {
+      accountAddress: { toString: () => "0xfeedbeef" },
+    } as never; // exercises the typeof-not-string branch
+
+    await mgr.fundAccount(fakeAccount, 100);
+    expect(fetchFn.mock.calls[1]![0]).toContain("address=0xfeedbeef");
+  });
+
+  it("fundAccounts iterates and funds each account in turn", async () => {
+    const { adapter } = buildFakeAdapter();
+    const fetchFn = vi.fn();
+    fetchFn.mockResolvedValueOnce({ ok: true }); // waitForReady
+    fetchFn.mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchFn);
+
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: true });
+    await mgr.start();
+
+    await mgr.fundAccounts(["0x1", "0x2", "0x3"], 100);
+    // 1 ready + 3 mint calls = 4 total.
+    expect(fetchFn.mock.calls.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/movehat/vitest.config.ts
+++ b/packages/movehat/vitest.config.ts
@@ -20,15 +20,18 @@ export default defineConfig({
       ],
       // Global floor stays at 15 until M3.5 flips it to 80. Per-target
       // entries below ratchet specific files to ≥80% as M3 sub-PRs land
-      // (M3.2 = runtime + config + AccountManager).
+      // (M3.2 = runtime/config/AccountManager; M3.3 = fork/manager,
+      // node/LocalNodeManager).
       thresholds: {
         lines: 15,
         functions: 15,
         branches: 10,
         statements: 15,
-        "src/runtime.ts":             { lines: 80, statements: 80, functions: 70, branches: 65 },
-        "src/core/config.ts":         { lines: 80, statements: 80, functions: 80, branches: 70 },
-        "src/core/AccountManager.ts": { lines: 80, statements: 80, functions: 80, branches: 65 },
+        "src/runtime.ts":               { lines: 80, statements: 80, functions: 70, branches: 65 },
+        "src/core/config.ts":           { lines: 80, statements: 80, functions: 80, branches: 70 },
+        "src/core/AccountManager.ts":   { lines: 80, statements: 80, functions: 80, branches: 65 },
+        "src/fork/manager.ts":          { lines: 80, statements: 80, functions: 75, branches: 60 },
+        "src/node/LocalNodeManager.ts": { lines: 80, statements: 80, functions: 75, branches: 60 },
       },
     },
     testTimeout: 10000,


### PR DESCRIPTION
## Summary

Second test-coverage sub-PR of M3 (issue #70). Lifts the two heaviest 0–8% files into the ≥80% band by adding two NEW test suites that drive the lifecycle managers through their adapter/HTTP boundaries.

| File | Before | After (stmts) |
|---|---|---|
| `src/fork/manager.ts` | 7.8% | **97.1%** |
| `src/node/LocalNodeManager.ts` | 0.0% | **94.4%** |

Total tests: 279 → 323 (+44).

## Scope

- **NEW** `src/fork/__tests__/manager.test.ts` — 24 cases
  - initialize/load lifecycle, apiKey threading, setApiKey reconstruction
  - getAccount / getResource / getAllResources cache semantics
  - fundAccount fresh-CoinStore + accumulation + non-404 rethrow
  - fundMultipleAccounts, setResource overwrite, listAccounts
  - getOrCreateAccount synthesis path, resetState cache clear
  - Strategy: `vi.mock('../api.js')` for the upstream `MovementApiClient`; real `ForkStorage` against a tmpdir (storage is already ~85% via its own suite)

- **NEW** `src/node/__tests__/LocalNodeManager.test.ts` — 20 cases
  - Constructor defaults + port overrides
  - start spawns `movement node run-localnet` with expected args + silent/non-silent listener wiring
  - WARN-line filtering on stderr
  - forceRestart cleans testDir + appends `--force-restart`
  - Idempotent start, SIGTERM stop, clean refuses while running
  - waitForReady 60s timeout error (driven via fake timers + ECONNREFUSED fetch stub, synchronous `.catch` to avoid unhandled-rejection noise)
  - fundAccount happy path + faucet failure + Account-like input
  - fundAccounts iteration
  - Strategy: fake `ChildProcessAdapter` whose `spawn()` returns a PassThrough-stream'd `SpawnedProcess`; `vi.stubGlobal('fetch', …)` per-test for ready + faucet endpoints

- **EDIT** `packages/movehat/vitest.config.ts` — per-file thresholds for the 2 files.

## DoD (Tracks #70 / Closes #133)

- [x] `packages/movehat/src/fork/manager.ts` ≥80% statements
- [x] `packages/movehat/src/node/LocalNodeManager.ts` ≥80% statements
- [x] `vitest.config.ts` per-target threshold entries added

## Verification

| Tier | Command | Result |
|---|---|---|
| 1 | `pnpm --filter movehat exec tsc --noEmit` | pass (clean) |
| 1 | `pnpm --filter movehat test` | 323/323 pass (was 279) |
| 1 | `pnpm --filter movehat test:coverage` | 5 M3 targets ≥80%; threshold map enforced |
| 1 | `pnpm check:example` | pass |
| 2 | N/A | no public surface change |
| 3 | N/A | runs at batch-PR time |

## Test plan

- [x] Local pre-push gate (tsc + tests + check:example) passed
- [x] `test:coverage` reports per-file ≥80% on both targets
- [x] No unhandled rejections in test output (verified post-fix on waitForReady-timeout test)