### PR TITLE
develop → main: Tier B dogfood test infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,15 @@ packages/docs/content/docs/api/reference/
 /tmp/
 .movehat/
 
+# Move build artifacts (leak from Docker bind-mount when movement CLI runs inside container)
+Move.lock
+
+# pnpm CAS cache (leaks into repo root when pnpm runs inside Docker without access to ~/.local/share/pnpm/store)
+.pnpm-store/
+
+# Claude Code session state
+.claude/
+
 # Local reference 
 /catapulta/
 

--- a/Dockerfile.dogfood
+++ b/Dockerfile.dogfood
@@ -1,0 +1,41 @@
+# Dockerfile.dogfood — Tier B end-to-end dogfood test environment.
+#
+# Real Movement CLI (SHA256-pinned to match .github/workflows/ci.yml) +
+# Node 20 + pnpm. Builds movehat from the bind-mounted source, installs
+# globally inside the container, and runs scripts/dogfood-test.sh which
+# exercises the full user journey: scaffold → user-authored module edit →
+# compile → test on real local Movement node → fork-mode validation.
+#
+# Build + run via:
+#   pnpm docker:test:dogfood
+
+FROM node:20-bookworm
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Movement CLI. SHA256 must match the value pinned in
+# .github/workflows/ci.yml (`MOVEMENT_CLI_SHA256_LINUX_X64`). When that
+# value is rotated, this one must rotate in the same PR.
+ARG MOVEMENT_CLI_SHA256_LINUX_X64=f2bdf3fa82e6b49c83c91be0967640282e1759e66b237440709a8779a9f9c1b2
+ARG MOVEMENT_CLI_TAG=bypass-homebrew
+RUN ARTIFACT=movement-cli-l1-linux-x86_64.tar.gz && \
+    curl -fLO "https://github.com/movementlabsxyz/homebrew-movement-cli/releases/download/${MOVEMENT_CLI_TAG}/${ARTIFACT}" && \
+    echo "${MOVEMENT_CLI_SHA256_LINUX_X64}  ${ARTIFACT}" | sha256sum -c && \
+    mkdir -p /tmp/movement-cli && \
+    tar -xzf ${ARTIFACT} -C /tmp/movement-cli && \
+    mv /tmp/movement-cli/movement /usr/local/bin/movement && \
+    chmod +x /usr/local/bin/movement && \
+    rm -rf /tmp/movement-cli ${ARTIFACT} && \
+    movement --version
+
+RUN npm install -g pnpm@9
+
+WORKDIR /workspace
+
+ENV CI=true
+
+CMD ["bash", "/workspace/scripts/dogfood-test.sh"]

--- a/Dockerfile.dogfood
+++ b/Dockerfile.dogfood
@@ -9,12 +9,19 @@
 # Build + run via:
 #   pnpm docker:test:dogfood
 
-FROM node:20-bookworm
+# Debian Trixie (13) ships glibc 2.41 / libstdc++ from gcc 14. Required
+# because the upstream Movement CLI binary is compiled against glibc 2.38+
+# and CXXABI 1.3.15 (gcc 13+). The previous bookworm base (glibc 2.36)
+# could not load the binary even under Rosetta. CI uses ubuntu-latest
+# (24.04, glibc 2.39) which is also new enough; trixie matches the CI
+# capability for local parity.
+FROM node:20-trixie-slim
 
 RUN apt-get update && apt-get install -y \
     curl \
     ca-certificates \
     python3 \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Movement CLI. SHA256 must match the value pinned in
@@ -33,6 +40,18 @@ RUN ARTIFACT=movement-cli-l1-linux-x86_64.tar.gz && \
     movement --version
 
 RUN npm install -g pnpm@9
+
+# Pre-warm Movement CLI's AptosFramework dependency cache. Without this,
+# the first `movement move build` inside the running container has to git-
+# clone aptos-core (large repo) which under Rosetta emulation routinely
+# exceeds movehat's default 2-minute CLI timeout — manifests as
+# "Compilation failed: Command timed out after 120000ms". Cloning once at
+# image build time bakes the deps into /root/.move/, so all subsequent
+# builds inside the container are fast.
+COPY scripts/warm /tmp/warm
+RUN cd /tmp/warm && \
+    movement move build --named-addresses warm=0xcafe && \
+    rm -rf /tmp/warm
 
 WORKDIR /workspace
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -177,6 +177,28 @@ This simulates:
 5. Running movehat commands
 6. Creating and testing a project
 
+### Tier B end-to-end dogfood test
+
+Validates the **full user journey** including a user-authored Move edit and fork-mode invariants:
+
+```bash
+pnpm docker:test:dogfood
+```
+
+What it does (~2–3 min):
+
+1. Builds + packs movehat from current source.
+2. Installs the tarball globally inside the container.
+3. Scaffolds a new project via `movehat init`.
+4. **Extends the template Counter module with a user-authored `reset()` function** (and a matching mocha test) — proves the framework supports real contributor edits, not just the canned template.
+5. Compiles with the real Movement CLI (SHA256-pinned, same revision as CI).
+6. Runs the mocha test suite against a **real local Movement node** spawned by `Harness.createLocal`.
+7. Creates a testnet fork via `Harness.createFork("testnet")` and verifies fork-mode invariants: deploy attempts must be rejected; post-`cleanup()` property access must throw `HarnessDisposedError`.
+
+Files: `Dockerfile.dogfood`, `scripts/dogfood-test.sh`, `scripts/dogfood-fork-test.ts`.
+
+The fork system is intentionally read-only today. Tracking writable-fork support: [#192](https://github.com/gilbertsahumada/movehat/issues/192).
+
 ### Test All Configurations
 
 ```bash

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -54,6 +54,18 @@ services:
         npm test
       "
 
+  # Tier B dogfood test — full end-to-end user journey with real Movement CLI
+  # (install + scaffold + user-authored Move edit + compile + test on local
+  # node + fork-mode invariants). Run via `pnpm docker:test:dogfood`.
+  test-dogfood:
+    build:
+      context: .
+      dockerfile: Dockerfile.dogfood
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    command: bash /workspace/scripts/dogfood-test.sh
+
   # Test de integración completa
   test-integration:
     build:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -57,10 +57,20 @@ services:
   # Tier B dogfood test — full end-to-end user journey with real Movement CLI
   # (install + scaffold + user-authored Move edit + compile + test on local
   # node + fork-mode invariants). Run via `pnpm docker:test:dogfood`.
+  #
+  # `platform: linux/amd64` is required because the Movement CLI binary is
+  # x86_64-only (no ARM64 Linux build exists upstream). On Apple Silicon
+  # this forces Docker Desktop to use Rosetta emulation; on amd64 hosts
+  # (CI, Intel Macs, Linux PCs) it's a no-op. Without this, Apple Silicon
+  # hits "rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2"
+  # during Movement CLI install.
   test-dogfood:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile.dogfood
+      platforms:
+        - linux/amd64
     volumes:
       - .:/workspace
     working_dir: /workspace

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docker:test": "docker-compose -f docker-compose.test.yml up --abort-on-container-exit",
     "docker:test:node20": "docker-compose -f docker-compose.test.yml up test-node20",
     "docker:test:node22": "docker-compose -f docker-compose.test.yml up test-node22",
+    "docker:test:dogfood": "docker-compose -f docker-compose.test.yml build test-dogfood && docker-compose -f docker-compose.test.yml run --rm test-dogfood",
     "docker:clean": "docker-compose -f docker-compose.test.yml down --rmi local --volumes",
     "build:docs": "pnpm --filter docs build",
     "dev:docs": "pnpm --filter docs dev",

--- a/scripts/dogfood-fork-test.ts
+++ b/scripts/dogfood-fork-test.ts
@@ -1,0 +1,76 @@
+// scripts/dogfood-fork-test.ts
+//
+// Run by the dogfood-test.sh orchestrator (step 9/9). Validates that
+// fork-mode invariants hold against real testnet state:
+//   1. Harness.createFork("testnet") spawns a working fork-mode instance.
+//   2. Attempting a write (deployCodeObject) is rejected.
+//   3. After cleanup(), property access on a poisoned method throws
+//      HarnessDisposedError synchronously.
+//
+// Read-only verification of the on-chain side is intentionally limited:
+// the fork server proxies /accounts and /resources but not module-ABI
+// hydration, so SDK paths that load module ABI raise endpoint_not_found.
+// See packages/docs/content/docs/api/harness.mdx "Fork-mode view caveat".
+
+import { Harness, HarnessDisposedError } from "movehat";
+
+async function main(): Promise<void> {
+  console.log("Creating fork from testnet (this may take a few seconds)...");
+  const harness = await Harness.createFork("testnet");
+
+  console.log(
+    `✓ Fork harness ready — mode=${harness.mode}, network=${harness.runtime.network.name}`
+  );
+
+  // --- Invariant 1: deployCodeObject must throw on a fork-mode harness ---
+  let writeRejected = false;
+  try {
+    await harness.deployCodeObject({ moduleName: "dogfood_module" });
+  } catch (err) {
+    writeRejected = true;
+    const msg = err instanceof Error ? err.message : String(err);
+    console.log(`✓ deployCodeObject rejected: ${msg.split("\n")[0]}`);
+  }
+  if (!writeRejected) {
+    throw new Error(
+      "INVARIANT BROKEN: fork-mode deployCodeObject did NOT throw — writable forks are not supported (see issue #192)"
+    );
+  }
+
+  // --- Invariant 2: cleanup() poisons the harness ---
+  await harness.cleanup();
+  console.log("✓ cleanup() completed");
+
+  // --- Invariant 3: post-cleanup property access throws HarnessDisposedError ---
+  let poisoned = false;
+  try {
+    // Property access on a poisoned method triggers the Proxy trap.
+    harness.runViewFunction({ function: "0x1::nothing::nothing" });
+  } catch (err) {
+    poisoned = err instanceof HarnessDisposedError;
+    if (poisoned) {
+      console.log(
+        `✓ post-cleanup harness throws HarnessDisposedError (method='${
+          (err as HarnessDisposedError).methodName
+        }')`
+      );
+    } else {
+      throw err;
+    }
+  }
+  if (!poisoned) {
+    throw new Error(
+      "INVARIANT BROKEN: post-cleanup harness did not throw HarnessDisposedError"
+    );
+  }
+
+  console.log("FORK TEST PASSED");
+}
+
+main().catch((err: unknown) => {
+  console.error(
+    "FORK TEST FAILED:",
+    err instanceof Error ? err.stack ?? err.message : String(err)
+  );
+  process.exit(1);
+});

--- a/scripts/dogfood-test.sh
+++ b/scripts/dogfood-test.sh
@@ -56,93 +56,94 @@ command -v movehat >/dev/null || fail "movehat not on PATH after global install"
 log "movehat version: $(movehat --version)"
 
 step "4/9 — Scaffold a new project via movehat init"
+# `movehat init <name>` uses the argument as both the directory AND the
+# Move package name. Pass a bare identifier (not a path) so Move.toml
+# gets a valid `name = "dogfood-project"`.
+PROJECT_NAME="$(basename "${PROJECT_DIR}")"
+PROJECT_PARENT="$(dirname "${PROJECT_DIR}")"
 rm -rf "${PROJECT_DIR}"
-movehat init "${PROJECT_DIR}" 2>&1 | tail -10
+cd "${PROJECT_PARENT}"
+movehat init "${PROJECT_NAME}" 2>&1 | tail -10
 cd "${PROJECT_DIR}"
 test -f move/sources/Counter.move || fail "Scaffold did not produce Counter.move"
 test -f tests/Counter.test.ts || fail "Scaffold did not produce Counter.test.ts"
-log "Project scaffolded at ${PROJECT_DIR}"
+log "Project scaffolded at ${PROJECT_DIR} (package name: ${PROJECT_NAME})"
 
-step "5/9 — Extend Counter with a user-authored reset() function"
-# Inject `reset()` before the existing #[test(...)] annotation block.
-# Validates that movehat's compile/test flow accepts user-authored
-# changes to the template, not just the shipped template content.
+step "5/9 — Extend Counter with a user-authored reset() function + Move test"
+# Inject `reset()` entry function AND a corresponding #[test] right
+# before the existing test_increment annotation. Validates that
+# movehat's compile/test flow accepts user-authored changes to the
+# template, not just the shipped template content.
 python3 - <<'PYEOF'
 import re
 from pathlib import Path
 
 p = Path("move/sources/Counter.move")
 src = p.read_text()
-reset_fn = '''
+injection = '''
     public entry fun reset(account: &signer) acquires Counter {
         let account_addr = signer::address_of(account);
         assert!(exists<Counter>(account_addr), E_NOT_INITIALIZED);
         let counter = borrow_global_mut<Counter>(account_addr);
         counter.value = 0;
     }
+
+    #[test(account = @0x1)]
+    public fun test_reset(account: &signer) acquires Counter {
+        let addr = signer::address_of(account);
+        aptos_framework::account::create_account_for_test(addr);
+
+        init(account);
+        increment(account);
+        increment(account);
+        assert!(get(addr) == 2, 100);
+
+        reset(account);
+        assert!(get(addr) == 0, 101);
+    }
 '''
-new_src = re.sub(r'(\n)(\s*#\[test\()', reset_fn + r'\1\2', src, count=1)
+new_src = re.sub(r'(\n)(\s*#\[test\()', injection + r'\1\2', src, count=1)
 if new_src == src:
     raise SystemExit("FAIL: could not find #[test(...) annotation to inject reset() before. Template may have changed.")
 p.write_text(new_src)
-print(f"OK — reset() injected into Counter.move ({len(new_src)} bytes)")
+print(f"OK — reset() entry fn + test_reset Move test injected ({len(new_src)} bytes)")
 PYEOF
-
-# Append a TypeScript test that exercises reset()
-cat >> tests/Counter.test.ts <<'TSEOF'
-
-// Dogfood addition — validates the user-authored reset() function works
-// end-to-end against a real local Movement node.
-describe("Counter reset() — user-authored entry function", () => {
-  it("alice can reset her counter back to 0 after incrementing", async () => {
-    const alice = harness.runtime.getAccountByLabel("alice");
-
-    // Initialize counter for alice
-    await counter.call(alice, "init", []);
-
-    // Increment twice
-    await counter.call(alice, "increment", []);
-    await counter.call(alice, "increment", []);
-
-    let result = await harness.runViewFunction({
-      function: `${counterAddr}::counter::get`,
-      functionArguments: [alice.accountAddress.toString()],
-    });
-    expect(parseInt(result[0] as string)).to.equal(2);
-
-    // Reset
-    await counter.call(alice, "reset", []);
-
-    result = await harness.runViewFunction({
-      function: `${counterAddr}::counter::get`,
-      functionArguments: [alice.accountAddress.toString()],
-    });
-    expect(parseInt(result[0] as string)).to.equal(0);
-  });
-});
-TSEOF
-log "Counter.move extended with reset()"
-log "Counter.test.ts extended with reset() test"
+log "Counter.move extended with reset() + test_reset()"
 
 step "6/9 — Install project dependencies"
-npm install 2>&1 | tail -5
+npm install 2>&1 | grep -vE "^npm (warn|notice)" | head -30 || true
 
 step "7/9 — Compile Move modules"
-movehat compile 2>&1 | tail -10
+# Debug: dump the file state movehat compile will see (helps diagnose
+# "No such file or directory" type errors which don't tell us which file).
+echo "--- Move.toml ---"
+cat move/Move.toml
+echo "--- move/sources/Counter.move (head + tail) ---"
+head -40 move/sources/Counter.move
+echo "  ..."
+tail -20 move/sources/Counter.move
+echo "--- ls move/ ---"
+ls -la move/ move/sources/
+echo "--- compile output ---"
+# Full output (no tail) so Move compiler errors are visible if any.
+movehat compile 2>&1
 
-step "8/9 — Run TypeScript tests against a real local Movement node"
-# This spawns a real `movement node run-localnet`, funds the labeled
-# accounts, autoDeploys counter, and runs the mocha suite (including the
-# user-authored reset() test).
+step "8/9 — Run Move unit tests"
+# We use --move (Move-level unit tests) rather than --ts because the
+# `movement node run-local-testnet` path crashes on Linux x86_64 with
+# the upstream MintFunder ENOT_APTOS_FRAMEWORK_ADDRESS bug (same one
+# that gates harness-local in CI behind MOVEHAT_SKIP_LOCAL_NODE).
+# Move tests exercise init + increment + reset semantics natively with
+# no node spawn, so they're portable across all hosts. The TypeScript
+# Harness.createLocal path is validated separately in the integration
+# suite running on macOS hosts directly (no Rosetta).
 set +e
-movehat test --ts 2>&1 | tee /tmp/dogfood-test.log
+movehat test --move 2>&1 | tee /tmp/dogfood-test.log
 TEST_EXIT=${PIPESTATUS[0]}
 set -e
-test "${TEST_EXIT}" -eq 0 || fail "movehat test --ts exited ${TEST_EXIT}"
-grep -qE "passing" /tmp/dogfood-test.log || fail "Mocha did not report a passing count"
-PASS_COUNT=$(grep -oE "([0-9]+) passing" /tmp/dogfood-test.log | head -1 | grep -oE "^[0-9]+")
-log "Tests passed: ${PASS_COUNT}"
-test "${PASS_COUNT}" -ge 1 || fail "No tests passed"
+test "${TEST_EXIT}" -eq 0 || fail "movehat test --move exited ${TEST_EXIT}"
+grep -qE "Test result: OK" /tmp/dogfood-test.log || fail "Move tests did not report OK"
+log "Move tests passed (includes user-authored test_reset)"
 
 step "9/9 — Fork-mode validation (read-only + write rejection)"
 cp "${WORK_DIR}/scripts/dogfood-fork-test.ts" scripts/dogfood-fork-test.ts
@@ -157,6 +158,6 @@ echo
 echo "═══════════════════════════════════════════════════════"
 echo "  DOGFOOD TEST PASSED"
 echo "  - Install + scaffold + user-authored Move edit + compile"
-echo "  - ${PASS_COUNT} mocha tests passed against real local node"
+echo "  - Move unit tests passed (including test_reset)"
 echo "  - Fork-mode read + write-rejection invariants validated"
 echo "═══════════════════════════════════════════════════════"

--- a/scripts/dogfood-test.sh
+++ b/scripts/dogfood-test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# scripts/dogfood-test.sh
+#
+# Tier B end-to-end dogfood test. Runs the full user journey:
+#   1. Build + pack movehat from /workspace source
+#   2. Install the tarball globally
+#   3. Scaffold a new project via `movehat init`
+#   4. Extend the template Counter module with a user-authored reset()
+#      function and a matching test (proves the framework supports real
+#      contributor edits, not just the canned template)
+#   5. Compile with the real Movement CLI
+#   6. Run mocha test suite against a real local Movement node spawned
+#      by Harness.createLocal
+#   7. Verify fork-mode invariants against testnet:
+#      - createFork succeeds
+#      - write attempts (deployCodeObject) are rejected
+#      - post-cleanup poisoning works
+#
+# Intended to run inside Dockerfile.dogfood with the repo bind-mounted
+# at /workspace. Invoke from the host via `pnpm docker:test:dogfood`.
+
+set -euo pipefail
+
+WORK_DIR="${WORK_DIR:-/workspace}"
+PROJECT_DIR="${PROJECT_DIR:-/tmp/dogfood-project}"
+SOURCE_PKG="${WORK_DIR}/packages/movehat"
+
+step() { echo; echo "═══ $* ═══"; }
+log()  { echo "  $*"; }
+fail() { echo "DOGFOOD FAIL: $*" >&2; exit 1; }
+
+step "1/9 — Verify environment"
+node --version || fail "Node not installed"
+movement --version || fail "Movement CLI not installed"
+pnpm --version || fail "pnpm not installed"
+log "node:     $(node --version)"
+log "movement: $(movement --version)"
+log "pnpm:     $(pnpm --version)"
+
+step "2/9 — Build + pack movehat from source"
+cd "${SOURCE_PKG}"
+# Workspace install is heavy; rely on the host having already built dist/
+# when possible, but reinstall + rebuild for full-from-scratch faithfulness.
+cd "${WORK_DIR}"
+pnpm install --frozen-lockfile 2>&1 | tail -3 || pnpm install 2>&1 | tail -3
+pnpm build:movehat 2>&1 | tail -3
+cd "${SOURCE_PKG}"
+TARBALL=$(npm pack 2>&1 | tail -1)
+TARBALL_PATH="${SOURCE_PKG}/${TARBALL}"
+test -f "${TARBALL_PATH}" || fail "Tarball not produced: ${TARBALL_PATH}"
+log "Packed: ${TARBALL}"
+
+step "3/9 — Install movehat globally from the freshly-packed tarball"
+npm install -g "${TARBALL_PATH}" 2>&1 | tail -3
+command -v movehat >/dev/null || fail "movehat not on PATH after global install"
+log "movehat version: $(movehat --version)"
+
+step "4/9 — Scaffold a new project via movehat init"
+rm -rf "${PROJECT_DIR}"
+movehat init "${PROJECT_DIR}" 2>&1 | tail -10
+cd "${PROJECT_DIR}"
+test -f move/sources/Counter.move || fail "Scaffold did not produce Counter.move"
+test -f tests/Counter.test.ts || fail "Scaffold did not produce Counter.test.ts"
+log "Project scaffolded at ${PROJECT_DIR}"
+
+step "5/9 — Extend Counter with a user-authored reset() function"
+# Inject `reset()` before the existing #[test(...)] annotation block.
+# Validates that movehat's compile/test flow accepts user-authored
+# changes to the template, not just the shipped template content.
+python3 - <<'PYEOF'
+import re
+from pathlib import Path
+
+p = Path("move/sources/Counter.move")
+src = p.read_text()
+reset_fn = '''
+    public entry fun reset(account: &signer) acquires Counter {
+        let account_addr = signer::address_of(account);
+        assert!(exists<Counter>(account_addr), E_NOT_INITIALIZED);
+        let counter = borrow_global_mut<Counter>(account_addr);
+        counter.value = 0;
+    }
+'''
+new_src = re.sub(r'(\n)(\s*#\[test\()', reset_fn + r'\1\2', src, count=1)
+if new_src == src:
+    raise SystemExit("FAIL: could not find #[test(...) annotation to inject reset() before. Template may have changed.")
+p.write_text(new_src)
+print(f"OK — reset() injected into Counter.move ({len(new_src)} bytes)")
+PYEOF
+
+# Append a TypeScript test that exercises reset()
+cat >> tests/Counter.test.ts <<'TSEOF'
+
+// Dogfood addition — validates the user-authored reset() function works
+// end-to-end against a real local Movement node.
+describe("Counter reset() — user-authored entry function", () => {
+  it("alice can reset her counter back to 0 after incrementing", async () => {
+    const alice = harness.runtime.getAccountByLabel("alice");
+
+    // Initialize counter for alice
+    await counter.call(alice, "init", []);
+
+    // Increment twice
+    await counter.call(alice, "increment", []);
+    await counter.call(alice, "increment", []);
+
+    let result = await harness.runViewFunction({
+      function: `${counterAddr}::counter::get`,
+      functionArguments: [alice.accountAddress.toString()],
+    });
+    expect(parseInt(result[0] as string)).to.equal(2);
+
+    // Reset
+    await counter.call(alice, "reset", []);
+
+    result = await harness.runViewFunction({
+      function: `${counterAddr}::counter::get`,
+      functionArguments: [alice.accountAddress.toString()],
+    });
+    expect(parseInt(result[0] as string)).to.equal(0);
+  });
+});
+TSEOF
+log "Counter.move extended with reset()"
+log "Counter.test.ts extended with reset() test"
+
+step "6/9 — Install project dependencies"
+npm install 2>&1 | tail -5
+
+step "7/9 — Compile Move modules"
+movehat compile 2>&1 | tail -10
+
+step "8/9 — Run TypeScript tests against a real local Movement node"
+# This spawns a real `movement node run-localnet`, funds the labeled
+# accounts, autoDeploys counter, and runs the mocha suite (including the
+# user-authored reset() test).
+set +e
+movehat test --ts 2>&1 | tee /tmp/dogfood-test.log
+TEST_EXIT=${PIPESTATUS[0]}
+set -e
+test "${TEST_EXIT}" -eq 0 || fail "movehat test --ts exited ${TEST_EXIT}"
+grep -qE "passing" /tmp/dogfood-test.log || fail "Mocha did not report a passing count"
+PASS_COUNT=$(grep -oE "([0-9]+) passing" /tmp/dogfood-test.log | head -1 | grep -oE "^[0-9]+")
+log "Tests passed: ${PASS_COUNT}"
+test "${PASS_COUNT}" -ge 1 || fail "No tests passed"
+
+step "9/9 — Fork-mode validation (read-only + write rejection)"
+cp "${WORK_DIR}/scripts/dogfood-fork-test.ts" scripts/dogfood-fork-test.ts
+set +e
+movehat run scripts/dogfood-fork-test.ts 2>&1 | tee /tmp/dogfood-fork.log
+FORK_EXIT=${PIPESTATUS[0]}
+set -e
+test "${FORK_EXIT}" -eq 0 || fail "Fork test script exited ${FORK_EXIT}"
+grep -q "FORK TEST PASSED" /tmp/dogfood-fork.log || fail "Fork test did not declare success"
+
+echo
+echo "═══════════════════════════════════════════════════════"
+echo "  DOGFOOD TEST PASSED"
+echo "  - Install + scaffold + user-authored Move edit + compile"
+echo "  - ${PASS_COUNT} mocha tests passed against real local node"
+echo "  - Fork-mode read + write-rejection invariants validated"
+echo "═══════════════════════════════════════════════════════"

--- a/scripts/warm/Move.toml
+++ b/scripts/warm/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "warm"
+version = "1.0.0"
+
+[addresses]
+warm = "_"
+
+[dependencies.AptosFramework]
+git = "https://github.com/movementlabsxyz/aptos-core.git"
+rev = "movement"
+subdir = "aptos-move/framework/aptos-framework"

--- a/scripts/warm/sources/Warm.move
+++ b/scripts/warm/sources/Warm.move
@@ -1,0 +1,6 @@
+// Minimal Move module used only to pre-warm the Movement CLI's
+// AptosFramework dependency cache during Docker image build. Not shipped
+// to users; not exercised at runtime.
+module warm::warm {
+    public fun nothing() {}
+}


### PR DESCRIPTION
## Summary

Batch merge of three sub-PRs that together land the Tier B end-to-end dogfood test.

| PR | Title | Commit |
|---|---|---|
| #193 | chore: add Tier B end-to-end dogfood test | fc3f408 |
| #194 | fix(dogfood): make Tier B test pass on Apple Silicon + Linux x86_64 | 5e77fcf |
| #196 | chore(gitignore): ignore runtime artifacts that leak into repo | 6d9bc49 |

## What lands

**Tier B dogfood test** (`pnpm docker:test:dogfood`) — full user journey validated in an isolated Docker environment with the real Movement CLI:
1. Build + pack movehat from source.
2. Install the tarball globally.
3. Scaffold a fresh project via `movehat init`.
4. Inject a user-authored `reset()` entry function + matching `#[test]` into the template Counter — proves the framework accepts real contributor edits, not just canned scaffolding.
5. Compile with Movement CLI.
6. Run Move unit tests (includes the injected `test_reset`).
7. Fork-mode validation: `createFork("testnet")` succeeds, `deployCodeObject` throws on the read-only fork, post-cleanup poisoning works.

Empirically validated on Apple Silicon via Docker Desktop / Rosetta. First-run ~6 min (image build); subsequent runs ~2 min.

**Why Tier B and not Tier C**: the upstream `movement node run-local-testnet` bug (#149, `ENOT_APTOS_FRAMEWORK_ADDRESS` in MintFunder) blocks `harness-local` on Linux x86_64. CI gates this behind `MOVEHAT_SKIP_LOCAL_NODE`. The dogfood test uses Move-level unit tests (no node spawn) instead, so it's portable. Tier C (testnet deploy E2E) is deferred until a writable-fork story exists — tracked in issue #192.

## Files

- New: `Dockerfile.dogfood`, `scripts/dogfood-test.sh`, `scripts/dogfood-fork-test.ts`, `scripts/warm/Move.toml`, `scripts/warm/sources/Warm.move`.
- Modified: `docker-compose.test.yml` (new `test-dogfood` service), root `package.json` (new `docker:test:dogfood` script), `.gitignore` (runtime artifact noise from the new test surface).

## Follow-ups filed during this milestone

- #192 — Tier C (writable fork) tracking issue.
- #195 — `movehat init` should validate package name as a Move identifier (paper-cut surfaced while diagnosing dogfood issues).

## Tier 2 / Tier 3

- Sub-PRs #193 / #194: marked N/A — Docker infra + orchestrator, no source / packaging behavior. The dogfood test *is* the validation gate.
- Sub-PR #196: marked N/A — `.gitignore`-only change.
- This batch: `pnpm docker:test:dogfood` re-runs would replay the validation; not re-running on the batch PR since each sub-PR already exercised it locally and no code merges with the batch.

## Test plan

- [x] Sub-PRs #193 / #194 / #196 merged green to develop with third-party CI passes (CodeRabbit / GitGuardian / Socket).
- [x] `pnpm docker:test:dogfood` end-to-end green locally (sub-PR #194 evidence).
- [x] `gh pr view --json mergeable` returns `MERGEABLE` before promoting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added end-to-end dogfood testing infrastructure validating the complete user workflow including build, installation, project initialization, compilation, and fork-mode scenarios.

* **Documentation**
  * Added Tier B dogfood test documentation.

* **Chores**
  * Updated build artifact ignores and configured Docker-based test environment with dependency cache pre-warming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/197)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->