### PR TITLE
chore(publish): switch to npm Trusted Publishers + provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      - name: Upgrade npm to >= 11.5.1 for Trusted Publishers
+        # Trusted Publishers require npm >= 11.5.1 — the OIDC exchange
+        # and provenance attestation paths only ship in that line.
+        # Node 20 bundles npm ~10.x, so the upgrade is mandatory.
+        # See https://docs.npmjs.com/trusted-publishers.
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install
 
@@ -106,19 +113,22 @@ jobs:
           echo "Build verification passed"
           ls -la dist/
 
-      - name: Publish to npm
+      - name: Publish to npm (Trusted Publishers + provenance)
+        # Authenticates via the GitHub Actions OIDC token (job already
+        # has `id-token: write`). Requires a Trusted Publisher
+        # configured on npmjs.com for the movehat package — see
+        # `MOVEMENT_CLI_COMPAT.md`-style operational doc / PR body.
+        # No NPM_TOKEN secret consumed.
         run: |
           cd packages/movehat
           VERSION=${{ steps.get_version.outputs.version }}
 
-          # If version is alpha/beta/rc , publish with tag
+          # If version is alpha/beta/rc, publish with the `next` tag
           if [[ "$VERSION" == *"-alpha"* || "$VERSION" == *"-beta"* || "$VERSION" == *"-rc"* ]]; then
-            npm publish --access public --tag next
+            npm publish --access public --provenance --tag next
           else
-            npm publish --access public
+            npm publish --access public --provenance
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Commit version bump back to repository
         if: github.event_name == 'release'


### PR DESCRIPTION
Migrates the npm publish flow from a long-lived \`NPM_TOKEN\` secret to GitHub Actions OIDC via [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers).

## Trigger

The first \`v0.2.0\` release attempt (workflow run [25900571480](https://github.com/gilbertsahumada/movehat/actions/runs/25900571480)) failed at \`Publish to npm\` with:

\`\`\`
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/movehat - Not found
\`\`\`

Diagnosis: \`NPM_TOKEN\` secret silently expired (last successful publish was \`v0.1.9\` on 2026-01-10, ~4 months ago). All other publish.yml gates ran green (CHANGELOG gate, unit tests, integration suite, smoke, build, tarball verification) — only the npm registry authentication step failed.

Rather than rotate the token, switching to Trusted Publishers eliminates the rotating-secret failure mode entirely + adds provenance attestations.

## Workflow changes

| Section | Before | After |
|---|---|---|
| npm version | bundled with Node 20 (~10.x) | \`npm install -g npm@latest\` (need ≥11.5.1 for TP support) |
| Publish step env | \`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` | no token; OIDC via job-level \`id-token: write\` (already present) |
| Publish flags | \`npm publish --access public\` | \`npm publish --access public --provenance\` |
| Tag override (alpha/beta/rc) | preserved | preserved + \`--provenance\` |

7 lines of explanatory comments + 9 lines of substantive change.

## Operational prerequisite (out-of-band — repo cannot codify)

Before re-triggering publish: configure the Trusted Publisher on npmjs.com:

1. https://www.npmjs.com/package/movehat → Settings → Publishing → Add Trusted Publisher.
2. Publisher: **GitHub Actions**.
3. Organization or user: **gilbertsahumada**.
4. Repository: **movehat**.
5. Workflow filename: **publish.yml**.
6. Environment: (leave blank — no environment used).

The TP config exists per-package on npmjs.com side. The publish.yml workflow can't reach in and check it; the failure mode if missing is a clear "no trusted publisher matched" error at publish time, not a silent skip.

## After this PR lands

1. Configure Trusted Publisher on npmjs.com (operator step, see above).
2. Re-trigger v0.2.0 publish: \`gh workflow run publish.yml --ref main -f version=0.2.0\`. The release + tag + CHANGELOG are already in place from the earlier (failed-at-publish) attempt.
3. Verify: \`npm view movehat@0.2.0\`; expect \`latest: 0.2.0\` and provenance attestation visible on the package page.
4. Remove the \`NPM_TOKEN\` secret from https://github.com/gilbertsahumada/movehat/settings/secrets/actions — no longer consumed.

## Tier 2 / Tier 3

- N/A — CI-only change. Workflow is exercised next time a release is cut.

## §8 self-review

Will be posted as a comment.

## Risks

- npm@latest could include a regression that breaks the publish step. Mitigation: if anything fails, pin to \`npm@11.5.1\` explicitly.
- Trusted Publisher misconfiguration on npmjs.com would surface as a clear publish-time error. No silent failure modes possible (token-based path had exactly that — silent expiry).