### PR TITLE
docs(claude): codify M4 process learnings (§7 closeout + §8 pre-merge gate & defer threshold)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,15 +151,34 @@ Why this matters: without this rule, the ROADMAP drifts from reality. M0 + M1.1 
 
 How to apply: when finalizing a sub-PR (before pushing), grep the ROADMAP for the milestone you just touched, and check off every bullet the PR satisfies. If you're unsure whether a bullet is satisfied, ask in the PR description rather than guessing.
 
+### Milestone closeout (separate PR after batch merge)
+
+After a `develop → main` batch PR merges, open a follow-on `docs/MN-roadmap-status` PR targeting `develop`:
+
+- Flip the milestone header line from `### MN — …` to `### MN — ✅ shipped in PR #<batch> (develop → main batch) — …`.
+- Add the sub-PR + commit-hash table inside the milestone section: columns `| Sub | Description | PR | Commit |` — mirrors the precedent set by M3 (PR #142 / commit `d8bafac`) and M4 (PR #151 / commit `0568049`).
+- List any follow-up issues filed during the milestone with a one-line "deferred to MN+1" rationale.
+- No code, no test, no CI changes. Pure ROADMAP edit.
+
+Why a separate PR from the batch itself: the batch is the change-set; the closeout is the post-mortem. Mixing them makes the batch diff harder to review (status flips bury inside hundreds of code-diff lines) and the milestone status harder to find via `git log --grep`.
+
 ## 8. Self-Review Before Merge — Unconditional
 
 **Every PR gets a structured self-review before `gh pr merge` runs. No exceptions — including pure-docs PRs, one-line fixes, single-file edits, and PRs the author is confident about.**
+
+**Pre-merge checklist** (from #148 Major #1 — verify each item before `gh pr merge`):
+
+- [ ] §8 self-review posted as a `gh pr review --comment` by the PR author
+- [ ] 🔴 / 🟡 findings resolved on the same branch, OR explicitly deferred in a follow-up resolution comment with rationale
+- [ ] Tier 2 / Tier 3 results recorded in the PR body (or `N/A` with reason per §6.2 / §6.3)
+- [ ] `gh pr view N --json mergeable --jq .mergeable` returns `MERGEABLE` (not `UNKNOWN` or `CONFLICTING`)
 
 The rule:
 
 - Before calling `gh pr merge N`, post a self-review via `gh pr review N --comment` using the same severity-tiered structure used on prior PRs:
   - 🔴 blockers (correctness, security, broken contracts)
   - 🟡 worth fixing before merge (real concerns, fragile assumptions, deferred-but-noted)
+    - **Defer threshold** (from #150 Minor #1): when (a) the fix is ≤5 LoC AND (b) the cost of being wrong is non-zero (i.e. not pure stylistic), apply the fix in the originating PR — don't wait for a second reviewer to agree. The bar "wait until two reviewers flag it" makes the second reviewer pay the cost of catching what should have been fixed on first surface.
   - 🟢 nits (style, naming, polish)
 - If the review surfaces **🔴 or 🟡** findings, either fix them on the same branch and post a resolution comment listing what was resolved vs deferred, or explicitly note in the resolution why a 🟡 is being deferred to a follow-up sub-PR.
 - Merge happens only after **(a)** review is posted, **(b)** 🟡-or-worse findings are resolved or explicitly deferred with a reason, **(c)** mergeable state is CLEAN, **(d)** install-verification gates from §6.2 / §6.3 have been run (or marked N/A in the PR body with reason).


### PR DESCRIPTION
## Summary

Three pure-addition edits to `CLAUDE.md` — each closes one open process gap surfaced in the M4 post-merge §8 reviews on #148/#150/#151. Now executable because PR #154 re-tracked CLAUDE.md as a repo file.

## What's in the PR

| § | New content | Anchor | Origin |
|---|---|---|---|
| §7 | "Milestone closeout (separate PR after batch merge)" subsection | End of §7, after "How to apply" | #151 Minor #1 |
| §8 | "Pre-merge checklist" bold callout (4 checkbox bullets) | Right after §8 headline rule | #148 Major #1 |
| §8 | "Defer threshold" indented sub-bullet under 🟡 | Under existing 🟡 description | #150 Minor #1 |

**Diff scope: 1 file, 19 insertions, 0 deletions.** Pure additions. Existing §7/§8 paragraphs unchanged — the ~46 historical citations against prior text continue to resolve.

## Concrete edits

### §7 — Milestone closeout subsection

```diff
+### Milestone closeout (separate PR after batch merge)
+
+After a `develop → main` batch PR merges, open a follow-on `docs/MN-roadmap-status` PR targeting `develop`:
+
+- Flip the milestone header line from `### MN — …` to `### MN — ✅ shipped in PR #<batch> (develop → main batch) — …`.
+- Add the sub-PR + commit-hash table inside the milestone section: columns `| Sub | Description | PR | Commit |` — mirrors the precedent set by M3 (PR #142 / commit `d8bafac`) and M4 (PR #151 / commit `0568049`).
+- List any follow-up issues filed during the milestone with a one-line "deferred to MN+1" rationale.
+- No code, no test, no CI changes. Pure ROADMAP edit.
+
+Why a separate PR from the batch itself: the batch is the change-set; the closeout is the post-mortem. Mixing them makes the batch diff harder to review (status flips bury inside hundreds of code-diff lines) and the milestone status harder to find via `git log --grep`.
```

Codifies what M3 and M4 already did de-facto. M5 won't need to re-derive the pattern.

### §8 — Pre-merge checklist

```diff
+**Pre-merge checklist** (from #148 Major #1 — verify each item before `gh pr merge`):
+
+- [ ] §8 self-review posted as a `gh pr review --comment` by the PR author
+- [ ] 🔴 / 🟡 findings resolved on the same branch, OR explicitly deferred in a follow-up resolution comment with rationale
+- [ ] Tier 2 / Tier 3 results recorded in the PR body (or `N/A` with reason per §6.2 / §6.3)
+- [ ] `gh pr view N --json mergeable --jq .mergeable` returns `MERGEABLE` (not `UNKNOWN` or `CONFLICTING`)
```

The §8 rule was already "unconditional" textually — three M4 skips (#148, #150, #151) proved the textual emphasis wasn't enough. The checklist adds visible prominence right after the headline so it's the first thing the operator sees.

### §8 — Defer threshold

```diff
   - 🟡 worth fixing before merge (real concerns, fragile assumptions, deferred-but-noted)
+    - **Defer threshold** (from #150 Minor #1): when (a) the fix is ≤5 LoC AND (b) the cost of being wrong is non-zero (i.e. not pure stylistic), apply the fix in the originating PR — don't wait for a second reviewer to agree. The bar "wait until two reviewers flag it" makes the second reviewer pay the cost of catching what should have been fixed on first surface.
```

The MH_CLI_REDEPLOY env-restore defer (PR #145 §8 review → CodeRabbit re-flag on #148 → 3-line fix on #150) is the canonical case where the prior implicit threshold was wrong.

## Out of scope (per the plan's locked-decision #4)

- **Wall-clock projection bias** (the fourth lesson from the M4 post-merge reviews) — niche SLO-planning heuristic, not a universal per-PR rule. Will get applied in the M5 plan directly when CI-budget setting becomes relevant; no §-edit warranted.
- **Mechanical script** for self-review-presence enforcement — textual prominence is the proportional fix. If §8 skips continue post-codify, escalate to a `scripts/check-self-review.js`-style gate then.
- **§1-§6 edits** unrelated to the three M4 learnings — surgical scope (§3).

## Verification (Tier 1)

- ✅ `git diff develop..HEAD -- CLAUDE.md | grep "^[+-]" | grep -vE "^---|^\+\+\+" | wc -l` → **19** (matches projection)
- ✅ `git diff develop..HEAD -- CLAUDE.md | grep "^-" | grep -v "^---" | wc -l` → **0** (zero removed lines confirms pure additions)
- ✅ `grep -n "Milestone closeout\|Pre-merge checklist\|Defer threshold" CLAUDE.md` → three matches at lines 154 / 169 / 181 in expected sections
- ✅ `pnpm --filter movehat exec tsc --noEmit` → clean (no src change)
- ✅ `pnpm --filter movehat test` → 397/397 pass (unchanged)

## Recursive self-host check

This PR is the **first PR where the new §8 pre-merge checklist gets walked on its own merge.** If the rule passes its own gate, that's a small but meaningful self-consistency win. The self-review comment below will execute the new checklist explicitly so the audit trail shows the rule being applied to itself.

## Test plan

- [ ] CI green on this PR (docs-only — same shape as #142, #151, #152, #154)
- [ ] §8 self-review posted using the new pre-merge checklist as a literal walkthrough
- [ ] Merge to `develop`
- [ ] Next milestone's `develop → main` batch carries the codified rules to `main`

Refs #148 Major #1, #150 Minor #1, #151 Minor #1.