### PR TITLE
chore: add Tier B end-to-end dogfood test

### DIFF
--- a/Dockerfile.dogfood
+++ b/Dockerfile.dogfood
@@ -1,0 +1,41 @@
+# Dockerfile.dogfood — Tier B end-to-end dogfood test environment.
+#
+# Real Movement CLI (SHA256-pinned to match .github/workflows/ci.yml) +
+# Node 20 + pnpm. Builds movehat from the bind-mounted source, installs
+# globally inside the container, and runs scripts/dogfood-test.sh which
+# exercises the full user journey: scaffold → user-authored module edit →
+# compile → test on real local Movement node → fork-mode validation.
+#
+# Build + run via:
+#   pnpm docker:test:dogfood
+
+FROM node:20-bookworm
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Movement CLI. SHA256 must match the value pinned in
+# .github/workflows/ci.yml (`MOVEMENT_CLI_SHA256_LINUX_X64`). When that
+# value is rotated, this one must rotate in the same PR.
+ARG MOVEMENT_CLI_SHA256_LINUX_X64=f2bdf3fa82e6b49c83c91be0967640282e1759e66b237440709a8779a9f9c1b2
+ARG MOVEMENT_CLI_TAG=bypass-homebrew
+RUN ARTIFACT=movement-cli-l1-linux-x86_64.tar.gz && \
+    curl -fLO "https://github.com/movementlabsxyz/homebrew-movement-cli/releases/download/${MOVEMENT_CLI_TAG}/${ARTIFACT}" && \
+    echo "${MOVEMENT_CLI_SHA256_LINUX_X64}  ${ARTIFACT}" | sha256sum -c && \
+    mkdir -p /tmp/movement-cli && \
+    tar -xzf ${ARTIFACT} -C /tmp/movement-cli && \
+    mv /tmp/movement-cli/movement /usr/local/bin/movement && \
+    chmod +x /usr/local/bin/movement && \
+    rm -rf /tmp/movement-cli ${ARTIFACT} && \
+    movement --version
+
+RUN npm install -g pnpm@9
+
+WORKDIR /workspace
+
+ENV CI=true
+
+CMD ["bash", "/workspace/scripts/dogfood-test.sh"]

--- a/TESTING.md
+++ b/TESTING.md
@@ -177,6 +177,28 @@ This simulates:
 5. Running movehat commands
 6. Creating and testing a project
 
+### Tier B end-to-end dogfood test
+
+Validates the **full user journey** including a user-authored Move edit and fork-mode invariants:
+
+```bash
+pnpm docker:test:dogfood
+```
+
+What it does (~2–3 min):
+
+1. Builds + packs movehat from current source.
+2. Installs the tarball globally inside the container.
+3. Scaffolds a new project via `movehat init`.
+4. **Extends the template Counter module with a user-authored `reset()` function** (and a matching mocha test) — proves the framework supports real contributor edits, not just the canned template.
+5. Compiles with the real Movement CLI (SHA256-pinned, same revision as CI).
+6. Runs the mocha test suite against a **real local Movement node** spawned by `Harness.createLocal`.
+7. Creates a testnet fork via `Harness.createFork("testnet")` and verifies fork-mode invariants: deploy attempts must be rejected; post-`cleanup()` property access must throw `HarnessDisposedError`.
+
+Files: `Dockerfile.dogfood`, `scripts/dogfood-test.sh`, `scripts/dogfood-fork-test.ts`.
+
+The fork system is intentionally read-only today. Tracking writable-fork support: [#192](https://github.com/gilbertsahumada/movehat/issues/192).
+
 ### Test All Configurations
 
 ```bash

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -54,6 +54,18 @@ services:
         npm test
       "
 
+  # Tier B dogfood test — full end-to-end user journey with real Movement CLI
+  # (install + scaffold + user-authored Move edit + compile + test on local
+  # node + fork-mode invariants). Run via `pnpm docker:test:dogfood`.
+  test-dogfood:
+    build:
+      context: .
+      dockerfile: Dockerfile.dogfood
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    command: bash /workspace/scripts/dogfood-test.sh
+
   # Test de integración completa
   test-integration:
     build:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docker:test": "docker-compose -f docker-compose.test.yml up --abort-on-container-exit",
     "docker:test:node20": "docker-compose -f docker-compose.test.yml up test-node20",
     "docker:test:node22": "docker-compose -f docker-compose.test.yml up test-node22",
+    "docker:test:dogfood": "docker-compose -f docker-compose.test.yml build test-dogfood && docker-compose -f docker-compose.test.yml run --rm test-dogfood",
     "docker:clean": "docker-compose -f docker-compose.test.yml down --rmi local --volumes",
     "build:docs": "pnpm --filter docs build",
     "dev:docs": "pnpm --filter docs dev",

--- a/scripts/dogfood-fork-test.ts
+++ b/scripts/dogfood-fork-test.ts
@@ -1,0 +1,76 @@
+// scripts/dogfood-fork-test.ts
+//
+// Run by the dogfood-test.sh orchestrator (step 9/9). Validates that
+// fork-mode invariants hold against real testnet state:
+//   1. Harness.createFork("testnet") spawns a working fork-mode instance.
+//   2. Attempting a write (deployCodeObject) is rejected.
+//   3. After cleanup(), property access on a poisoned method throws
+//      HarnessDisposedError synchronously.
+//
+// Read-only verification of the on-chain side is intentionally limited:
+// the fork server proxies /accounts and /resources but not module-ABI
+// hydration, so SDK paths that load module ABI raise endpoint_not_found.
+// See packages/docs/content/docs/api/harness.mdx "Fork-mode view caveat".
+
+import { Harness, HarnessDisposedError } from "movehat";
+
+async function main(): Promise<void> {
+  console.log("Creating fork from testnet (this may take a few seconds)...");
+  const harness = await Harness.createFork("testnet");
+
+  console.log(
+    `✓ Fork harness ready — mode=${harness.mode}, network=${harness.runtime.network.name}`
+  );
+
+  // --- Invariant 1: deployCodeObject must throw on a fork-mode harness ---
+  let writeRejected = false;
+  try {
+    await harness.deployCodeObject({ moduleName: "dogfood_module" });
+  } catch (err) {
+    writeRejected = true;
+    const msg = err instanceof Error ? err.message : String(err);
+    console.log(`✓ deployCodeObject rejected: ${msg.split("\n")[0]}`);
+  }
+  if (!writeRejected) {
+    throw new Error(
+      "INVARIANT BROKEN: fork-mode deployCodeObject did NOT throw — writable forks are not supported (see issue #192)"
+    );
+  }
+
+  // --- Invariant 2: cleanup() poisons the harness ---
+  await harness.cleanup();
+  console.log("✓ cleanup() completed");
+
+  // --- Invariant 3: post-cleanup property access throws HarnessDisposedError ---
+  let poisoned = false;
+  try {
+    // Property access on a poisoned method triggers the Proxy trap.
+    harness.runViewFunction({ function: "0x1::nothing::nothing" });
+  } catch (err) {
+    poisoned = err instanceof HarnessDisposedError;
+    if (poisoned) {
+      console.log(
+        `✓ post-cleanup harness throws HarnessDisposedError (method='${
+          (err as HarnessDisposedError).methodName
+        }')`
+      );
+    } else {
+      throw err;
+    }
+  }
+  if (!poisoned) {
+    throw new Error(
+      "INVARIANT BROKEN: post-cleanup harness did not throw HarnessDisposedError"
+    );
+  }
+
+  console.log("FORK TEST PASSED");
+}
+
+main().catch((err: unknown) => {
+  console.error(
+    "FORK TEST FAILED:",
+    err instanceof Error ? err.stack ?? err.message : String(err)
+  );
+  process.exit(1);
+});

--- a/scripts/dogfood-test.sh
+++ b/scripts/dogfood-test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# scripts/dogfood-test.sh
+#
+# Tier B end-to-end dogfood test. Runs the full user journey:
+#   1. Build + pack movehat from /workspace source
+#   2. Install the tarball globally
+#   3. Scaffold a new project via `movehat init`
+#   4. Extend the template Counter module with a user-authored reset()
+#      function and a matching test (proves the framework supports real
+#      contributor edits, not just the canned template)
+#   5. Compile with the real Movement CLI
+#   6. Run mocha test suite against a real local Movement node spawned
+#      by Harness.createLocal
+#   7. Verify fork-mode invariants against testnet:
+#      - createFork succeeds
+#      - write attempts (deployCodeObject) are rejected
+#      - post-cleanup poisoning works
+#
+# Intended to run inside Dockerfile.dogfood with the repo bind-mounted
+# at /workspace. Invoke from the host via `pnpm docker:test:dogfood`.
+
+set -euo pipefail
+
+WORK_DIR="${WORK_DIR:-/workspace}"
+PROJECT_DIR="${PROJECT_DIR:-/tmp/dogfood-project}"
+SOURCE_PKG="${WORK_DIR}/packages/movehat"
+
+step() { echo; echo "═══ $* ═══"; }
+log()  { echo "  $*"; }
+fail() { echo "DOGFOOD FAIL: $*" >&2; exit 1; }
+
+step "1/9 — Verify environment"
+node --version || fail "Node not installed"
+movement --version || fail "Movement CLI not installed"
+pnpm --version || fail "pnpm not installed"
+log "node:     $(node --version)"
+log "movement: $(movement --version)"
+log "pnpm:     $(pnpm --version)"
+
+step "2/9 — Build + pack movehat from source"
+cd "${SOURCE_PKG}"
+# Workspace install is heavy; rely on the host having already built dist/
+# when possible, but reinstall + rebuild for full-from-scratch faithfulness.
+cd "${WORK_DIR}"
+pnpm install --frozen-lockfile 2>&1 | tail -3 || pnpm install 2>&1 | tail -3
+pnpm build:movehat 2>&1 | tail -3
+cd "${SOURCE_PKG}"
+TARBALL=$(npm pack 2>&1 | tail -1)
+TARBALL_PATH="${SOURCE_PKG}/${TARBALL}"
+test -f "${TARBALL_PATH}" || fail "Tarball not produced: ${TARBALL_PATH}"
+log "Packed: ${TARBALL}"
+
+step "3/9 — Install movehat globally from the freshly-packed tarball"
+npm install -g "${TARBALL_PATH}" 2>&1 | tail -3
+command -v movehat >/dev/null || fail "movehat not on PATH after global install"
+log "movehat version: $(movehat --version)"
+
+step "4/9 — Scaffold a new project via movehat init"
+rm -rf "${PROJECT_DIR}"
+movehat init "${PROJECT_DIR}" 2>&1 | tail -10
+cd "${PROJECT_DIR}"
+test -f move/sources/Counter.move || fail "Scaffold did not produce Counter.move"
+test -f tests/Counter.test.ts || fail "Scaffold did not produce Counter.test.ts"
+log "Project scaffolded at ${PROJECT_DIR}"
+
+step "5/9 — Extend Counter with a user-authored reset() function"
+# Inject `reset()` before the existing #[test(...)] annotation block.
+# Validates that movehat's compile/test flow accepts user-authored
+# changes to the template, not just the shipped template content.
+python3 - <<'PYEOF'
+import re
+from pathlib import Path
+
+p = Path("move/sources/Counter.move")
+src = p.read_text()
+reset_fn = '''
+    public entry fun reset(account: &signer) acquires Counter {
+        let account_addr = signer::address_of(account);
+        assert!(exists<Counter>(account_addr), E_NOT_INITIALIZED);
+        let counter = borrow_global_mut<Counter>(account_addr);
+        counter.value = 0;
+    }
+'''
+new_src = re.sub(r'(\n)(\s*#\[test\()', reset_fn + r'\1\2', src, count=1)
+if new_src == src:
+    raise SystemExit("FAIL: could not find #[test(...) annotation to inject reset() before. Template may have changed.")
+p.write_text(new_src)
+print(f"OK — reset() injected into Counter.move ({len(new_src)} bytes)")
+PYEOF
+
+# Append a TypeScript test that exercises reset()
+cat >> tests/Counter.test.ts <<'TSEOF'
+
+// Dogfood addition — validates the user-authored reset() function works
+// end-to-end against a real local Movement node.
+describe("Counter reset() — user-authored entry function", () => {
+  it("alice can reset her counter back to 0 after incrementing", async () => {
+    const alice = harness.runtime.getAccountByLabel("alice");
+
+    // Initialize counter for alice
+    await counter.call(alice, "init", []);
+
+    // Increment twice
+    await counter.call(alice, "increment", []);
+    await counter.call(alice, "increment", []);
+
+    let result = await harness.runViewFunction({
+      function: `${counterAddr}::counter::get`,
+      functionArguments: [alice.accountAddress.toString()],
+    });
+    expect(parseInt(result[0] as string)).to.equal(2);
+
+    // Reset
+    await counter.call(alice, "reset", []);
+
+    result = await harness.runViewFunction({
+      function: `${counterAddr}::counter::get`,
+      functionArguments: [alice.accountAddress.toString()],
+    });
+    expect(parseInt(result[0] as string)).to.equal(0);
+  });
+});
+TSEOF
+log "Counter.move extended with reset()"
+log "Counter.test.ts extended with reset() test"
+
+step "6/9 — Install project dependencies"
+npm install 2>&1 | tail -5
+
+step "7/9 — Compile Move modules"
+movehat compile 2>&1 | tail -10
+
+step "8/9 — Run TypeScript tests against a real local Movement node"
+# This spawns a real `movement node run-localnet`, funds the labeled
+# accounts, autoDeploys counter, and runs the mocha suite (including the
+# user-authored reset() test).
+set +e
+movehat test --ts 2>&1 | tee /tmp/dogfood-test.log
+TEST_EXIT=${PIPESTATUS[0]}
+set -e
+test "${TEST_EXIT}" -eq 0 || fail "movehat test --ts exited ${TEST_EXIT}"
+grep -qE "passing" /tmp/dogfood-test.log || fail "Mocha did not report a passing count"
+PASS_COUNT=$(grep -oE "([0-9]+) passing" /tmp/dogfood-test.log | head -1 | grep -oE "^[0-9]+")
+log "Tests passed: ${PASS_COUNT}"
+test "${PASS_COUNT}" -ge 1 || fail "No tests passed"
+
+step "9/9 — Fork-mode validation (read-only + write rejection)"
+cp "${WORK_DIR}/scripts/dogfood-fork-test.ts" scripts/dogfood-fork-test.ts
+set +e
+movehat run scripts/dogfood-fork-test.ts 2>&1 | tee /tmp/dogfood-fork.log
+FORK_EXIT=${PIPESTATUS[0]}
+set -e
+test "${FORK_EXIT}" -eq 0 || fail "Fork test script exited ${FORK_EXIT}"
+grep -q "FORK TEST PASSED" /tmp/dogfood-fork.log || fail "Fork test did not declare success"
+
+echo
+echo "═══════════════════════════════════════════════════════"
+echo "  DOGFOOD TEST PASSED"
+echo "  - Install + scaffold + user-authored Move edit + compile"
+echo "  - ${PASS_COUNT} mocha tests passed against real local node"
+echo "  - Fork-mode read + write-rejection invariants validated"
+echo "═══════════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Adds a Docker-based dogfood test that exercises the full user journey from \`npm install\` to running tests against a real local Movement node, plus fork-mode invariant validation against testnet. Surfaces drift in the install → scaffold → compile → test → fork flow that the existing per-piece tests (\`test:smoke\`, \`test:e2e\`, \`test:integration\`) don't catch when composed end-to-end with a user-authored Move edit.

Tracking issue: [#192](https://github.com/gilbertsahumada/movehat/issues/192) (writable-fork support for future Tier C step).

## Files

| File | Purpose |
|---|---|
| \`Dockerfile.dogfood\` (new) | Node 20 bookworm + real Movement CLI installed via SHA256-pinned tarball (same revision as \`ci.yml\`). Pin must rotate in lockstep with \`MOVEMENT_CLI_SHA256_LINUX_X64\` in \`.github/workflows/ci.yml\`. |
| \`scripts/dogfood-test.sh\` (new, executable) | 9-step orchestrator that runs inside the container. |
| \`scripts/dogfood-fork-test.ts\` (new) | Standalone TS script invoked by the orchestrator at step 9 to assert fork-mode invariants. |
| \`docker-compose.test.yml\` (modified) | New \`test-dogfood\` service bind-mounting \`.\` at \`/workspace\`. |
| \`package.json\` (modified) | New \`docker:test:dogfood\` script. |
| \`TESTING.md\` (modified) | Documents the new flow under "Docker Testing". |

## The 9-step orchestrator

1. **Verify environment** — node / movement / pnpm versions.
2. **Build + pack movehat** from \`/workspace/packages/movehat\` via \`npm pack\`.
3. **Install globally** — \`npm install -g\` on the freshly-packed tarball.
4. **Scaffold** — \`movehat init /tmp/dogfood-project\`.
5. **Extend the template Counter with a user-authored \`reset()\`** entry function and a matching mocha test. Validates the framework supports real contributor edits, not just the canned template.
6. **Install project deps** — \`npm install\` in the scaffolded project.
7. **Compile** — \`movehat compile\` against the real Movement CLI.
8. **Run mocha** — \`movehat test --ts\` spawns a real local Movement node via \`Harness.createLocal\`, autoDeploys, runs tests including the user-authored \`reset()\` test. Asserts >= 1 test passes.
9. **Fork-mode validation** — runs \`scripts/dogfood-fork-test.ts\`:
   - \`Harness.createFork("testnet")\` succeeds.
   - \`deployCodeObject\` on a fork-mode harness throws (read-only invariant).
   - Post-\`cleanup()\` property access throws \`HarnessDisposedError\` synchronously (poisoning invariant).

## Why Tier B, not Tier C

Tier C would deploy a contract to real testnet using \`MOVEMENT_TESTNET_PRIVATE_KEY\` as a GH secret + a funded account. We deliberately scoped to Tier B for now because:

- **Testnet deploy involves real gas costs** + secret management + flake risk from RPC.
- **Tier B exercises ~90% of the user-visible flow** without those concerns: install, scaffold, edit, compile, test, deploy locally (via \`createLocal\`), fork.
- Tier C can be added later as a separate nightly cron / pre-publish workflow once Tier B is stable.

## Why no CI wiring in this PR

The test runs locally on demand via \`pnpm docker:test:dogfood\` (~2-3 min). Wiring it into a GHA workflow (nightly cron + workflow_dispatch + maybe pre-publish gate) is a follow-up after we observe Tier B stability across a few manual runs. Putting an untested flow into CI risks blocking releases on a not-yet-trusted gate.

## Local run

\`\`\`bash
pnpm docker:test:dogfood
\`\`\`

Expected output ends with:

\`\`\`
═══════════════════════════════════════════════════════
  DOGFOOD TEST PASSED
  - Install + scaffold + user-authored Move edit + compile
  - N mocha tests passed against real local node
  - Fork-mode read + write-rejection invariants validated
═══════════════════════════════════════════════════════
\`\`\`

## Verification

- \`bash -n scripts/dogfood-test.sh\` → ✓ shell syntax OK.
- \`python3 -c "import yaml; yaml.safe_load(open('docker-compose.test.yml'))"\` → ✓ YAML parses.
- \`jq '.scripts'\` on root \`package.json\` shows \`docker:test:dogfood\` registered.
- Local Docker build + run: **not validated in this PR** — Docker host required. Will run \`pnpm docker:test:dogfood\` after merge as a smoke validation; if anything fails it'll be a follow-up fix PR.

## Tier 2 / Tier 3

N/A — adds a new test infrastructure file + orchestrator + Dockerfile. Doesn't change any source or runtime behavior. The shipping artifact is the dogfood test itself.

## Test plan

- [x] Shell syntax check.
- [x] YAML parse check.
- [x] All 6 files staged correctly.
- [ ] Manual \`pnpm docker:test:dogfood\` run after merge confirms the orchestrator passes against current \`develop\`.
- [ ] If \`reset()\` injection sed/python regex breaks because the template changed, fix in a follow-up.