### PR TITLE
chore(publish): switch to npm Trusted Publishers (TP migration batch)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
+      - name: Upgrade npm to >= 11.5.1 for Trusted Publishers
+        # Trusted Publishers require npm >= 11.5.1 — the OIDC exchange
+        # and provenance attestation paths only ship in that line.
+        # Node 20 bundles npm ~10.x, so the upgrade is mandatory.
+        # See https://docs.npmjs.com/trusted-publishers.
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install
 
@@ -106,19 +113,22 @@ jobs:
           echo "Build verification passed"
           ls -la dist/
 
-      - name: Publish to npm
+      - name: Publish to npm (Trusted Publishers + provenance)
+        # Authenticates via the GitHub Actions OIDC token (job already
+        # has `id-token: write`). Requires a Trusted Publisher
+        # configured on npmjs.com for the movehat package — see
+        # `MOVEMENT_CLI_COMPAT.md`-style operational doc / PR body.
+        # No NPM_TOKEN secret consumed.
         run: |
           cd packages/movehat
           VERSION=${{ steps.get_version.outputs.version }}
 
-          # If version is alpha/beta/rc , publish with tag
+          # If version is alpha/beta/rc, publish with the `next` tag
           if [[ "$VERSION" == *"-alpha"* || "$VERSION" == *"-beta"* || "$VERSION" == *"-rc"* ]]; then
-            npm publish --access public --tag next
+            npm publish --access public --provenance --tag next
           else
-            npm publish --access public
+            npm publish --access public --provenance
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Commit version bump back to repository
         if: github.event_name == 'release'


### PR DESCRIPTION
\`develop → main\` batch for the Trusted Publishers migration (PR #172). Single-PR batch — recovery continuation after the first v0.2.0 release attempt's NPM_TOKEN expired.

## Sub-PR

| Sub | Description | PR | Commit |
|---|---|---|---|
| TP migration | \`chore(publish): switch to npm Trusted Publishers + provenance\` | [#172](https://github.com/gilbertsahumada/movehat/pull/172) | \`79321af\` |

## Recovery flow context

1. Original v0.2.0 release attempt failed at \`npm version\` step (run 25900063511, 2026-05-15) — fixed in hotfix PR #170 (\`--allow-same-version\`).
2. Re-cut release attempt failed at \`Publish to npm\` step (run 25900571480) — \`NPM_TOKEN\` had silently expired (404 on PUT /movehat).
3. This batch carries the TP migration to main so the next workflow_dispatch will authenticate via OIDC + emit provenance.
4. Out-of-band: Trusted Publisher configured on npmjs.com for the movehat package by the maintainer (CONFIRMED done).

## Post-merge action

\`gh workflow run publish.yml --ref main -f version=0.2.0\`

The existing v0.2.0 tag + release + CHANGELOG stay; only the publish step re-runs (now via OIDC).

## §8 self-review

Will be posted as a comment.

## Tier 3

E2E was 32/32 green on the M6 batch (#169) and reconfirmed in #171. No source changes since then — only \`.github/workflows/publish.yml\` touched.