### PR TITLE
chore(release): prepare v0.2.1 — fix npm README + accumulated docs/pipeline changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.1] - 2026-05-15
+
+### Fixed
+
+- npm registry README was stuck on the pre-reorg version because `packages/movehat/README.md` had drifted ~6 months behind the workspace-root `README.md`. The package's README has been resynced with the current root README (aggressively reorganized in [#178](https://github.com/gilbertsahumada/movehat/pull/178) + [#187](https://github.com/gilbertsahumada/movehat/pull/187)), and a `prepack` lifecycle script now auto-syncs the file on every `npm pack` / `npm publish` so drift cannot recur. Closes [#189](https://github.com/gilbertsahumada/movehat/pull/189).
+
+### Changed
+
+- Docs site migrated to the custom domain `https://movehat.org` (was `gilbertsahumada.github.io/movehat`). All README + in-package documentation links updated. ([#184](https://github.com/gilbertsahumada/movehat/pull/184))
+- README aggressively reorganized: 873 → 214 lines (-75%). Replaced the dump-style feature list with a Quick Start + one canonical Harness test + one canonical deployment script + CLI reference table + troubleshooting table. Long-form content lives on the docs site. ([#178](https://github.com/gilbertsahumada/movehat/pull/178), [#187](https://github.com/gilbertsahumada/movehat/pull/187))
+- Docs landing + intro page redesigned with Fumadocs Cards / Tabs / Callout components, mobile-first responsive layout, terminal preview, and copy buttons on all code snippets. ([#187](https://github.com/gilbertsahumada/movehat/pull/187))
+- Deployment example in README modernized from the legacy `harness.runtime.deployContract()` path to `harness.deployCodeObject({ moduleName })` to match the shipped template. ([#187](https://github.com/gilbertsahumada/movehat/pull/187))
+- CI workflow narrowed to fire only on `push:main` + PRs targeting `main` (was `push: [main, develop, feature/*]` + PRs to both). The `develop → main` batch PR is now the single internal-CI checkpoint; sub-PRs to develop rely on local Tier-1 + §8 self-review. `workflow_dispatch` added as manual escape hatch. ([#186](https://github.com/gilbertsahumada/movehat/pull/186))
+- Minimum Node version aligned to `>= 20` (was inconsistent — package.json `engines.node` already required 20+ but contributor docs / docker-compose said 18). Dropped the `test-node18` Docker service and the `pnpm docker:test:node18` script. ([#184](https://github.com/gilbertsahumada/movehat/pull/184))
+
+---
+
 ## [0.2.0] - 2026-05-15
 
 ### Removed

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {


### PR DESCRIPTION
## Summary

Patch release. Bumps \`packages/movehat/package.json\` from \`0.2.0\` → \`0.2.1\` and adds the corresponding \`## [0.2.1]\` section to \`CHANGELOG.md\` (required by the \`check-changelog.js\` publish gate).

## Why 0.2.1

Primary motivation: the npm registry page for \`movehat@0.2.0\` shows a stale, pre-reorg README (16-bullet feature dump, fork system as Step 7, old \`deployContract\` example). The root cause was found and fixed in [#189](https://github.com/gilbertsahumada/movehat/pull/189): \`packages/movehat/README.md\` had drifted from the workspace-root \`README.md\` since the published package's README lives inside that directory. A \`prepack\` lifecycle hook now syncs the file on every pack/publish, so the next release ships the correct README and future drift is impossible.

But npm doesn't update READMEs for already-published versions. To get the corrected README onto the npm page, we need to publish a new version. 0.2.1 is the minimal bump.

## Bundled (incidentally)

Everything else that landed on \`develop\` and \`main\` since 0.2.0 published:

- \`#178\`, \`#187\`: README + docs landing aggressive reorganization (873 → 214 lines; new Fumadocs-native intro; deploy example modernized).
- \`#180\`, \`#181\`: workflow-comment + source-comment cleanup (internal milestone refs stripped, stale claims removed).
- \`#184\`: custom domain \`movehat.org\`, CNAME file, basePath removed.
- \`#186\`: CI workflow scope narrowed to push:main + PRs:main.
- \`#189\`: the npm README sync fix that motivates this release.
- Node version alignment to \`>= 20\` (dropped Node 18 references from CONTRIBUTING, docker-compose, etc).

No public API surface modified. No behavior changes. \`engines.node\` unchanged at \`>= 20.0.0\`. Existing callers upgrade transparently.

## Release flow

1. This PR merges to \`develop\` (Tier-1 / §8 self-review per usual).
2. Batch \`develop → main\` PR opens. CI runs full internal workflow.
3. After main merge, I create a GitHub release tagged \`v0.2.1\` from main.
4. \`.github/workflows/publish.yml\` fires on \`release: published\`:
   - Runs CHANGELOG gate (already verified locally: ✓).
   - Runs unit + integration tests.
   - Builds + smoke-tests the package.
   - Publishes to npm via OIDC + SLSA provenance (Trusted Publishers config in place since [#172](https://github.com/gilbertsahumada/movehat/pull/172)).
5. After publish lands, verify \`https://npmjs.com/package/movehat\` shows the new README.

## Verification

- \`node packages/movehat/scripts/check-changelog.js\` against the updated state: ✓ matches version 0.2.1.
- \`jq '.version' packages/movehat/package.json\`: \`0.2.1\` ✓.
- \`npm pack --dry-run\` from \`packages/movehat/\` confirmed earlier: prepack fires + synced README in tarball.

## Tier 2 / Tier 3

N/A — release-prep PR. Two files changed (\`package.json\` version + \`CHANGELOG.md\` entry). The release artifact validation happens in \`publish.yml\` itself when the release is cut.

## Test plan

- [x] CHANGELOG section for 0.2.1 present and valid.
- [x] package.json version bumped.
- [ ] After release v0.2.1 is cut from main, confirm \`publish.yml\` succeeds and \`movehat@0.2.1\` lands on npm.
- [ ] After publish, visit https://www.npmjs.com/package/movehat and confirm the redesigned README is shown.