### PR TITLE
feat(api)!: remove getMovehat() + bump to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.0] - 2026-05-15
+
+### Removed
+
+- **BREAKING**: `getMovehat()` (and the `mh()` alias from earlier alpha releases) has been removed. The function was marked `@deprecated` since M2.4 and pointed callers at the Hardhat-style `Harness.create*` factories. Migration: replace `const mh = await getMovehat()` with either `const harness = await Harness.createLive("testnet")` (new code, lifecycle-managed) or `const runtime = await initRuntime()` (advanced use-case, equivalent to the old `getMovehat` behavior). See [#73](https://github.com/gilbertsahumada/movehat/issues/73) + [#166](https://github.com/gilbertsahumada/movehat/issues/166).
+
+### Changed
+
+- Bumped to `0.2.0` per semver-under-0.x convention: removing a publicly-exported function is a breaking change. Users pinning `~0.1` will not auto-upgrade — explicit version bump required.
+- `MovehatRuntime` type export retained (live runtime type used by `Harness.runtime`, `initRuntime()`, and all harness helpers — was misidentified as "legacy" in meta-issue #73; correction documented in PR M6.2).
+
+### Added
+
+- M5 cycle (shipped to develop pre-0.2.0; user-visible side effects):
+  - Auto-generated API reference at `/api/reference/{classes,interfaces,functions,type-aliases}/` via TypeDoc + Fumadocs ([#160](https://github.com/gilbertsahumada/movehat/pull/160)).
+  - Fork-system performance baseline + `BENCHMARKS.md` ([#161](https://github.com/gilbertsahumada/movehat/pull/161)).
+  - `MOVEMENT_CLI_COMPAT.md` with SHA256-pinned CLI artifact integrity ([#162](https://github.com/gilbertsahumada/movehat/pull/162), closes [#140](https://github.com/gilbertsahumada/movehat/issues/140)).
+- M6 cycle:
+  - `CHANGELOG.md` gate enforced in `publish.yml` — releases without a matching `## [X.Y.Z]` section fail before publishing ([#167](https://github.com/gilbertsahumada/movehat/pull/167)).
+  - Unit + integration tests run in `publish.yml` before `npm publish`.
+
+### Fixed
+
+- `ForkManager.fundAccount` and `getOrCreateAccount` previously synthesized `authentication_key` via `address.padEnd(66, '0')`, which was a no-op for already-66-char normalized addresses (`auth_key === address`). Replaced with `sha3-256(addrBytes)` — distinguishable from the address by construction. Closes [#63](https://github.com/gilbertsahumada/movehat/issues/63).
+
+---
+
 ## [0.1.9] - 2026-01-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -334,32 +334,35 @@ export default {
 
 ## Writing Deployment Scripts
 
-Deployment scripts use the **Movehat Runtime Environment (MRE)**:
+Deployment scripts use the **Hardhat-style `Harness` API**:
 
 ```typescript
 // scripts/deploy-counter.ts
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const harness = await Harness.createLive("testnet");
+  try {
+    console.log("Deploying from:", harness.runtime.account.accountAddress.toString());
+    console.log("Network:", harness.runtime.network.name);
 
-  console.log("Deploying from:", mh.account.accountAddress.toString());
-  console.log("Network:", mh.config.network);
+    // Deploy (publish) the module
+    // Movehat automatically checks if already deployed
+    const deployment = await harness.runtime.deployContract("counter");
 
-  // Deploy (publish) the module
-  // Movehat automatically checks if already deployed
-  const deployment = await mh.deployContract("counter");
+    console.log("Module deployed at:", deployment.address);
+    console.log("Transaction:", deployment.txHash);
 
-  console.log("Module deployed at:", deployment.address);
-  console.log("Transaction:", deployment.txHash);
+    // Get contract instance
+    const contract = harness.runtime.getContract(deployment.address, "counter");
 
-  // Get contract instance
-  const contract = mh.getContract(deployment.address, "counter");
+    // Initialize the counter
+    await contract.call(harness.runtime.account, "init", []);
 
-  // Initialize the counter
-  await contract.call(mh.account, "init", []);
-
-  console.log("Counter initialized!");
+    console.log("Counter initialized!");
+  } finally {
+    await harness.cleanup();
+  }
 }
 
 main().catch((error) => {
@@ -426,27 +429,31 @@ movehat run scripts/deploy-counter.ts --network testnet --redeploy
 
 ### Available Runtime Properties
 
+The runtime is reachable as `harness.runtime` on any Harness instance. For advanced use cases that need to skip the Harness lifecycle, `initRuntime()` returns the same shape directly.
+
 ```typescript
-const mh = await getMovehat();
+import { Harness } from "movehat";
+const harness = await Harness.createLive("testnet");
+const r = harness.runtime;
 
 // Core
-mh.config         // Resolved configuration
-mh.network        // Network info (name, chainId, rpc)
-mh.aptos          // Movement TypeScript SDK client
-mh.account        // Primary account
-mh.accounts       // All configured accounts
+r.config         // Resolved configuration
+r.network        // Network info (name, chainId, rpc)
+r.aptos          // Movement TypeScript SDK client
+r.account        // Primary account
+r.accounts       // All configured accounts
 
 // Contract helpers
-mh.getContract    // Get contract helper
+r.getContract    // Get contract helper
 
 // Deployment functions
-mh.deployContract       // Deploy and track module
-mh.getDeployment        // Get deployment info for a module
-mh.getDeployments       // Get all deployments for current network
-mh.getDeploymentAddress // Get deployed address for a module
+r.deployContract       // Deploy and track module
+r.getDeployment        // Get deployment info for a module
+r.getDeployments       // Get all deployments for current network
+r.getDeploymentAddress // Get deployed address for a module
 
 // Network management
-mh.switchNetwork  // Switch to different network
+r.switchNetwork  // Switch to different network
 ```
 
 ### Using Multiple Accounts
@@ -455,15 +462,16 @@ mh.switchNetwork  // Switch to different network
 // movehat.config.ts - Configure multiple accounts
 export default {
   accounts: [
-    process.env.PRIVATE_KEY,     // Primary (mh.account)
-    process.env.SECONDARY_KEY,   // mh.accounts[1]
+    process.env.PRIVATE_KEY,     // Primary (r.account)
+    process.env.SECONDARY_KEY,   // r.accounts[1]
   ].filter(Boolean),
 };
 
 // In your script - Access accounts
-const mh = await getMovehat();
-const primaryAccount = mh.account;               // accounts[0]
-const secondaryAccount = mh.getAccountByIndex(1); // accounts[1]
+const harness = await Harness.createLive("testnet");
+const r = harness.runtime;
+const primaryAccount = r.account;                 // accounts[0]
+const secondaryAccount = r.getAccountByIndex(1);  // accounts[1]
 ```
 
 ## Writing Tests
@@ -804,24 +812,27 @@ MH_DEFAULT_NETWORK=mainnet
 ### Deploy and Initialize
 
 ```typescript
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const harness = await Harness.createLive("testnet");
+  try {
+    // 1. Deploy (publish) the module
+    // Automatically checks if already deployed
+    const deployment = await harness.runtime.deployContract("counter");
+    console.log("Module deployed at:", deployment.address);
+    console.log("Transaction:", deployment.txHash);
 
-  // 1. Deploy (publish) the module
-  // Automatically checks if already deployed
-  const deployment = await mh.deployContract("counter");
-  console.log("Module deployed at:", deployment.address);
-  console.log("Transaction:", deployment.txHash);
+    // 2. Initialize
+    const contract = harness.runtime.getContract(deployment.address, "counter");
+    await contract.call(harness.runtime.account, "init", []);
 
-  // 2. Initialize
-  const contract = mh.getContract(deployment.address, "counter");
-  await contract.call(mh.account, "init", []);
-
-  // 3. Verify
-  const value = await contract.view("getValue", []);
-  console.log("Initial value:", value);
+    // 3. Verify
+    const value = await contract.view("getValue", []);
+    console.log("Initial value:", value);
+  } finally {
+    await harness.cleanup();
+  }
 }
 
 main().catch(console.error);
@@ -830,19 +841,23 @@ main().catch(console.error);
 ### Multi-Network Deployment
 
 ```typescript
-import { getMovehat } from "movehat";
+import { Harness } from "movehat";
 
 async function main() {
-  const mh = await getMovehat();
+  const network = process.argv[2] ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    if (harness.runtime.network.name === "mainnet") {
+      console.log("WARNING: Deploying to MAINNET");
+      // Add confirmation logic
+    }
 
-  if (mh.config.network === "mainnet") {
-    console.log("WARNING: Deploying to MAINNET");
-    // Add confirmation logic
+    // Deploy module - automatically tracked per network
+    const deployment = await harness.runtime.deployContract("counter");
+    console.log(`Deployed on ${harness.runtime.network.name}:`, deployment.address);
+  } finally {
+    await harness.cleanup();
   }
-
-  // Deploy module - automatically tracked per network
-  const deployment = await mh.deployContract("counter");
-  console.log(`Deployed on ${mh.config.network}:`, deployment.address);
 }
 
 main().catch(console.error);

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -247,8 +247,8 @@ Follow-up issues filed during M4 (all upstream Movement CLI / SDK, deferred to M
 
 | Sub | Description | Status |
 |---|---|---|
-| M6.1 | `ci(release): CHANGELOG gate + unit/integration tests in publish.yml + backfill` (issue #165) | 🔄 in-flight |
-| M6.2 | `feat(api)!: remove getMovehat() + bump to 0.2.0` (issue #166, closes #73 meta) | ⏳ |
+| M6.1 | `ci(release): CHANGELOG gate + unit/integration tests in publish.yml + backfill` (issue #165) | ✅ shipped in PR #167 |
+| M6.2 | `feat(api)!: remove getMovehat() + bump to 0.2.0` (issue #166, closes #73 meta) | 🔄 in-flight |
 
 **Definition of Done — Publish workflow**:
 - [x] `.github/workflows/publish.yml` triggers on GitHub release publish + `workflow_dispatch` (M6.1 — the original "v* tags" wording was specced before the workflow shipped; `release.published` is a higher-level wrapper that fires on tag-bound release creation. Functionally equivalent for the gate-on-release semantics.)
@@ -259,11 +259,11 @@ Follow-up issues filed during M4 (all upstream Movement CLI / SDK, deferred to M
 - [x] GitHub release created with the `CHANGELOG` section as body (operational flow: maintainer runs `gh release create vX.Y.Z --notes "$(awk '/## \[X.Y.Z\]/,/## \[/' CHANGELOG.md | head -n -1)"` to source release notes from CHANGELOG. Documented in `MOVEMENT_CLI_COMPAT.md`-style operational ownership.)
 
 **Definition of Done — `getMovehat()` removal & version bump**:
-- [ ] `getMovehat` no longer exported from `packages/movehat/src/index.ts` (M6.2 — meta-issue #73's "mh" was renamed to `getMovehat` in M1.5; the actual symbol to remove is `getMovehat`.)
+- [x] `getMovehat` no longer exported from `packages/movehat/src/index.ts` (M6.2 — meta-issue #73's "mh" was renamed to `getMovehat` in M1.5; removed the export + the function body in `runtime.ts` + the template `.d.ts` shim declaration + all README/example callers (migrated to `Harness.createLive()`).)
 - [N/A] Remove `MovehatRuntime` legacy types — meta-issue #73 was wrong on this. `MovehatRuntime` is the **live** runtime type used by `Harness.runtime`, `initRuntime()`, and all harness helpers. Removing it would break the live public surface. Only `getMovehat()` itself goes; `MovehatRuntime` stays exported.
-- [ ] `packages/movehat/package.json` version bumped to `0.2.0` (M6.2 — meta-issue's "0.1.0" target is stale; package already at 0.1.9 with 9 published 0.1.x versions. `getMovehat()` removal is breaking → semver bump to 0.2.0.)
-- [ ] `npm view movehat@0.2.0` returns the new version after publish (M6.2 — release create + workflow trigger sequence; verification post-merge.)
-- [ ] `npm pack` output does not contain `getMovehat` symbol (M6.2 — verified via `tar -tzf` + grep.)
+- [x] `packages/movehat/package.json` version bumped to `0.2.0` (M6.2 — meta-issue's "0.1.0" target was stale; package was already at 0.1.9 with 9 published 0.1.x versions. `getMovehat()` removal is breaking → semver bump to 0.2.0.)
+- [ ] `npm view movehat@0.2.0` returns the new version after publish (M6.2 — pending release create + workflow trigger sequence; verified post-merge.)
+- [ ] `npm pack` output does not contain `getMovehat` symbol (M6.2 — pending tarball verification post-merge.)
 
 ### M7 — Maintenance quota (continuous) — (KPI 2)
 

--- a/examples/counter-example/scripts/deploy-greeting.ts
+++ b/examples/counter-example/scripts/deploy-greeting.ts
@@ -1,50 +1,52 @@
-import { getMovehat, ModuleAlreadyDeployedError } from "movehat";
+import { Harness, ModuleAlreadyDeployedError } from "movehat";
 
 async function main() {
   console.log("🚀 Deploying Greeting contract...\n");
 
-  // Get the Movehat Runtime Environment
-  const mh = await getMovehat();
+  const harness = await Harness.createLive("testnet");
+  try {
+    console.log(`✅ Runtime initialized`);
+    console.log(`   Account: ${harness.runtime.account.accountAddress.toString()}`);
+    console.log(`   Network: ${harness.runtime.network.name}`);
+    console.log(`   RPC: ${harness.runtime.network.rpc}\n`);
 
-  console.log(`✅ Runtime initialized`);
-  console.log(`   Account: ${mh.account.accountAddress.toString()}`);
-  console.log(`   Network: ${mh.network.name}`);
-  console.log(`   RPC: ${mh.network.rpc}\n`);
+    // Deploy (publish) the module
+    // Automatically checks if already deployed and suggests --redeploy if needed
+    const deployment = await harness.runtime.deployContract("greeting");
 
-  // Deploy (publish) the module
-  // Automatically checks if already deployed and suggests --redeploy if needed
-  const deployment = await mh.deployContract("greeting");
+    console.log(`\n✅ Module deployed at: ${deployment.address}::greeting`);
+    if (deployment.txHash) {
+      console.log(`   Transaction: ${deployment.txHash}`);
+    }
 
-  console.log(`\n✅ Module deployed at: ${deployment.address}::greeting`);
-  if (deployment.txHash) {
-    console.log(`   Transaction: ${deployment.txHash}`);
+    // Get contract instance
+    const greeting = harness.runtime.getContract(deployment.address, "greeting");
+
+    // Set initial greeting
+    console.log("\n📝 Setting initial greeting...");
+    const txResult = await greeting.call(harness.runtime.account, "set_greeting", [
+      "Hello, Movement Network!"
+    ]);
+
+    console.log(`✅ Transaction hash: ${txResult.hash}`);
+    console.log(`✅ Greeting set successfully!`);
+
+    // Verify
+    const greetingText = await greeting.view<string>("get_greeting", [
+      harness.runtime.account.accountAddress.toString()
+    ]);
+
+    console.log(`\n📊 Current greeting: "${greetingText}"`);
+
+    // Get count
+    const count = await greeting.view<string>("get_count", [
+      harness.runtime.account.accountAddress.toString()
+    ]);
+
+    console.log(`📊 Greeting count: ${count}`);
+  } finally {
+    await harness.cleanup();
   }
-
-  // Get contract instance
-  const greeting = mh.getContract(deployment.address, "greeting");
-
-  // Set initial greeting
-  console.log("\n📝 Setting initial greeting...");
-  const txResult = await greeting.call(mh.account, "set_greeting", [
-    "Hello, Movement Network!"
-  ]);
-
-  console.log(`✅ Transaction hash: ${txResult.hash}`);
-  console.log(`✅ Greeting set successfully!`);
-
-  // Verify
-  const greetingText = await greeting.view<string>("get_greeting", [
-    mh.account.accountAddress.toString()
-  ]);
-
-  console.log(`\n📊 Current greeting: "${greetingText}"`);
-
-  // Get count
-  const count = await greeting.view<string>("get_count", [
-    mh.account.accountAddress.toString()
-  ]);
-
-  console.log(`📊 Greeting count: ${count}`);
 }
 
 main().catch((error) => {

--- a/packages/docs/content/docs/api/harness.mdx
+++ b/packages/docs/content/docs/api/harness.mdx
@@ -188,10 +188,10 @@ The poisoning is implemented via a `Proxy` whose `get` trap throws on access to 
 
 ## Coexistence with `setupTestFixture` / `mh()`
 
-Both pre-M2 helpers continue to work in M2.4:
+Of the pre-M2 helpers:
 
 - `import { setupTestFixture } from "movehat/helpers"` — still exported, still functional.
-- `import { getMovehat } from "movehat"` — exported with a `@deprecated` JSDoc tag; removed in `0.1.0` (M6 / [#73](https://github.com/gilbertsahumada/movehat/issues/73)).
+- `import { getMovehat } from "movehat"` — **removed in `0.2.0`** (M6 / [#73](https://github.com/gilbertsahumada/movehat/issues/73)). Use `Harness.create*` factories or `initRuntime()` instead.
 
 `Harness.createLocal` actually goes through `setupLocalTesting` (which `setupTestFixture` also uses) under the hood — the test environment is identical. The migration is API-level, not infrastructure-level.
 

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {

--- a/packages/movehat/src/__tests__/runtime.test.ts
+++ b/packages/movehat/src/__tests__/runtime.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { getMovehat, initRuntime } from "../runtime.js";
+import { initRuntime } from "../runtime.js";
 import { _resetConfigCache } from "../core/config.js";
 import { AccountManager } from "../core/AccountManager.js";
 
@@ -15,7 +15,6 @@ import { AccountManager } from "../core/AccountManager.js";
  *   - config override merging
  *   - getAccountByIndex bounds error
  *   - switchNetwork delegates back into initRuntime
- *   - getMovehat = initRuntime() with no options
  *
  * Mainnet/security gates live in `resolveNetworkConfig` and are
  * covered in `core/__tests__/config.test.ts` to avoid re-driving the
@@ -181,35 +180,3 @@ describe("initRuntime", () => {
   });
 });
 
-describe("getMovehat (deprecated alias)", () => {
-  let tmpCwd: string;
-  let origCwd: string;
-
-  beforeEach(() => {
-    origCwd = process.cwd();
-    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-runtime-test-"));
-    process.chdir(tmpCwd);
-    _resetConfigCache();
-    AccountManager.clearPool();
-    writeConfig(tmpCwd, CONFIG_TWO_NETWORKS_TWO_ACCOUNTS);
-  });
-
-  afterEach(() => {
-    process.chdir(origCwd);
-    rmSync(tmpCwd, { recursive: true, force: true });
-    _resetConfigCache();
-    AccountManager.clearPool();
-  });
-
-  it("returns the same shape as initRuntime() with no options", async () => {
-    const fromGet = await getMovehat();
-    const fromInit = await initRuntime();
-
-    // Two fresh runtimes — addresses derive from the same private keys,
-    // so they should match.
-    expect(fromGet.network.name).toBe(fromInit.network.name);
-    expect(fromGet.account.accountAddress.toString()).toBe(
-      fromInit.account.accountAddress.toString()
-    );
-  });
-});

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -2,12 +2,10 @@
 export * from "./helpers/index.js";
 export type { MovehatConfig } from "./types/config.js";
 
-// Export Movehat Runtime Environment.
-// `getMovehat` is @deprecated since M2.4 (pre-1.0) — see runtime.ts
-// JSDoc. Use the Harness.create* factories below for new code.
-// `initRuntime` stays as a public utility but external callers should
-// prefer Harness; it's the construction primitive Harness.createLive uses.
-export { initRuntime, getMovehat } from "./runtime.js";
+// Movehat Runtime Environment. `initRuntime` is a public utility but
+// external callers should prefer Harness; it's the construction primitive
+// `Harness.createLive` uses.
+export { initRuntime } from "./runtime.js";
 export type { MovehatRuntime, NetworkInfo } from "./types/runtime.js";
 
 // Export Fork system

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -157,34 +157,3 @@ export async function initRuntime(
   return runtime;
 }
 
-/**
- * Get the Movehat Runtime Environment.
- *
- * @deprecated since M2.4 (pre-1.0). Prefer the Hardhat-style `Harness`
- * factories (`Harness.createLocal` / `createFork` / `createLive`)
- * which carry explicit lifecycle (`harness.cleanup()`) and
- * use-after-cleanup safety. `getMovehat()` will be removed in
- * `0.1.0` (M6 / issue #73).
- *
- * Migration:
- * ```diff
- * - import { getMovehat } from "movehat";
- * - const mh = await getMovehat();
- * - const deployment = await mh.deployContract("counter");
- * + import { Harness } from "movehat";
- * + const harness = await Harness.createLive("testnet");
- * + try {
- * +   const deployment = await harness.deployCodeObject({ moduleName: "counter" });
- * +   // ...
- * + } finally {
- * +   await harness.cleanup();
- * + }
- * ```
- *
- * As of M1.5 each call constructs a fresh runtime — the previous
- * module-cached behavior was removed because it leaked state between
- * parallel tests and hid the runtime dependency from script signatures.
- */
-export async function getMovehat(): Promise<MovehatRuntime> {
-  return initRuntime();
-}

--- a/packages/movehat/src/templates/movehat.config.ts
+++ b/packages/movehat/src/templates/movehat.config.ts
@@ -5,9 +5,8 @@
 // template). The `Harness.create*` factories read this file via
 // `loadUserConfig` to resolve the active network + accounts.
 //
-// The older `getMovehat()` / `setupTestFixture()` helpers also read
-// the same shape and are still supported (marked `@deprecated` from
-// M2; removal is M6 / 0.1.0).
+// The `setupTestFixture()` helper also reads the same shape and
+// remains supported as a lighter-weight alternative to Harness.
 
 import dotenv from "dotenv";
 dotenv.config();

--- a/packages/movehat/src/templates/types/movehat.d.ts
+++ b/packages/movehat/src/templates/types/movehat.d.ts
@@ -53,9 +53,6 @@ declare module 'movehat' {
     switchNetwork: (networkName: string) => Promise<MovehatRuntime>;
   }
 
-  // getMovehat is a thin alias of initRuntime as of M1.5 — each call
-  // constructs a fresh runtime. The previous cached behavior is gone.
-  export function getMovehat(): Promise<MovehatRuntime>;
   export function initRuntime(configOverride?: Partial<MovehatConfig>): Promise<MovehatRuntime>;
 }
 


### PR DESCRIPTION
Closes #166 #73. Tracks nothing additional (M6 meta complete after this).

## Summary

Final M6 sub-PR. Finalizes the \`getMovehat()\` deprecation arc started in M2.4 and bumps to \`0.2.0\` per semver (breaking change marker).

> **BREAKING CHANGE**: \`getMovehat()\` is no longer exported. Migration:
>
> **Recommended** — \`Harness.createLive()\` (lifecycle-managed):
> \`\`\`ts
> import { Harness } from "movehat";
> const harness = await Harness.createLive("testnet");
> try {
>   const deployment = await harness.runtime.deployContract("counter");
>   // ...
> } finally {
>   await harness.cleanup();
> }
> \`\`\`
>
> **Advanced** — \`initRuntime()\` (low-level, no Harness lifecycle):
> \`\`\`ts
> import { initRuntime } from "movehat";
> const runtime = await initRuntime();
> const deployment = await runtime.deployContract("counter");
> \`\`\`

## Critical correction to meta-issue #73

Meta-issue says "remove \`mh()\` AND \`MovehatRuntime\` legacy types". Reality:

- There is no \`mh()\` — the symbol is \`getMovehat\` (renamed in M1.5).
- \`MovehatRuntime\` is **NOT legacy** — it's the live runtime type used by \`Harness.runtime\`, \`initRuntime()\`, and all harness helpers (\`script.ts\`, \`view.ts\`, \`codeObject.ts\`). Removing it would break the live public surface.
- Version target \`0.1.0\` is stale — package was already at \`0.1.9\` with 9 published 0.1.x versions.

**Only \`getMovehat()\` itself is removed; \`MovehatRuntime\` stays.** ROADMAP M6 DoD updated with \`[N/A]\` + rationale per CLAUDE.md §7.

## Changes (11 files)

| File | Change |
|---|---|
| \`packages/movehat/src/index.ts\` | Drop \`getMovehat\` export + deprecation comment block. \`MovehatRuntime\` type stays. |
| \`packages/movehat/src/runtime.ts\` | Delete \`getMovehat()\` function body + its 30-line JSDoc. \`initRuntime\` and other exports preserved. |
| \`packages/movehat/src/templates/types/movehat.d.ts\` | Drop \`getMovehat\` declaration. |
| \`packages/movehat/src/templates/movehat.config.ts\` | Update comment (drop \`getMovehat()\` reference). |
| \`packages/movehat/src/__tests__/runtime.test.ts\` | Delete deprecated-alias describe block + import. |
| \`packages/movehat/package.json\` | Version \`0.1.9\` → \`0.2.0\`. |
| \`CHANGELOG.md\` | Add \`[0.2.0]\` section with Removed/Changed/Added/Fixed buckets. References #73 + #166 + M5/M6 cycles. |
| \`README.md\` | Migrate 4 code examples from \`getMovehat()\` to \`Harness.createLive()\`. The "Available Runtime Properties" section now uses \`r = harness.runtime\` shorthand. |
| \`examples/counter-example/scripts/deploy-greeting.ts\` | Migrate to \`Harness.createLive()\` + \`try/finally\` cleanup. |
| \`packages/docs/content/docs/api/harness.mdx\` | Update inline removal note: "removed in 0.1.0" → "removed in 0.2.0". |
| \`ROADMAP.md\` | M6.2 row marked in-flight; M6 "getMovehat() removal" DoD bullets ticked or marked N/A. |

## §8 self-review

Will be posted as a separate \`gh pr review --comment\` per §8 unconditional rule.

## Tier 2 / Tier 3 (per §6.2 / §6.3)

- **Tier 2 \`pnpm check:example\`**: ✅ green (build:movehat + typecheck:example).
- **Tier 2 \`pnpm test:smoke\`**: ✅ green — build → pack \`movehat-0.2.0.tgz\` → global install → CLI smoke.
- **Tier 2 \`pnpm test:example\`**: green (mocha 9/9 on the prior PR baseline; getMovehat is not exercised, only Harness flows are).
- **Tarball verification**: \`tar -xzOf movehat-0.2.0.tgz package/dist/index.js | grep -c "getMovehat"\` = **0** (post-comment-removal). \`tar -xzOf … package/dist/runtime.js | grep -c "getMovehat"\` = **0**. \`tar -tzf | grep "getMovehat"\` = **0 files**. Closes the spirit of "Published bundle does not contain \`getMovehat\` symbol" DoD bullet.
- **Tier 3 \`pnpm test:e2e\`** + **\`bash scripts/pre-publish.sh\`**: will be run BEFORE the develop → main batch + release create. Not run pre-merge to develop because the batch PR is the gate point; running E2E twice (here + on batch) is wasteful and adds ~5min to release flow with no signal benefit (no code change between this merge and the batch merge).

## Tier 1 verification

- ✅ \`pnpm --filter movehat test\` — **396/396 green** (was 397; the deprecated-alias test was deleted with the function).
- ✅ \`pnpm check:example\` — green.
- ✅ \`pnpm docs:api\` — clean regen, 50 pages (was 51; \`getMovehat.mdx\` correctly dropped).
- ✅ Pre-push hook green on this push.

## Operational flow post-merge

1. Merge this PR to \`develop\`.
2. Open \`develop → main\` batch PR. Run \`pnpm test:e2e\` (mandatory per §6.3). Merge.
3. From \`main\`: \`bash scripts/pre-publish.sh\` (10-step gate, includes Tier 3 e2e). All green expected.
4. \`gh release create v0.2.0 --target main --notes "$(awk '/## \\[0.2.0\\]/,/## \\[0.1\\.9\\]/' CHANGELOG.md | head -n -1)"\` — fires \`publish.yml\`.
5. Workflow runs: CHANGELOG gate (verifies \`## [0.2.0]\`) → unit tests → integration tests → build → npm publish → commit version bump back. Expected wall-clock: ~5 min.
6. Verify: \`npm view movehat@0.2.0\` returns the new version; \`npm view movehat dist-tags\` shows \`latest: 0.2.0\`.

## Plan reference

Local plan: \`/Users/gilbertsahumada/.claude/plans/planifiquemos-la-implementacion-del-logical-pebble.md\` (M6.2 section).