### PR TITLE
fix: publish.yml --allow-same-version (post-v0.2.0 hotfix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,15 @@ jobs:
           echo "Publishing version: $VERSION"
 
       - name: Update package version
+        # `--allow-same-version` makes this step a no-op when the in-repo
+        # manifest already declares the release tag's version (i.e. the
+        # version bump shipped in the PR that landed before the tag was
+        # cut, rather than relying on the workflow to do the bump).
+        # Without it, npm errors with "Version not changed" and the
+        # release fails — see v0.2.0 attempt at 2026-05-15 (run 25900063511).
         run: |
           cd packages/movehat
-          npm version ${{ steps.get_version.outputs.version }} --no-git-tag-version
+          npm version ${{ steps.get_version.outputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Verify CHANGELOG section exists for release version
         # Codified CHANGELOG gate per M6 (issue #73, sub-issue #165). Blocks


### PR DESCRIPTION
Direct \`develop → main\` batch for the publish.yml hotfix (PR #170). Single-PR batch — no M-cycle is closing; this is recovery after the first v0.2.0 release attempt failed.

## Sub-PR

| Sub | Description | PR | Commit |
|---|---|---|---|
| Hotfix | \`fix(publish): allow same-version on npm version step\` | [#170](https://github.com/gilbertsahumada/movehat/pull/170) | \`de4c626\` |

## Recovery flow

1. First v0.2.0 attempt (run [25900063511](https://github.com/gilbertsahumada/movehat/actions/runs/25900063511)) failed at \`Update package version\` because \`npm version 0.2.0 --no-git-tag-version\` rejects same-version.
2. \`v0.2.0\` tag + release deleted on GitHub (no npm artifact was ever pushed — clean slate).
3. This PR carries the 7-line workflow fix to main so the v0.2.0 re-cut can proceed.

## Tier 3 (per §6.3)

E2E was 32/32 green on the M6 batch (#169). This hotfix is workflow-only — no source changes between #169's main and this batch's main. \`pnpm test:e2e:quick\` re-run not necessary; no movehat code path is exercised differently.

## §8 self-review

Will be posted as a comment.

## Post-merge

1. From updated main: \`gh release create v0.2.0 --target main --notes-file /tmp/v0.2.0-notes.md\` (single-line invocation this time).
2. publish.yml fires; CHANGELOG gate runs; unit + integration tests run; build; npm publish.
3. Verify \`npm view movehat@0.2.0\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to prevent publication failures when version is already set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/171)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->