### PR TITLE
feat(docs): deploy fumadocs site to GitHub Pages

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,77 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/docs/**'
+      - 'packages/movehat/src/**'
+      - 'packages/movehat/typedoc.json'
+      - 'packages/movehat/scripts/postprocess-typedoc.mjs'
+      - '.github/workflows/docs-deploy.yml'
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, skipping older queued runs.
+concurrency:
+  group: 'docs-deploy'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build docs site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build movehat (TypeDoc prebuild needs dist/)
+        run: pnpm build:movehat
+
+      - name: Build docs site
+        run: pnpm build:docs
+        env:
+          # Base path for GitHub Pages project site
+          # (gilbertsahumada.github.io/movehat/).
+          MOVEHAT_DOCS_BASE_PATH: /movehat
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/docs/out
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -48,6 +48,10 @@ jobs:
           # Base path for GitHub Pages project site
           # (gilbertsahumada.github.io/movehat/).
           MOVEHAT_DOCS_BASE_PATH: /movehat
+          # Canonical site URL for og:metadata, llms.txt, copy-link
+          # actions. NEXT_PUBLIC_ prefix exposes it to client bundles
+          # (the llm-actions.tsx button uses it in the browser).
+          NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL: https://gilbertsahumada.github.io/movehat
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/packages/docs/app/docs/[[...slug]]/_components/llm-actions.tsx
+++ b/packages/docs/app/docs/[[...slug]]/_components/llm-actions.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-const SITE_URL = 'https://movehat.dev';
+const SITE_URL = process.env.NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL ?? 'https://movehat.dev';
 
 function buildProviderUrl(provider: 'chatgpt' | 'claude' | 'gemini', docUrl: string) {
   const prompt = `Read this Movehat documentation page and help me understand it: ${docUrl}`;

--- a/packages/docs/app/layout.tsx
+++ b/packages/docs/app/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 import './global.css';
 
-const siteUrl = 'https://movehat.dev';
+const siteUrl = process.env.NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL ?? 'https://movehat.dev';
 const description =
   'A Hardhat-like development framework for Movement L1 smart contracts. Write tests and deployment scripts in TypeScript.';
 

--- a/packages/docs/app/llms-full.txt/route.ts
+++ b/packages/docs/app/llms-full.txt/route.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 export const dynamic = 'force-static';
 
-const SITE_URL = 'https://movehat.dev';
+const SITE_URL = process.env.NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL ?? 'https://movehat.dev';
 
 export async function GET() {
   const pages = source.getPages();

--- a/packages/docs/app/llms.txt/route.ts
+++ b/packages/docs/app/llms.txt/route.ts
@@ -2,7 +2,7 @@ import { source } from '@/lib/source';
 
 export const dynamic = 'force-static';
 
-const SITE_URL = 'https://movehat.dev';
+const SITE_URL = process.env.NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL ?? 'https://movehat.dev';
 
 export function GET() {
   const pages = source.getPages();

--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -1,11 +1,20 @@
 import { createMDX } from 'fumadocs-mdx/next';
 
+// Set MOVEHAT_DOCS_BASE_PATH=/movehat when building for GitHub Pages
+// (the published URL is gilbertsahumada.github.io/movehat/, so all
+// internal links + asset URLs need the /movehat prefix). Local
+// `pnpm dev:docs` and unsuffixed `pnpm build:docs` leave it empty so
+// preview / Vercel / Netlify hosts keep working unchanged.
+const basePath = process.env.MOVEHAT_DOCS_BASE_PATH ?? '';
+
 /** @type {import('next').NextConfig} */
 const config = {
   output: 'export',
   images: {
     unoptimized: true,
   },
+  basePath,
+  assetPrefix: basePath || undefined,
 };
 
 const withMDX = createMDX();


### PR DESCRIPTION
Closes the KPI 2 acceptance criterion **\"docs site deployed and accessible\"**. Currently \`pnpm build:docs\` produces \`packages/docs/out/\` correctly but the artifact lives only on developer machines.

## Changes

| File | Change |
|---|---|
| \`packages/docs/next.config.mjs\` | Env-conditional \`basePath\` + \`assetPrefix\` reading \`MOVEHAT_DOCS_BASE_PATH\`. Unset = unchanged behavior (local dev, Vercel, Netlify). Set to \`/movehat\` = all internal links + asset URLs carry the prefix (GH Pages project site URL). |
| \`packages/docs/public/.nojekyll\` | Empty file. Without it GH Pages runs Jekyll and ignores \`_next/\` (filenames starting with underscore). Next copies \`public/\` → \`out/\` at build. |
| \`.github/workflows/docs-deploy.yml\` | Two-job workflow (build + deploy) using \`actions/configure-pages\`, \`actions/upload-pages-artifact\`, \`actions/deploy-pages\`. Triggers on push to main when docs sources or TypeDoc pipeline change; \`workflow_dispatch\` for manual re-deploys. \`MOVEHAT_DOCS_BASE_PATH: /movehat\` set in the build step env. |

## Why GitHub Pages over Vercel/Netlify

- Already on GitHub — no external service to authorize.
- Site is static (\`output: 'export'\`); no SSR / edge functions needed.
- Free for public repos.
- Custom domain still possible later (add \`CNAME\` file + DNS).

## Verification (local)

\`\`\`
# With basePath (GH Pages mode)
$ MOVEHAT_DOCS_BASE_PATH=/movehat pnpm build:docs
# → assets at /movehat/_next/static/...
# → internal links at /movehat/docs

# Without basePath (default — Vercel/Netlify/local preview)
$ pnpm build:docs
# → assets at /_next/static/...
# → internal links at /docs
\`\`\`

Both verified locally. The \`.nojekyll\` file appears in \`out/\` after build (Next copies it from \`public/\`).

## Maintainer step (one-time)

After this PR merges + reaches main, enable Pages in repo settings:

1. Open https://github.com/gilbertsahumada/movehat/settings/pages
2. **Source**: \`GitHub Actions\` (not branch-based).
3. Save.

The first \`docs-deploy.yml\` run (auto-fires when main receives this change, or via \`workflow_dispatch\`) publishes to:

**https://gilbertsahumada.github.io/movehat/**

## §8 self-review

Will be posted as a comment.

## Tier 2 / Tier 3

- N/A — docs + workflow change; no \`packages/movehat/src/**\` / \`bin/**\` / template touched. Build script outputs verified manually (both modes).

## Risks

| Risk | Mitigation |
|---|---|
| Pages \"first deploy\" is sometimes flaky due to env not yet provisioned | Workflow can be re-run via \`workflow_dispatch\` until it sticks. |
| Future custom domain breaks basePath | Move env var to a clean override + add a switch. Out of scope. |
| og:image and og:url metadata in layout.tsx hardcoded to \`https://movehat.dev\` | Pre-existing, unrelated to deployment. Followup if site is published under that domain later. |

## After this lands

KPI 2 \"docs site deployed and accessible\" → green.