### PR TITLE
chore(gitignore): ignore runtime artifacts that leak into repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,15 @@ packages/docs/content/docs/api/reference/
 /tmp/
 .movehat/
 
+# Move build artifacts (leak from Docker bind-mount when movement CLI runs inside container)
+Move.lock
+
+# pnpm CAS cache (leaks into repo root when pnpm runs inside Docker without access to ~/.local/share/pnpm/store)
+.pnpm-store/
+
+# Claude Code session state
+.claude/
+
 # Local reference 
 /catapulta/
 


### PR DESCRIPTION
## Summary

Three sources of untracked-file noise were filling up the working tree (10k+ files surfaced in IDE file listings):

| Path | Source | Size |
|---|---|---|
| `.pnpm-store/` | pnpm CAS cache. Leaks into repo root when `pnpm install` runs inside the dogfood Docker container — no access to host `~/.local/share/pnpm/store/`, so pnpm falls back to CWD which under bind-mount is the host repo. | 723MB / 27k files |
| `Move.lock` | Generated by `movement move build` (specifically in `scripts/warm/` from the dogfood image pre-warm step, but applies to any Move package). | ~2KB |
| `.claude/` | Claude Code session state — per-machine runtime, not project content. | <1KB |

Also removed `packages/movehat/public/movehat_move.png` — uncommitted since May 6, not referenced in any `.md`/`.mdx`/`.tsx`. Orphan.

## Why now

Surfaced while preparing the develop→main batch for Tier B dogfood (PRs #193 + #194). The pnpm-store leak is a direct side-effect of the new Docker dogfood test, so the ignore rule belongs in the same milestone.

## Test plan

- [x] `git status` clean after applying.
- [x] Existing tracked files unaffected (only `.gitignore` modified).

## Tier 2 / Tier 3

N/A — `.gitignore` change + orphan asset removal. No source / runtime / packaging behavior.