### PR TITLE
ci(docs): deploy fumadocs to GitHub Pages (KPI 2 "docs site deployed")

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,77 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/docs/**'
+      - 'packages/movehat/src/**'
+      - 'packages/movehat/typedoc.json'
+      - 'packages/movehat/scripts/postprocess-typedoc.mjs'
+      - '.github/workflows/docs-deploy.yml'
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, skipping older queued runs.
+concurrency:
+  group: 'docs-deploy'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build docs site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build movehat (TypeDoc prebuild needs dist/)
+        run: pnpm build:movehat
+
+      - name: Build docs site
+        run: pnpm build:docs
+        env:
+          # Base path for GitHub Pages project site
+          # (gilbertsahumada.github.io/movehat/).
+          MOVEHAT_DOCS_BASE_PATH: /movehat
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/docs/out
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -48,6 +48,10 @@ jobs:
           # Base path for GitHub Pages project site
           # (gilbertsahumada.github.io/movehat/).
           MOVEHAT_DOCS_BASE_PATH: /movehat
+          # Canonical site URL for og:metadata, llms.txt, copy-link
+          # actions. NEXT_PUBLIC_ prefix exposes it to client bundles
+          # (the llm-actions.tsx button uses it in the browser).
+          NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL: https://gilbertsahumada.github.io/movehat
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -239,16 +239,29 @@ Follow-up issues filed during M4 (all upstream Movement CLI / SDK, deferred to M
 - [x] Closes #140 (artifact integrity verification — `sha256sum -c` BEFORE `chmod +x`/`sudo mv`, fails the job on mismatch) (M5.3)
 - [x] Documents #146 reproduction + hypotheses in `MOVEMENT_CLI_COMPAT.md` "Known issues" section (M5.3)
 
-### M6 — Publish workflow with changelog gate + 0.1.0 release (~2 days, issue #73) — (KPI 2)
+### M6 — ✅ shipped — Publish workflow with changelog gate + 0.2.0 release (~2 days, issue #73) — (KPI 2)
 
 **Goal**: Establish a release pipeline that validates the changelog and publishes to npm.
 
-**Sub-PRs**:
+**Sub-PRs + commit hashes** (mirrors the M3 / M4 / M5 precedent):
 
-| Sub | Description | Status |
+| Sub | Description | PR | Commit |
+|---|---|---|---|
+| M6.1 | CHANGELOG gate + unit/integration tests in publish.yml + backfill (closes #165) | [#167](https://github.com/gilbertsahumada/movehat/pull/167) | `d62f7bb` |
+| M6.2 | Remove getMovehat() + bump to 0.2.0 (BREAKING; closes #166, #73 meta) | [#168](https://github.com/gilbertsahumada/movehat/pull/168) | `ca950e3` |
+| M6 batch | develop → main batch (M6.1 + M6.2) | [#169](https://github.com/gilbertsahumada/movehat/pull/169) | `3a26caf` |
+| Hotfix | fix(publish): allow same-version on npm version step | [#170](https://github.com/gilbertsahumada/movehat/pull/170) | `de4c626` |
+| Hotfix batch | develop → main batch (hotfix) | [#171](https://github.com/gilbertsahumada/movehat/pull/171) | `5dc86ce` |
+| TP migration | chore(publish): switch to npm Trusted Publishers + provenance | [#172](https://github.com/gilbertsahumada/movehat/pull/172) | `79321af` |
+| TP batch | develop → main batch (TP migration) | [#173](https://github.com/gilbertsahumada/movehat/pull/173) | `4b39b5b` |
+
+**Release**: [v0.2.0](https://github.com/gilbertsahumada/movehat/releases/tag/v0.2.0) (tag `v0.2.0`, published to npm 2026-05-15 via `workflow_dispatch` run [25901196103](https://github.com/gilbertsahumada/movehat/actions/runs/25901196103); SLSA v1 provenance attached via Trusted Publishers).
+
+**Follow-ups filed during M6** (deferred to later milestones):
+
+| Issue | Title | Reason for defer |
 |---|---|---|
-| M6.1 | `ci(release): CHANGELOG gate + unit/integration tests in publish.yml + backfill` (issue #165) | ✅ shipped in PR #167 |
-| M6.2 | `feat(api)!: remove getMovehat() + bump to 0.2.0` (issue #166, closes #73 meta) | 🔄 in-flight |
+| [#174](https://github.com/gilbertsahumada/movehat/issues/174) | `[publish.yml] Post-publish commit step is brittle (dirty package-lock.json after npm@latest upgrade)` | Cosmetic — `npm publish` already succeeded; the post-publish bookkeeping step failed but the artifact is live. Likely simplest fix: remove the step entirely (the M6.2-onward convention is "bump version in the PR that ships the release", which makes the step redundant). |
 
 **Definition of Done — Publish workflow**:
 - [x] `.github/workflows/publish.yml` triggers on GitHub release publish + `workflow_dispatch` (M6.1 — the original "v* tags" wording was specced before the workflow shipped; `release.published` is a higher-level wrapper that fires on tag-bound release creation. Functionally equivalent for the gate-on-release semantics.)
@@ -262,8 +275,15 @@ Follow-up issues filed during M4 (all upstream Movement CLI / SDK, deferred to M
 - [x] `getMovehat` no longer exported from `packages/movehat/src/index.ts` (M6.2 — meta-issue #73's "mh" was renamed to `getMovehat` in M1.5; removed the export + the function body in `runtime.ts` + the template `.d.ts` shim declaration + all README/example callers (migrated to `Harness.createLive()`).)
 - [N/A] Remove `MovehatRuntime` legacy types — meta-issue #73 was wrong on this. `MovehatRuntime` is the **live** runtime type used by `Harness.runtime`, `initRuntime()`, and all harness helpers. Removing it would break the live public surface. Only `getMovehat()` itself goes; `MovehatRuntime` stays exported.
 - [x] `packages/movehat/package.json` version bumped to `0.2.0` (M6.2 — meta-issue's "0.1.0" target was stale; package was already at 0.1.9 with 9 published 0.1.x versions. `getMovehat()` removal is breaking → semver bump to 0.2.0.)
-- [ ] `npm view movehat@0.2.0` returns the new version after publish (M6.2 — pending release create + workflow trigger sequence; verified post-merge.)
-- [ ] `npm pack` output does not contain `getMovehat` symbol (M6.2 — pending tarball verification post-merge.)
+- [x] `npm view movehat@0.2.0` returns the new version after publish (M6.2 — confirmed 2026-05-15: `latest` dist-tag flipped from 0.1.9 → 0.2.0; SLSA v1 provenance attached via Trusted Publishers — verified `attestations.provenance.predicateType: https://slsa.dev/provenance/v1`.)
+- [x] `npm pack` output does not contain `getMovehat` symbol (M6.2 — verified against the published tarball: `tar -xzOf movehat-0.2.0.tgz package/dist/index.js | grep -c getMovehat` = 0; `tar -tzf | grep -ic getMovehat` = 0.)
+
+**Migration to Trusted Publishers** (out-of-scope per original M6 plan but driven by NPM_TOKEN expiry during release):
+
+- [x] `publish.yml` migrated from `NPM_TOKEN` secret to GitHub Actions OIDC via npm Trusted Publishers (PR #172).
+- [x] Trusted Publisher configured on npmjs.com for the `movehat` package (out-of-band by maintainer; verified by the successful OIDC-authenticated publish in run #25901196103).
+- [x] `--provenance` flag added; SLSA v1 attestations now ship with every release.
+- [ ] **TODO (post-M6 cleanup)**: delete the `NPM_TOKEN` secret from repo settings — no longer consumed.
 
 ### M7 — Maintenance quota (continuous) — (KPI 2)
 

--- a/packages/docs/app/docs/[[...slug]]/_components/llm-actions.tsx
+++ b/packages/docs/app/docs/[[...slug]]/_components/llm-actions.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-const SITE_URL = 'https://movehat.dev';
+const SITE_URL = process.env.NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL ?? 'https://movehat.dev';
 
 function buildProviderUrl(provider: 'chatgpt' | 'claude' | 'gemini', docUrl: string) {
   const prompt = `Read this Movehat documentation page and help me understand it: ${docUrl}`;

--- a/packages/docs/app/layout.tsx
+++ b/packages/docs/app/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 import './global.css';
 
-const siteUrl = 'https://movehat.dev';
+const siteUrl = process.env.NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL ?? 'https://movehat.dev';
 const description =
   'A Hardhat-like development framework for Movement L1 smart contracts. Write tests and deployment scripts in TypeScript.';
 

--- a/packages/docs/app/llms-full.txt/route.ts
+++ b/packages/docs/app/llms-full.txt/route.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 export const dynamic = 'force-static';
 
-const SITE_URL = 'https://movehat.dev';
+const SITE_URL = process.env.NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL ?? 'https://movehat.dev';
 
 export async function GET() {
   const pages = source.getPages();

--- a/packages/docs/app/llms.txt/route.ts
+++ b/packages/docs/app/llms.txt/route.ts
@@ -2,7 +2,7 @@ import { source } from '@/lib/source';
 
 export const dynamic = 'force-static';
 
-const SITE_URL = 'https://movehat.dev';
+const SITE_URL = process.env.NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL ?? 'https://movehat.dev';
 
 export function GET() {
   const pages = source.getPages();

--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -1,11 +1,20 @@
 import { createMDX } from 'fumadocs-mdx/next';
 
+// Set MOVEHAT_DOCS_BASE_PATH=/movehat when building for GitHub Pages
+// (the published URL is gilbertsahumada.github.io/movehat/, so all
+// internal links + asset URLs need the /movehat prefix). Local
+// `pnpm dev:docs` and unsuffixed `pnpm build:docs` leave it empty so
+// preview / Vercel / Netlify hosts keep working unchanged.
+const basePath = process.env.MOVEHAT_DOCS_BASE_PATH ?? '';
+
 /** @type {import('next').NextConfig} */
 const config = {
   output: 'export',
   images: {
     unoptimized: true,
   },
+  basePath,
+  assetPrefix: basePath || undefined,
 };
 
 const withMDX = createMDX();


### PR DESCRIPTION
\`develop → main\` batch for PR #176. Single-PR batch closing the KPI 2 \"docs site deployed and accessible\" acceptance criterion.

## Sub-PR

| Sub | Description | PR | Commit |
|---|---|---|---|
| Docs deploy | \`feat(docs): deploy fumadocs site to GitHub Pages\` + §8 follow-up fix | [#176](https://github.com/gilbertsahumada/movehat/pull/176) | \`d639259\` |

## What ships to main

1. \`packages/docs/next.config.mjs\` — env-conditional \`basePath\` + \`assetPrefix\`.
2. \`packages/docs/public/.nojekyll\` — empty file so GH Pages serves \`_next/\`.
3. \`.github/workflows/docs-deploy.yml\` — build + deploy job using \`actions/{configure-pages,upload-pages-artifact,deploy-pages}\`.
4. Site URL env-configurable (\`NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL\`) across layout/llms.txt/llms-full.txt/llm-actions.

## §8 self-review

Will be posted as a comment.

## Tier 2 / Tier 3

- N/A — docs build + new workflow only.

## After this merges

1. Maintainer confirms GH Pages is enabled (Settings → Pages → Source: GitHub Actions).
2. \`docs-deploy.yml\` workflow auto-fires on push to main (path filter matches \`packages/docs/**\` + \`.github/workflows/docs-deploy.yml\`).
3. ~3-5 min later, site goes live at **https://gilbertsahumada.github.io/movehat/**.
4. KPI 2 \"docs site deployed and accessible\" → green.

## Status of overall KPIs after this lands

- **KPI 1** (Forklift API Parity + Testing & CI): mostly green; only verifiable gap is global coverage at 72.88% vs 80% strict literal reading.
- **KPI 2** (Release & Docs + Maintenance & Iteration): green after this PR + closing #40 + #42 (the only 2 \`bug+security\` issues remaining).