### PR TITLE
fix(publish): allow same-version on npm version step (post-v0.2.0 hotfix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,15 @@ jobs:
           echo "Publishing version: $VERSION"
 
       - name: Update package version
+        # `--allow-same-version` makes this step a no-op when the in-repo
+        # manifest already declares the release tag's version (i.e. the
+        # version bump shipped in the PR that landed before the tag was
+        # cut, rather than relying on the workflow to do the bump).
+        # Without it, npm errors with "Version not changed" and the
+        # release fails — see v0.2.0 attempt at 2026-05-15 (run 25900063511).
         run: |
           cd packages/movehat
-          npm version ${{ steps.get_version.outputs.version }} --no-git-tag-version
+          npm version ${{ steps.get_version.outputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Verify CHANGELOG section exists for release version
         # Codified CHANGELOG gate per M6 (issue #73, sub-issue #165). Blocks


### PR DESCRIPTION
Hotfix after the first v0.2.0 release attempt failed at the workflow's \`Update package version\` step. Tag and release were deleted; this PR fixes the workflow so the re-cut can proceed cleanly.

## Root cause

\`publish.yml\` step 7 ran:
\`\`\`bash
npm version 0.2.0 --no-git-tag-version
\`\`\`

against a manifest that already declared \`0.2.0\` (M6.2 / PR #168 bumped it). npm rejects this with \`npm error Version not changed\` and the workflow exits non-zero before reaching the gate, the tests, or the publish step.

## Fix

Add \`--allow-same-version\` to the same step:
\`\`\`bash
npm version 0.2.0 --no-git-tag-version --allow-same-version
\`\`\`

Now a no-op when manifest is already at target; unchanged behavior when it isn't. 7-line diff (6 lines explanatory comment + 1 line flag).

## Why direct to develop instead of "fast hotfix to main"

Standard branch workflow per CLAUDE.md. Develop → main batch comes next; the v0.2.0 re-cut is cheap (delete + recreate) once main has the fix.

## §8 self-review

Will be posted as a \`gh pr review --comment\`.

## Tier 2 / Tier 3

- N/A — CI-only change, no \`packages/movehat/src/**\` / templates touched. Workflow is exercised on release publish (will be re-tested on the v0.2.0 re-cut after this batch merges).

## Context

Failed run: https://github.com/gilbertsahumada/movehat/actions/runs/25900063511 (24s, "Version not changed").
v0.2.0 release + tag deleted at $(date -u +%FT%TZ) — no npm artifact was ever published; clean slate.