### PR TITLE
fix(test): restore MH_CLI_REDEPLOY in harness-local afterAll

### DIFF
--- a/packages/movehat/test/integration/harness-local.integration.test.ts
+++ b/packages/movehat/test/integration/harness-local.integration.test.ts
@@ -42,6 +42,7 @@ describe.skipIf(SKIP_LOCAL)('Harness.createLocal — full lifecycle', () => {
   let harness: Harness;
   let codeObjectAddr: string;
   let originalCwd: string;
+  let originalRedeployEnv: string | undefined;
 
   beforeAll(async () => {
     // `Harness.createLocal` → `initRuntime` → `loadUserConfig` reads
@@ -50,8 +51,12 @@ describe.skipIf(SKIP_LOCAL)('Harness.createLocal — full lifecycle', () => {
     // load succeeds without polluting the package root with a user-
     // facing config file. `MH_CLI_REDEPLOY=true` allows re-running the
     // suite without `deployments/local/counter.json` stale-record
-    // bookkeeping aborting the second run.
+    // bookkeeping aborting the second run. Both env mutations get
+    // restored in afterAll so the process state is exactly what it
+    // was on entry — defensive against future integration tests that
+    // run in the same fork.
     originalCwd = process.cwd();
+    originalRedeployEnv = process.env.MH_CLI_REDEPLOY;
     process.chdir(integrationDir);
     process.env.MH_CLI_REDEPLOY = 'true';
 
@@ -83,6 +88,11 @@ describe.skipIf(SKIP_LOCAL)('Harness.createLocal — full lifecycle', () => {
   afterAll(async () => {
     if (harness) await harness.cleanup();
     if (originalCwd) process.chdir(originalCwd);
+    if (originalRedeployEnv === undefined) {
+      delete process.env.MH_CLI_REDEPLOY;
+    } else {
+      process.env.MH_CLI_REDEPLOY = originalRedeployEnv;
+    }
   });
 
   it('deployCodeObject publishes the v1 package', async () => {


### PR DESCRIPTION
## Summary

Addresses CodeRabbit's actionable finding on the M4 batch PR #148 ([comment](https://github.com/gilbertsahumada/movehat/pull/148#discussion_r3241847370)). The integration suite's `harness-local.integration.test.ts` mutates `process.env.MH_CLI_REDEPLOY` in `beforeAll` but never restores it. Two independent reviewers (CodeRabbit + my own §8 self-review on #145 flagged this as Minor #2) agreed it should be defensive-by-default — fixing now.

## Change

```diff
 describe.skipIf(SKIP_LOCAL)('Harness.createLocal — full lifecycle', () => {
   let harness: Harness;
   let codeObjectAddr: string;
   let originalCwd: string;
+  let originalRedeployEnv: string | undefined;

   beforeAll(async () => {
     originalCwd = process.cwd();
+    originalRedeployEnv = process.env.MH_CLI_REDEPLOY;
     process.chdir(integrationDir);
     process.env.MH_CLI_REDEPLOY = 'true';
     // ...
   });

   afterAll(async () => {
     if (harness) await harness.cleanup();
     if (originalCwd) process.chdir(originalCwd);
+    if (originalRedeployEnv === undefined) {
+      delete process.env.MH_CLI_REDEPLOY;
+    } else {
+      process.env.MH_CLI_REDEPLOY = originalRedeployEnv;
+    }
   });
```

The `delete` branch matters when the original was undefined — setting `process.env.X = undefined` actually stores the string `"undefined"`, which would propagate as a truthy value to consumers.

## Why this matters now

The integration suite currently runs `pool: 'forks', singleFork: false` so cross-file bleed inside a single process is impossible. But the M4.1 original intent was `singleFork: true` — the port-collision constraint forced the switch. If we later return to a single-fork model (e.g. to amortize the local-node startup cost across files), this fix becomes load-bearing rather than defensive.

## Verification

- ✅ `pnpm --filter movehat exec tsc --noEmit` — clean
- ✅ `MOVEHAT_SKIP_LOCAL_NODE=true MOVEMENT_RPC_URL=https://testnet.movementnetwork.xyz/v1 pnpm test:integration` — 2/2 fork pass, 5 skipped, ~5 s (matches CI shape)

## Path forward

Once this lands on `develop`, the batch PR #148 auto-picks it up. The other CodeRabbit findings on #148 are either false positives or deferred to a follow-up `chore(docs): lint TESTING.md` chore (replied inline on each comment).

Refs #148, #149