### PR TITLE
chore(ci): scope CI to push:main + PRs to main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
 name: CI
 
 on:
+  # Runs only on the merge to main and on PRs targeting main.
+  # Sub-PRs to develop don't get CI — the batch develop→main PR is
+  # the validation gate. Maintainers running `pnpm test`,
+  # `pnpm check:example`, and Tier-2 smoke before merging sub-PRs to
+  # develop is the operational equivalent (see CLAUDE.md §6 / §8).
   push:
-    branches: [ main, develop, feature/* ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   # Build and type check


### PR DESCRIPTION
## Summary

The CI workflow currently runs on every push to \`main\` / \`develop\` / \`feature/*\` plus every PR targeting \`main\` / \`develop\`. With the develop→batch→main workflow this generates 2-3 duplicate runs per logical change:

1. Sub-PR opens on develop → \`pull_request\` trigger fires CI.
2. Sub-PR merges to develop → \`push:develop\` trigger fires CI again (duplicate).
3. Batch PR opens on main → \`pull_request\` trigger fires CI.
4. Batch merges to main → \`push:main\` trigger fires CI (often a third run).

This PR collapses CI to the single meaningful checkpoint: **PRs targeting main + the push to main itself**. The batch develop→main PR becomes the canonical validation gate.

## New scope (\`.github/workflows/ci.yml\`)

\`\`\`yaml
on:
  push:
    branches: [main]               # was: [main, develop, feature/*]
  pull_request:
    branches: [main]               # was: [main, develop]
  workflow_dispatch:               # new — manual rerun on any branch
\`\`\`

## Trade-off accepted

| Before | After |
|---|---|
| Sub-PRs to develop got automatic CI feedback | Sub-PRs to develop run no CI — maintainer runs Tier-1 locally before merge |
| Push to develop triggered CI | Push to develop is silent |
| Push to feature/* triggered CI | Push to feature/* is silent |
| Duplicate runs on PR open + sub-merge | Single run per validation point |

**Mitigation**: CLAUDE.md §8 Pre-merge checklist already mandates local Tier-1 verification (\`pnpm --filter movehat test\`, \`pnpm check:example\`) before merging sub-PRs to develop, plus Tier-2 smoke when source under \`packages/movehat/src/**\` is touched. The §8 self-review process is the operational equivalent of pre-merge CI for sub-PRs.

**Escape hatch**: \`workflow_dispatch\` lets a maintainer manually trigger CI on any branch from the Actions tab when they want a green check before opening the batch — covers the "I want CI on develop right now" case without restoring the noisy push trigger.

## What was NOT changed

- \`.github/workflows/publish.yml\`: only runs on \`release: published\` + \`workflow_dispatch\`. Already scoped correctly.
- \`.github/workflows/docs-deploy.yml\`: only runs on \`push: [main]\` + \`workflow_dispatch\`. Already scoped correctly.

## Verification

- \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"\`: ✓ parses.
- This PR is the first test of the new scope: it targets \`develop\`, so under the **new** rules CI would NOT run. CI runs on this PR only because the **old** trigger config is still on \`main\` until this lands. The merge-to-develop event will be the last CI fire on develop; after the next batch to main, sub-PRs are silent until they hit the batch.

## Tier 2 / Tier 3

N/A — workflow config change. CI on this PR itself is the validation gate.

## Test plan

- [x] YAML parses.
- [ ] CI runs on this PR (one last time under old config).
- [ ] After merge to develop + batch to main, observe that sub-PR opened against develop afterwards does NOT trigger CI.
- [ ] Verify \`workflow_dispatch\` button appears in the Actions UI.