### PR TITLE
chore(docs): lint TESTING.md (MD019 + step numbering)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 Complete testing and validation guide before publishing.
 
-##  Table of Contents
+## Table of Contents
 
 1. [Testing Levels](#testing-levels)
 2. [Local Testing](#local-testing)
@@ -13,7 +13,7 @@ Complete testing and validation guide before publishing.
 
 ---
 
-##  Testing Levels
+## Testing Levels
 
 ### 1. **Unit Tests** (Future)
 - Individual function testing
@@ -42,7 +42,7 @@ Complete testing and validation guide before publishing.
 
 ---
 
-##  Local Testing
+## Local Testing
 
 ### Quick Smoke Test
 
@@ -147,7 +147,7 @@ This checks:
 
 ---
 
-##  Docker Testing
+## Docker Testing
 
 Docker testing provides **isolated, reproducible environments** to test installation and usage across different configurations.
 
@@ -195,7 +195,7 @@ docker-compose -f docker-compose.test.yml down --rmi local --volumes
 
 ---
 
-##  Pre-Publish Checklist
+## Pre-Publish Checklist
 
 Before publishing to npm, complete this checklist:
 
@@ -250,7 +250,7 @@ Before publishing to npm, complete this checklist:
 
 ---
 
-##  CI/CD Pipeline
+## CI/CD Pipeline
 
 ### Automated Testing (GitHub Actions)
 
@@ -308,7 +308,7 @@ Pre-Publish Checks  Publish to npm  Create GitHub Release  Verify Install
 
 ---
 
-##  Manual Testing Steps
+## Manual Testing Steps
 
 ### Before Every Release
 
@@ -456,7 +456,7 @@ movehat test --move  # Fast tests only (no node required)
 
 ---
 
-##  Release Process
+## Release Process
 
 ### 1. Prepare Release
 
@@ -515,7 +515,7 @@ movehat --version
 
 ---
 
-##  Testing Metrics
+## Testing Metrics
 
 Track these metrics for quality:
 
@@ -528,7 +528,7 @@ Track these metrics for quality:
 
 ---
 
-##  Useful Commands
+## Useful Commands
 
 ```bash
 # Build package
@@ -562,7 +562,7 @@ npm publish
 
 ---
 
-##  Best Practices
+## Best Practices
 
 1. **Always test on clean install** - Users don't have your dev environment
 2. **Test major Node versions** - Support LTS versions (18, 20)
@@ -575,7 +575,7 @@ npm publish
 
 ---
 
-##  Troubleshooting Tests
+## Troubleshooting Tests
 
 ### Smoke Tests Failing
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -373,7 +373,7 @@ movehat update
 # Should check for updates
 ```
 
-#### 7. Test Help Commands
+#### 8. Test Help Commands
 
 ```bash
 movehat --help
@@ -382,7 +382,7 @@ movehat test --help
 movehat fork --help
 ```
 
-#### 8. Test on Different Systems (if possible)
+#### 9. Test on Different Systems (if possible)
 
 - [ ] macOS (Intel)
 - [ ] macOS (Apple Silicon)


### PR DESCRIPTION
## Summary

Addresses the two CodeRabbit findings deferred from the M4 batch PR #148 ([MD019 spacing](https://github.com/gilbertsahumada/movehat/pull/148#discussion_r3241847399) + [duplicate step numbering](https://github.com/gilbertsahumada/movehat/pull/148#discussion_r3241847404)). Both targeted pre-M4 content in TESTING.md, so they were declined in the M4 scope per CLAUDE.md §3 (Surgical Changes) and explicitly promised as a follow-up `chore(docs): lint TESTING.md` PR. This is that PR.

## Two commits

| SHA | Title | Lines |
|---|---|---|
| `ac64f90` | `docs(testing): fix MD019 spacing on H2 headings` | 12 ins / 12 del (12 headings × 1 line) |
| `43d990b` | `docs(testing): fix duplicate step numbering under Manual Testing Steps` | 2 ins / 2 del (renumber 7→8 and 8→9) |

Total diff: **14 insertions, 14 deletions, 1 file changed**. No code, no CI, no test surface touched.

## Changes

### MD019 (commit `ac64f90`) — H2 headings only

Twelve `##  Word` → `## Word`:

```
##  Table of Contents       →  ## Table of Contents
##  Testing Levels          →  ## Testing Levels
##  Local Testing           →  ## Local Testing
##  Docker Testing          →  ## Docker Testing
##  Pre-Publish Checklist   →  ## Pre-Publish Checklist
##  CI/CD Pipeline          →  ## CI/CD Pipeline
##  Manual Testing Steps    →  ## Manual Testing Steps
##  Release Process         →  ## Release Process
##  Testing Metrics         →  ## Testing Metrics
##  Useful Commands         →  ## Useful Commands
##  Best Practices          →  ## Best Practices
##  Troubleshooting Tests   →  ## Troubleshooting Tests
```

H3/H4 left untouched — they already comply.

### Duplicate step (commit `43d990b`) — renumber 7→8 + 8→9

```
####  1. Test Installation Fresh   (unchanged)
...
####  7. Test Update Command       (unchanged — first 7)
- ####  7. Test Help Commands
+ ####  8. Test Help Commands
- ####  8. Test on Different Systems (if possible)
+ ####  9. Test on Different Systems (if possible)
```

Heading anchors are auto-generated from heading **text**, not list ordinals — `grep -r "#7-test-help" .` and `grep -r "#8-test-on" .` both return zero matches, so no external links break.

## Verification

| Tier | Command | Expected | Got |
|---|---|---|---|
| 1 | `grep -nE "^##  " TESTING.md` | no matches | ✅ no matches |
| 1 | `grep -nE "^#### [0-9]+\. " TESTING.md \| sed -E 's/.*#### ([0-9]+)\..*/\1/' \| sort -n \| uniq -c` | each step appears once | ✅ `1 1`, `1 2`, ..., `1 9` |
| 1 | `pnpm --filter movehat exec tsc --noEmit` | clean | ✅ |
| 1 | `pnpm --filter movehat test` | 397/397 pass | ✅ 397/397 in 5.3 s |
| 1 | `git diff develop..HEAD --stat` | 1 file / 14 ins / 14 del | ✅ exact match |
| 2 | N/A — docs-only |
| 3 | covered by existing M4.2 CI flow (build + unit + matrix + e2e) on this PR |

## Why deliberately small

This PR is **only** the deferred CodeRabbit fixes. Per the locked decisions in the plan:
- No `.markdownlint.json` config or CI lint step — M5+ scope, paired with a broader docs-lint policy
- No H3/H4 touch — they already comply with MD019
- No prose edits — even where content is stale (e.g. "Unit Tests (Future)" which no longer holds post-M3), it belongs in a dedicated docs-refresh PR, not this lint chore

Keeps the diff trivially reviewable and bisectable.

## Path forward

- [ ] CI green on this PR (auto-runs the M4.2 workflow — build / unit / matrix / e2e + integration + grep guard)
- [ ] §8 self-review posted
- [ ] Reply on the original deferred threads ([#3241847399](https://github.com/gilbertsahumada/movehat/pull/148#discussion_r3241847399) + [#3241847404](https://github.com/gilbertsahumada/movehat/pull/148#discussion_r3241847404)) with this PR link so CodeRabbit can close them
- [ ] Merge to `develop`
- [ ] Next milestone's `develop → main` batch carries this docs change to `main` (no standalone batch needed for a docs chore)

Refs #148