### PR TITLE
chore: M4 self-review follow-ups (extract quality check + refresh Unit Tests docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,17 +254,12 @@ jobs:
         run: pnpm install
 
       - name: Check package.json
-        run: |
-          cd packages/movehat
-          node -e "
-            const pkg = require('./package.json');
-            const required = ['name', 'version', 'description', 'author', 'license', 'repository', 'bin'];
-            const missing = required.filter(f => !pkg[f]);
-            if (missing.length) {
-              console.error('Missing required fields:', missing);
-              process.exit(1);
-            }
-          "
+        # Validation logic lives in packages/movehat/scripts/check-package-json.js
+        # (ESM, uses `readFileSync` + `JSON.parse`). Extracted from an inline
+        # CommonJS `node -e` block per M4 self-review (#147 Major 3) — the
+        # inline form tripped the workflow validation hook on every ci.yml
+        # edit during the M4.2 cycle.
+        run: node packages/movehat/scripts/check-package-json.js
 
       - name: Check for TODO/FIXME comments
         run: |

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,10 +15,11 @@ Complete testing and validation guide before publishing.
 
 ## Testing Levels
 
-### 1. **Unit Tests** (Future)
-- Individual function testing
-- Mock dependencies
-- Fast execution (<1s)
+### 1. **Unit Tests** (~2 seconds)
+- 35 test files, 397 tests across `packages/movehat/src/**/__tests__/`
+- Vitest with v8 coverage; per-file ≥80% gates on 16 critical modules (M3.5 ratchet), global ≥70% floor
+- Run via `pnpm --filter movehat test` (no Movement node required)
+- Coverage gate enforced in CI via `Check coverage threshold` step in `.github/workflows/ci.yml`
 
 ### 2. **Smoke Tests** (~30 seconds)
 - Critical path validation

--- a/packages/movehat/scripts/check-package-json.js
+++ b/packages/movehat/scripts/check-package-json.js
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Path is anchored to this script's location so the check works
+// regardless of the caller's `cwd`. Pre-extraction the inline
+// `node -e` block in .github/workflows/ci.yml was invoked with
+// `cd packages/movehat` first; anchoring removes that coupling.
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(here, '..', 'package.json');
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const required = ['name', 'version', 'description', 'author', 'license', 'repository', 'bin'];
+const missing = required.filter((f) => !pkg[f]);
+
+if (missing.length) {
+  console.error(`Missing required fields in ${pkgPath}:`, missing);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Closes the two actionable items remaining open from the M4-cycle §8 self-reviews:

| Source | Item | Commit |
|---|---|---|
| §8 self-review on [#147](https://github.com/gilbertsahumada/movehat/pull/147#issuecomment-4451596324) — Major #3 | Pre-existing `node -e` block in `quality` job triggered the workflow validation hook as a false-positive on every M4-cycle ci.yml edit | `d55b1e6` (Commit A) |
| §8 self-review on [#152](https://github.com/gilbertsahumada/movehat/pull/152#pullrequestreview-...) — Minor #2 | `### 1. **Unit Tests** (Future)` in TESTING.md was stale — M3 actually shipped 397 unit tests with ≥80% per-file coverage gates | `319481e` (Commit B) |

Both deferred per CLAUDE.md §3 (Surgical Changes) during their original PRs to keep the M4 batch scope contained. Now that M4 is fully closed (#148 merged @ `e1dde96`), this is the right window to clean up.

## Commit A — `chore(ci): extract quality job package.json check to a script file`

**New file:** `packages/movehat/scripts/check-package-json.js` (~15 LoC, ESM).

```js
import { readFileSync } from 'node:fs';
import { resolve, dirname } from 'node:path';
import { fileURLToPath } from 'node:url';

const here = dirname(fileURLToPath(import.meta.url));
const pkgPath = resolve(here, '..', 'package.json');

const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
const required = ['name', 'version', 'description', 'author', 'license', 'repository', 'bin'];
const missing = required.filter((f) => !pkg[f]);

if (missing.length) {
  console.error(`Missing required fields in ${pkgPath}:`, missing);
  process.exit(1);
}
```

**Edit:** `.github/workflows/ci.yml` Code Quality job's `Check package.json` step. Replaced the 11-line inline `node -e` block with a single `node packages/movehat/scripts/check-package-json.js` invocation.

**Behavioral parity:**
- Same 7 required fields: `name, version, description, author, license, repository, bin`
- Same exit-code semantics (1 on missing, 0 on success)
- Only behavior difference: error message now includes the resolved `pkgPath` (useful context in a CI log)

**Bonus:** the inline form contained the literal token that the validation hook regex looked for; my first comment-only reword still hit it; second pass removed the token entirely. The `quality` job step is now permanently false-positive-free.

## Commit B — `docs(testing): refresh stale "Unit Tests" section with current state`

```diff
- ### 1. **Unit Tests** (Future)
- - Individual function testing
- - Mock dependencies
- - Fast execution (<1s)
+ ### 1. **Unit Tests** (~2 seconds)
+ - 35 test files, 397 tests across `packages/movehat/src/**/__tests__/`
+ - Vitest with v8 coverage; per-file ≥80% gates on 16 critical modules (M3.5 ratchet), global ≥70% floor
+ - Run via `pnpm --filter movehat test` (no Movement node required)
+ - Coverage gate enforced in CI via `Check coverage threshold` step in `.github/workflows/ci.yml`
```

Net: 5 ins / 4 del. Matches the level of specificity used in the existing "Smoke Tests", "E2E Tests", and "Integration Tests (zero-mock)" entries.

## Verification (Tier 1 local)

| Check | Result |
|---|---|
| `node packages/movehat/scripts/check-package-json.js` | ✅ exit 0 (all 7 fields present) |
| `grep -nE "require\(" .github/workflows/ci.yml` | ✅ no matches (false positive permanently retired) |
| `grep -n "Future" TESTING.md` | ✅ no matches |
| `pnpm --filter movehat exec tsc --noEmit` | ✅ clean |
| `pnpm --filter movehat test` | ✅ 397/397 unchanged |

## Out of scope

- `.markdownlint.json` + CI lint step → deferred to M5+ per §8 self-review on #152 (Minor #1).
- Wider TESTING.md content refresh — only "Unit Tests (Future)" was explicitly flagged stale; per §3 surgical changes, the rest stays.
- Post-merge §8 self-reviews on #148, #150, #151 (also offered in the same conversation) — shipping as 3 separate `gh pr review --comment` calls **after this PR merges**, not as code changes here.

## Test plan

- [ ] CI green on this PR — confirms the new script invocation produces identical pass/fail signal to the previous inline form
- [ ] §8 self-review posted (expected: no Major items — work is mechanical)
- [ ] Merge to `develop`
- [ ] Post the three deferred §8 self-reviews on #148, #150, #151
- [ ] Next milestone's `develop → main` batch carries this chore to main

Refs #147, #152