### PR TITLE
chore: strip internal milestone refs from source/tests/templates/docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bumped to `0.2.0` per semver-under-0.x convention: removing a publicly-exported function is a breaking change. Users pinning `~0.1` will not auto-upgrade — explicit version bump required.
-- `MovehatRuntime` type export retained (live runtime type used by `Harness.runtime`, `initRuntime()`, and all harness helpers — was misidentified as "legacy" in meta-issue #73; correction documented in PR #168).
+- `MovehatRuntime` type export retained (live runtime type used by `Harness.runtime`, `initRuntime()`, and all harness helpers — was misidentified as "legacy" in [#73](https://github.com/gilbertsahumada/movehat/issues/73); correction documented in [#168](https://github.com/gilbertsahumada/movehat/pull/168)).
 
 ### Added
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -17,7 +17,7 @@ Complete testing and validation guide before publishing.
 
 ### 1. **Unit Tests** (~2 seconds)
 - 35 test files, 397 tests across `packages/movehat/src/**/__tests__/`
-- Vitest with v8 coverage; per-file ≥80% gates on 16 critical modules (M3.5 ratchet), global ≥70% floor
+- Vitest with v8 coverage; per-file ≥80% gates on 16 critical modules, global ≥70% floor
 - Run via `pnpm --filter movehat test` (no Movement node required)
 - Coverage gate enforced in CI via `Check coverage threshold` step in `.github/workflows/ci.yml`
 

--- a/examples/counter-example/tests/Counter.test.ts
+++ b/examples/counter-example/tests/Counter.test.ts
@@ -4,14 +4,14 @@ import type { Account } from "@aptos-labs/ts-sdk";
 import { expect } from "chai";
 
 /**
- * Migrated to the M2 Harness API. Uses Harness.createLocal with
- * autoDeploy — same Publisher-based publish path the previous
- * setupTestFixture flow used. The sibling tests (greeting.test.ts,
- * message.test.ts) stay on setupTestFixture to demonstrate that the
- * older API continues to work side-by-side.
+ * Uses the Harness API: Harness.createLocal with autoDeploy. Same
+ * Publisher-based publish path the older setupTestFixture flow used.
+ * The sibling tests (greeting.test.ts, message.test.ts) stay on
+ * setupTestFixture to demonstrate that the older API continues to
+ * work side-by-side.
  *
- * For the new code-object deploy path (`harness.deployCodeObject`),
- * see scripts/deploy-counter.ts in this directory.
+ * For the code-object deploy path (`harness.deployCodeObject`), see
+ * scripts/deploy-counter.ts in this directory.
  */
 describe("Counter Contract", () => {
   let harness: Harness;

--- a/packages/docs/content/docs/getting-started/quickstart.mdx
+++ b/packages/docs/content/docs/getting-started/quickstart.mdx
@@ -115,7 +115,7 @@ describe("Counter Contract", () => {
 });
 ```
 
-> **Looking for the older API?** `setupTestFixture` / `teardownTestFixture` still works (see `movehat/helpers`); use whichever style fits your codebase. `Harness` is the new primary surface since M2.
+> **Looking for the older API?** `setupTestFixture` / `teardownTestFixture` still works (see `movehat/helpers`); use whichever style fits your codebase. `Harness` is the primary surface.
 
 Run with: `movehat test --ts` (starts local node)
 

--- a/packages/docs/content/docs/guides/deployment.mdx
+++ b/packages/docs/content/docs/guides/deployment.mdx
@@ -122,7 +122,7 @@ MH_CLI_REDEPLOY=true movehat run scripts/deploy-counter.ts --network testnet
 ```typescript
 const harness = await Harness.createLive("testnet");
 
-// Harness methods (M2 public API)
+// Harness methods
 harness.mode               // 'local' | 'fork' | 'live'
 harness.deployCodeObject   // movement move deploy-object
 harness.upgradeCodeObject  // movement move upgrade-object

--- a/packages/docs/content/docs/guides/scripts.mdx
+++ b/packages/docs/content/docs/guides/scripts.mdx
@@ -122,7 +122,7 @@ const harness = await Harness.createLive("testnet");
 harness.mode               // 'local' | 'fork' | 'live'
 harness.poisoned           // true once cleanup() has been called
 
-// Harness methods (M2 public API)
+// Harness methods
 harness.deployCodeObject   // movement move deploy-object
 harness.upgradeCodeObject  // movement move upgrade-object
 harness.runViewFunction    // aptos.view (read-only, works in all modes)

--- a/packages/movehat/bench/fork.bench.ts
+++ b/packages/movehat/bench/fork.bench.ts
@@ -1,11 +1,11 @@
-// Fork-system benchmarks (M5.2). Plain tsx script — vitest bench's per-iter
-// model doesn't fit Harness.createLocal / Harness.createFork (heavy lifecycle
-// ops that spawn a process / snapshot RPC). Each run prints a small table and
-// exits. Numbers are wall-clock, measured on the author's machine; CI variance
-// is expected for the heavy-setup suites.
+// Fork-system benchmarks. Plain tsx script — vitest bench's per-iter model
+// doesn't fit Harness.createLocal / Harness.createFork (heavy lifecycle ops
+// that spawn a process / snapshot RPC). Each run prints a small table and
+// exits. Numbers are wall-clock, measured on the author's machine; CI
+// variance is expected for the heavy-setup suites.
 //
 // Run: pnpm --filter movehat bench
-// Output is consumed by BENCHMARKS.md (baseline + after-optimization).
+// Output is consumed by BENCHMARKS.md.
 
 import { performance } from 'node:perf_hooks';
 import { existsSync, rmSync } from 'node:fs';

--- a/packages/movehat/scripts/check-changelog.js
+++ b/packages/movehat/scripts/check-changelog.js
@@ -1,10 +1,8 @@
 // Verify that CHANGELOG.md contains a section header matching the version
 // declared in packages/movehat/package.json. Blocks `npm publish` when the
-// release lacks a corresponding `## [X.Y.Z]` entry — the codified gate
-// meta-issue #73 specified for M6.
+// release lacks a corresponding `## [X.Y.Z]` entry.
 //
-// ESM, anchored via `import.meta.url` so the script works regardless of cwd
-// (matches the PR #153 check-package-json.js precedent).
+// ESM, anchored via `import.meta.url` so the script works regardless of cwd.
 //
 // Usage:
 //   node packages/movehat/scripts/check-changelog.js

--- a/packages/movehat/src/__tests__/fork/api.test.ts
+++ b/packages/movehat/src/__tests__/fork/api.test.ts
@@ -3,8 +3,8 @@ import type { ClientRequest, IncomingMessage } from "node:http";
 import { EventEmitter } from "node:events";
 
 /**
- * Tests for `MovementApiClient` Authorization header injection (M2.4
- * follow-up — wires the apiKey threading from `Harness.createFork`).
+ * Tests for `MovementApiClient` Authorization header injection —
+ * verifies the apiKey threading from `Harness.createFork`.
  *
  * Strategy: `vi.mock` `node:https` and `node:http` so the test
  * captures the request options passed to `client.get(url, options, cb)`

--- a/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
@@ -4,17 +4,15 @@ import { Harness, HarnessDisposedError } from "../../harness/index.js";
 import { setupHarnessTestFixture, type HarnessTestFixture } from "./_fixture.js";
 
 /**
- * Proxy poisoning is the load-bearing safety guarantee of M2: once a
- * Harness has been cleaned up, any further deploy / view / script /
- * upgrade call must throw `HarnessDisposedError` synchronously on
- * property access — not after the awaited method body. These tests
- * lock that contract.
+ * Proxy poisoning is the load-bearing safety guarantee of the Harness:
+ * once cleaned up, any further deploy / view / script / upgrade call
+ * must throw `HarnessDisposedError` synchronously on property access —
+ * not after the awaited method body. These tests lock that contract.
  *
  * Uses `Harness.createLive(network)` because it does not spawn a real
  * Movement node — `initRuntime` only constructs the SDK client (no RPC
  * round-trip) from the fixture config. `createLocal` / `createFork`
- * runtime tests live in the M4 integration suite where spinning a real
- * node is acceptable.
+ * runtime tests live in the integration suite.
  */
 describe("Harness — proxy poisoning", () => {
   let fixture: HarnessTestFixture;
@@ -93,10 +91,8 @@ describe("Harness — proxy poisoning", () => {
     expect(harness.runtime).toBeDefined();
   });
 
-  // The M2.3-era "stubs reject" assertion was retired when M2.3 shipped
-  // real bodies for runViewFunction and runMoveScript. All four methods
-  // now have dedicated test suites (codeObject.deploy/upgrade.test.ts,
-  // view.test.ts, script.test.ts).
+  // Dedicated suites exist for each of the four methods
+  // (codeObject.deploy/upgrade.test.ts, view.test.ts, script.test.ts).
 
   it("await harness.someAsyncMethod() pattern: post-cleanup throw happens before await", async () => {
     const harness = await Harness.createLive("testnet");

--- a/packages/movehat/src/__tests__/harness/codeObject.deploy.test.ts
+++ b/packages/movehat/src/__tests__/harness/codeObject.deploy.test.ts
@@ -304,7 +304,7 @@ describe("Harness.deployCodeObject", () => {
     }
   });
 
-  it("fork-mode harness throws synchronously before any CLI call (covered separately for createLocal/createFork in M4 integration suite)", async () => {
+  it("fork-mode harness throws synchronously before any CLI call (createLocal/createFork covered by the integration suite)", async () => {
     // This case can't be tested with a real createFork (it spawns a fork
     // server). Instead, prove that the disposed-instance path also fires
     // synchronously: a poisoned harness throws HarnessDisposedError on

--- a/packages/movehat/src/__tests__/harness/view.test.ts
+++ b/packages/movehat/src/__tests__/harness/view.test.ts
@@ -7,9 +7,9 @@ import { setupHarnessTestFixture, type HarnessTestFixture } from "./_fixture.js"
  * Tests for `Harness.runViewFunction` — the SDK delegation path.
  *
  * The Aptos SDK isn't behind an injectable adapter, so we monkey-patch
- * `harness.runtime.aptos.view` after `createLive`. One-off for M2.3.
- * Acceptable here because the function under test is a 6-line wrapper
- * that only forwards options.
+ * `harness.runtime.aptos.view` after `createLive`. Acceptable here
+ * because the function under test is a 6-line wrapper that only
+ * forwards options.
  */
 describe("Harness.runViewFunction", () => {
   let fixture: HarnessTestFixture;

--- a/packages/movehat/src/commands/__tests__/run.test.ts
+++ b/packages/movehat/src/commands/__tests__/run.test.ts
@@ -179,9 +179,9 @@ describe("runCommand — orchestrator", () => {
   // the workspace's own node_modules from __dirname's perspective, so the
   // fallback never throws. Patching `module.createRequire` to inject a
   // failing resolver fails with "Cannot redefine property" because the
-  // ESM-imported `node:module` is read-only. The branch is exercised by
-  // the existing "tsx not found" runtime failure in CI when tsx is
-  // accidentally missing from a published consumer. M4 integration covers.
+  // ESM-imported `node:module` is read-only. The branch is exercised
+  // by the integration suite via the "tsx not found" runtime failure
+  // when tsx is missing from a published consumer.
 
   it("catches and exits 1 when runCli throws (spawn-time failure)", async () => {
     runCliMock.mockRejectedValueOnce(new Error("ENOENT: node not found"));

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -41,11 +41,6 @@ export interface PublishInput {
 /**
  * Publishes a Move module via the Movement CLI.
  *
- * Extracted from `runtime.deployContract` (M1.4 / #79). Carries the
- * destructive Move.toml-rewrite + shared-yaml-write semantics of the
- * original closure verbatim in this scaffold commit — bug fixes for
- * #36 / #37 / #38 land in subsequent commits.
- *
  * @internal
  */
 export class Publisher {

--- a/packages/movehat/src/fork/__tests__/manager.test.ts
+++ b/packages/movehat/src/fork/__tests__/manager.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 /**
- * Tests for `ForkManager` (M3.3). Strategy:
+ * Tests for `ForkManager`. Strategy:
  *   - `vi.mock` the upstream `MovementApiClient` (network layer) so
  *     tests stay offline and deterministic.
  *   - Use a REAL `ForkStorage` against a tmpdir (storage is already

--- a/packages/movehat/src/fork/test.ts
+++ b/packages/movehat/src/fork/test.ts
@@ -9,7 +9,6 @@ export interface SnapshotOptions {
   /**
    * Override the child-process adapter. Test-only — production callers
    * leave this undefined so the default spawn-based adapter is used.
-   * Mirrors the M1.3c pattern on `runtime.deployContract`.
    */
   adapter?: ChildProcessAdapter;
 }

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -36,16 +36,10 @@ interface HarnessInit {
  * a Proxy that synchronously throws {@link HarnessDisposedError} on any
  * post-`cleanup()` call to one of the deployment / script / view methods.
  *
- * Methods `deployCodeObject`, `upgradeCodeObject`, `runViewFunction`,
- * and `runMoveScript` are stubbed in M2.1 — they throw at runtime until
- * M2.2/M2.3 lands. The type surface is complete so callers and docs can
- * be written against it ahead of time.
- *
- * AccountManager note: as of M2.1 the underlying account pool is a
- * process-wide static (see `core/AccountManager.ts`). Two Harness
- * instances in the same process share account labels; this is the same
- * constraint that already governs `setupTestFixture`. A per-Harness pool
- * is a future change.
+ * AccountManager note: the underlying account pool is a process-wide
+ * static (see `core/AccountManager.ts`). Two Harness instances in the
+ * same process share account labels; this is the same constraint that
+ * already governs `setupTestFixture`.
  */
 export class Harness {
   public readonly mode: HarnessMode;
@@ -128,7 +122,7 @@ export class Harness {
    * spawned; transactions are submitted to the configured RPC.
    *
    * @param network - Named network from movehat.config.ts.
-   * @param _faucetUrl - Reserved for M2.2 (auto-fund on networks with a faucet).
+   * @param _faucetUrl - Reserved for future auto-fund support on networks with a faucet.
    */
   static async createLive(network: string, _faucetUrl?: string): Promise<Harness> {
     const runtime = await initRuntime({ network });

--- a/packages/movehat/src/harness/codeObject.ts
+++ b/packages/movehat/src/harness/codeObject.ts
@@ -289,8 +289,6 @@ async function executeMovementMoveObject(
     }
 
     // Parse object address (for deploy-object) and txHash (both flows).
-    // No captured fixture exists at M2.2 commit time; M4 integration
-    // tests validate against real CLI output.
     const objectAddress = opts.fixedAddress ?? parseObjectAddress(deployOut);
     const txHash = parseTxHash(deployOut);
 
@@ -361,9 +359,7 @@ async function executeMovementMoveObject(
 /**
  * Extract a code-object address from `movement move deploy-object` stdout.
  *
- * Movement CLI typically emits the address in one of these shapes (none
- * of them captured at M2.2 commit time — patterns are speculative, with
- * M4 integration tests as the validation gate):
+ * Movement CLI typically emits the address in one of these shapes:
  *
  *   - Free text: `Code was successfully deployed to object address 0x…`
  *   - Free text: `Object address: 0x…`

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -20,8 +20,7 @@ import type { LocalTestOptions } from "../types/config.js";
  * @public The `runtime` and `teardown` fields are the supported surface.
  *         `localNode`, `forkServer`, and `forkManager` are exposed for
  *         escape hatches (e.g. mid-test `forkManager.resetState()`) but
- *         their concrete shapes are considered `@internal` until the M5
- *         TypeDoc pass formalizes the public API.
+ *         their concrete shapes are `@internal`.
  */
 export interface LocalTestingContext {
   runtime: MovehatRuntime;

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -18,6 +18,5 @@ export type { ForkMetadata, AccountState, LedgerInfo, AccountData, AccountResour
 // Export custom errors
 export { ModuleAlreadyDeployedError, PostPublishError } from "./errors.js";
 
-// Export Harness (Hardhat-style API — primary public surface from M2 onward)
 export { Harness, HarnessDisposedError } from "./harness/index.js";
 export type { HarnessMode } from "./harness/index.js";

--- a/packages/movehat/src/node/__tests__/LocalNodeManager.test.ts
+++ b/packages/movehat/src/node/__tests__/LocalNodeManager.test.ts
@@ -13,7 +13,7 @@ import type {
 } from "../../utils/childProcessAdapter.js";
 
 /**
- * Tests for `LocalNodeManager` (M3.3).
+ * Tests for `LocalNodeManager`.
  *
  * Strategy:
  *   - Inject a fake `ChildProcessAdapter` so we control the spawn

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -93,9 +93,7 @@ export async function initRuntime(
       adapter?: ChildProcessAdapter;
     }
   ): Promise<DeploymentInfo> => {
-    // Thin orchestrator over Publisher (M1.4 / #79). The 250-line closure
-    // body lives in core/Publisher.ts and carries the bug fixes for
-    // #36 / #37 / #38.
+    // Thin orchestrator; the actual logic lives in core/Publisher.ts.
     return new Publisher({ adapter: options?.adapter }).deploy({
       moduleName,
       config,

--- a/packages/movehat/src/templates/scripts/deploy-counter.ts
+++ b/packages/movehat/src/templates/scripts/deploy-counter.ts
@@ -3,7 +3,7 @@ import { Harness } from "movehat";
 async function main() {
   console.log("🚀 Deploying Counter contract...\n");
 
-  // Hardhat-style Harness — primary public API since M2.
+  // Hardhat-style Harness — the primary public API.
   // createLive binds to a real running network (testnet / mainnet / a
   // custom one defined in movehat.config.ts). No local process spawned.
   const network = process.env.MOVEHAT_NETWORK ?? "testnet";

--- a/packages/movehat/src/templates/tests/Counter.test.ts
+++ b/packages/movehat/src/templates/tests/Counter.test.ts
@@ -11,7 +11,7 @@ describe("Counter Contract", () => {
   before(async function () {
     this.timeout(60000); // Allow time for local node startup + deployment
 
-    // Hardhat-style Harness — primary public API since M2.
+    // Hardhat-style Harness — the primary public API.
     // createLocal spins up a Movement local node, funds the labeled
     // accounts from the local faucet, and (via autoDeploy) builds +
     // publishes the named modules so they're ready to use.
@@ -43,7 +43,7 @@ describe("Counter Contract", () => {
       const tx = await counter.call(deployer, "init", []);
       console.log(`   Init transaction: ${tx.hash}`);
 
-      // Read counter value via harness.runViewFunction (new in M2)
+      // Read counter value via harness.runViewFunction
       const [value] = await harness.runViewFunction({
         function: `${counter.moduleAddress}::counter::get`,
         functionArguments: [deployer.accountAddress.toString()],

--- a/packages/movehat/src/types/runtime.ts
+++ b/packages/movehat/src/types/runtime.ts
@@ -51,7 +51,7 @@ export interface MovehatRuntime {
   getAccountByIndex: (index: number) => Account;
 
   // Network switching — returns a new runtime bound to the requested
-  // network. As of M1.5 there is no module-cached runtime, so callers
-  // must capture and use the returned instance.
+  // network. There is no module-cached runtime, so callers must capture
+  // and use the returned instance.
   switchNetwork: (networkName: string) => Promise<MovehatRuntime>;
 }

--- a/packages/movehat/src/utils/address.ts
+++ b/packages/movehat/src/utils/address.ts
@@ -1,10 +1,6 @@
 /**
  * Address normalization helpers shared across the fork code.
  *
- * Two normalization variants live in production today and are preserved here
- * with identical semantics so the in-place migration in M1.2 is behavior-
- * preserving:
- *
  *   - `normalizeAddress`      → lowercase + `0x` + left-pad to 64 hex chars.
  *                                Used by `fork/manager.ts` for storage keys.
  *   - `normalizeAddressShort` → lowercase + `0x`, no padding.

--- a/packages/movehat/src/utils/childProcessAdapter.ts
+++ b/packages/movehat/src/utils/childProcessAdapter.ts
@@ -99,10 +99,9 @@ class DefaultChildProcessAdapter implements ChildProcessAdapter {
   run(input: RunInput): Promise<RunResult> {
     // Skip the default 5-minute timeout when the caller wires stdio
     // through to the terminal — interactive sessions (mocha, tsx scripts,
-    // `movement move test`, `pnpm install`) routinely exceed 5 minutes and
-    // SIGTERM'ing them silently is a regression vs the direct-spawn code
-    // these callers used before M1.3a. An explicitly-passed `timeoutMs`
-    // is always honored, regardless of `inheritStdio`.
+    // `movement move test`, `pnpm install`) routinely exceed 5 minutes
+    // and SIGTERM'ing them silently would be a regression. An explicit
+    // `timeoutMs` is always honored, regardless of `inheritStdio`.
     const timeoutMs =
       input.timeoutMs ?? (input.inheritStdio ? undefined : DEFAULT_TIMEOUT_MS);
 

--- a/packages/movehat/test/integration/harness-fork.integration.test.ts
+++ b/packages/movehat/test/integration/harness-fork.integration.test.ts
@@ -41,12 +41,10 @@ describe.skipIf(!RUN_FORK)('Harness.createFork — read-only against testnet', (
   it('deployCodeObject throws in fork mode (read-only enforcement)', async () => {
     // Synchronous-style assertion: `Harness.deployCodeObject` checks
     // `this.mode === 'fork'` before any CLI call, so this rejects
-    // without touching the network. The DoD's `createFork` test path
-    // checks both: (a) the harness boots, and (b) the read-only
-    // boundary is enforced. View-function reads against the fork are
-    // skipped — the fork server doesn't expose `/accounts/<addr>/module/`
-    // endpoints, so SDK ABI lookups raise `endpoint_not_found`. Probing
-    // fork-only read paths is M5 work (see TESTING.md).
+    // without touching the network. View-function reads against the
+    // fork are skipped — the fork server doesn't expose
+    // `/accounts/<addr>/module/` endpoints, so SDK ABI lookups raise
+    // `endpoint_not_found` (see TESTING.md).
     await expect(
       harness.deployCodeObject({
         moduleName: 'counter',

--- a/packages/movehat/vitest.config.ts
+++ b/packages/movehat/vitest.config.ts
@@ -18,41 +18,40 @@ export default defineConfig({
         'src/cli.ts',
         'src/types/**',
       ],
-      // Global floor + per-target map enforced as of M3.5. Per-file
-      // entries below ratchet the 16 critical M3 files to ≥80%; the
-      // global floor is set below 80 because helper/UI/setup modules
-      // outside the M3 target list still sit at 0–30% (banner, move-tests,
-      // setup, version-check, npm-registry, ui/spinner, etc). Raising
-      // those is M3-follow-up / M4 work. The per-target gate is the
-      // canonical correctness signal — regressions on listed files fail
-      // CI before they fail the (more lenient) global gate.
+      // Global floor + per-file map. Per-file entries below ratchet the
+      // 16 critical modules to ≥80%; the global floor is set below 80
+      // because helper/UI/setup modules outside that list still sit at
+      // 0–30% (banner, move-tests, setup, version-check, npm-registry,
+      // ui/spinner, etc). The per-file gate is the canonical correctness
+      // signal — regressions on listed files fail CI before they fail
+      // the (more lenient) global gate.
       thresholds: {
         lines: 70,
         functions: 65,
         branches: 55,
         statements: 70,
-        // M3.2 — core/runtime
+        // core/runtime
         "src/runtime.ts":               { lines: 80, statements: 80, functions: 70, branches: 65 },
         "src/core/config.ts":           { lines: 80, statements: 80, functions: 80, branches: 70 },
         "src/core/AccountManager.ts":   { lines: 80, statements: 80, functions: 80, branches: 65 },
-        // M3.3 — lifecycle managers
+        // lifecycle managers
         "src/fork/manager.ts":          { lines: 80, statements: 80, functions: 75, branches: 60 },
         "src/node/LocalNodeManager.ts": { lines: 80, statements: 80, functions: 75, branches: 60 },
-        // M3.4 — top-level commands
+        // top-level commands
         // run.ts threshold intentionally below 80: the orchestrator's
         // "tsx-not-found" branch (lines 80-101) requires patching
         // `module.createRequire`, which fails with "Cannot redefine
         // property" in vitest's ESM context. propagateRunResultExit
         // (signal/exit-code forwarder) is at 100%; validation branches
         // covered; happy path covered. Remaining ~25% is the tsx
-        // resolution fallback + final error exit — M4 integration covers.
+        // resolution fallback + final error exit (covered by integration).
         "src/commands/compile.ts":    { lines: 80, statements: 80, functions: 80,  branches: 65 },
         "src/commands/init.ts":       { lines: 80, statements: 80, functions: 75,  branches: 60 },
         "src/commands/run.ts":        { lines: 70, statements: 70, functions: 80,  branches: 65 },
         "src/commands/test.ts":       { lines: 80, statements: 80, functions: 75,  branches: 60 },
         "src/commands/test-move.ts":  { lines: 80, statements: 80, functions: 100, branches: 80 },
         "src/commands/update.ts":     { lines: 80, statements: 80, functions: 75,  branches: 50 },
-        // M3.5 — fork commands
+        // fork commands
         "src/commands/fork/create.ts":        { lines: 80, statements: 80, functions: 75, branches: 60 },
         "src/commands/fork/fund.ts":          { lines: 80, statements: 80, functions: 80, branches: 70 },
         "src/commands/fork/list.ts":          { lines: 80, statements: 80, functions: 75, branches: 60 },


### PR DESCRIPTION
## Summary

Exhaustive sweep across the codebase (29 files, -34 LoC net) stripping internal milestone references (`M1.1`, `M2.4`, `M3.5`, `M5 work`, etc.) from places where they meant nothing to a non-maintainer reader. Continues the cleanup arc of PR #178 (README/grant/KPI) and PR #180 (CI workflow comments).

## What changed

### Source files (TypeDoc-visible)
- **`harness/Harness.ts`**: removed a STALE doc claim — *"Methods deployCodeObject, upgradeCodeObject, runViewFunction, and runMoveScript are stubbed in M2.1 — they throw at runtime until M2.2/M2.3 lands."* M2.2 + M2.3 shipped a while ago; the methods are real. Cleaned class JSDoc + `_faucetUrl` param doc.
- **`index.ts`** / **`runtime.ts`** / **`core/Publisher.ts`** / **`fork/test.ts`** / **`types/runtime.ts`** / **`utils/address.ts`** / **`utils/childProcessAdapter.ts`** / **`harness/codeObject.ts`** / **`helpers/setupLocalTesting.ts`**: stripped M-refs from comments. Kept all technical WHY and \`#NN\` issue references that point at real GitHub context (bug fixes, security follow-ups).

### Tests + bench
- 9 test files + `bench/fork.bench.ts`: stripped *"Tests for X (M3.3)"*, *"M5 work"*, *"M2.4 follow-up"*, *"one-off for M2.3"* milestone tagging from describe blocks and inline comments.

### Build config
- **`vitest.config.ts`**: removed *"M3.2 — core/runtime"*, *"M3.5 — fork commands"* section headers; kept the technical rationale for each per-file threshold (why `run.ts` is at 70 not 80; why `serve.ts.functions` is at 25).

### Templates (shipped to users via \`movehat init\`)
- **\`templates/tests/Counter.test.ts\`** + **\`templates/scripts/deploy-counter.ts\`**: *"primary public API since M2"* → *"the primary public API"*; *"(new in M2)"* dropped.

### Example
- **\`examples/counter-example/tests/Counter.test.ts\`**: *"Migrated to the M2 Harness API"* → *"Uses the Harness API"*.

### Public docs site
- **\`content/docs/getting-started/quickstart.mdx\`**: *"primary surface since M2"* → *"primary surface"*.
- **\`content/docs/guides/{scripts,deployment}.mdx\`**: *"(M2 public API)"* dropped; the section already says \"Harness\".

### Repo docs
- **\`TESTING.md\`**: *"(M3.5 ratchet)"* dropped — the threshold is what it is today.
- **\`CHANGELOG.md\`** L33: *"meta-issue #73"* → \`[#73]\` with link, *"PR #168"* → \`[#168]\` with link.
- **\`packages/movehat/scripts/check-changelog.js\`**: dropped header comment *\"the codified gate meta-issue #73 specified for M6\"*.

## What was kept (deliberately)

- **\`ROADMAP.md\`**: per user direction — it's the public milestone tracker for contributors and intentionally carries M-refs.
- **\`CLAUDE.md\`**: M-refs in §5/§7 are load-bearing examples of the workflow rules themselves (e.g. *\"Use titles like \`[M1.3] Migrate child_process callers to runCli\`\"*).
- **All \`#NN\` issue/PR refs in source comments** where they point at real GitHub context (e.g. *\"Bug #36\"*, *\"closes #57\"*, *\"#149 reproduction\"*). These are GitHub-public and help readers find the original rationale.
- **\`MOVEMENT_CLI_COMPAT.md\`** and references to it from README/CHANGELOG — that file is real public documentation with the SHA256-pin policy, not an internal tracking doc.

## Verification

| Step | Result |
|---|---|
| Final grep `M[0-9]\\.?[0-9]?[a-z]?` outside ROADMAP/CLAUDE/CHANGELOG/SVG-paths | empty |
| Final grep `KPI\\|GRANT\\|Movement Network Foundation\\|meta-issue` outside ROADMAP/CLAUDE/CHANGELOG | empty |
| \`pnpm --filter movehat build\` | ✓ |
| \`pnpm --filter movehat test\` | 396/396 ✓ |
| \`pnpm check:example\` | ✓ |

## Tier 2 / Tier 3

\`N/A\` per §6.2 / §6.3: 29 files of comment/text changes only, plus one stale-claim JSDoc deletion in \`Harness.ts\`. No public method signatures changed; no runtime behavior touched. Tier 1 (build + unit tests + example typecheck) verified locally above.

## Test plan

- [x] Unit tests: 396/396 pass after edits.
- [x] Build clean.
- [x] Example typecheck clean.
- [ ] CI green confirms no accidental import/JSDoc breakage in files I edited.