### PR TITLE
feat(init): sanitize project name as Move identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `movehat init <name>` now sanitizes the project name into a valid Move
+  identifier when writing `move/Move.toml`, preserving the original name for
+  `package.json` and the directory. Invalid characters (hyphens, slashes,
+  dots) are replaced with underscores; names starting with a digit are
+  prefixed with `pkg_`. A warning is printed when sanitization changes the
+  name. Names that resolve to nothing usable (`.`, `..`, empty, only
+  separators) are now rejected with a clear error. Previously, passing a
+  path like `/tmp/my-project` produced a malformed `Move.toml` and a cryptic
+  `"No such file or directory"` compile failure. Closes
+  [#195](https://github.com/gilbertsahumada/movehat/issues/195).
+
 ### Deprecated
 
 ### Removed

--- a/packages/movehat/src/commands/__tests__/init.test.ts
+++ b/packages/movehat/src/commands/__tests__/init.test.ts
@@ -13,7 +13,8 @@ vi.mock("../../helpers/banner.js", () => ({
   printMovehatBanner: () => undefined,
 }));
 
-const { default: initCommand } = await import("../init.js");
+const initModule = await import("../init.js");
+const { default: initCommand, resolveProjectNames, InvalidProjectNameError } = initModule;
 
 /**
  * Strategy: real tmpdir + real fs ops (matches §6.1's example-as-canonical
@@ -28,10 +29,38 @@ const { default: initCommand } = await import("../init.js");
  * to `src/templates/` cleanly. No bundling step required.
  */
 
+describe("resolveProjectNames", () => {
+  const cases: Array<[
+    string,
+    { dirName: string; npmName: string; moveName: string; sanitized: boolean }
+  ]> = [
+    ["my_project", { dirName: "my_project", npmName: "my_project", moveName: "my_project", sanitized: false }],
+    ["my-project", { dirName: "my-project", npmName: "my-project", moveName: "my_project", sanitized: true }],
+    ["/tmp/my-project", { dirName: "/tmp/my-project", npmName: "my-project", moveName: "my_project", sanitized: true }],
+    ["123abc", { dirName: "123abc", npmName: "123abc", moveName: "pkg_123abc", sanitized: true }],
+    ["_underscore", { dirName: "_underscore", npmName: "_underscore", moveName: "_underscore", sanitized: false }],
+    ["UPPER", { dirName: "UPPER", npmName: "UPPER", moveName: "UPPER", sanitized: false }],
+    ["  spaced  ", { dirName: "spaced", npmName: "spaced", moveName: "spaced", sanitized: false }],
+    ["with spaces", { dirName: "with spaces", npmName: "with spaces", moveName: "with_spaces", sanitized: true }],
+  ];
+
+  it.each(cases)("derives names for %j", (input, expected) => {
+    expect(resolveProjectNames(input)).toEqual(expected);
+  });
+
+  it.each(["", "   ", ".", "..", "/", "////"])(
+    "rejects %j as an invalid project name",
+    (input) => {
+      expect(() => resolveProjectNames(input)).toThrow(InvalidProjectNameError);
+    }
+  );
+});
+
 describe("initCommand", () => {
   let tmpParent: string;
   let origCwd: string;
   let exitSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     promptsMock.mockReset();
@@ -48,6 +77,7 @@ describe("initCommand", () => {
       }) as never);
     vi.spyOn(console, "log").mockImplementation(() => undefined);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -59,9 +89,9 @@ describe("initCommand", () => {
   });
 
   it("happy path: scaffolds a project from the canonical template", async () => {
-    await initCommand("my-test-project");
+    await initCommand("my_test_project");
 
-    const target = join(tmpParent, "my-test-project");
+    const target = join(tmpParent, "my_test_project");
     expect(existsSync(target)).toBe(true);
     // Canonical files at the project root.
     expect(existsSync(join(target, "package.json"))).toBe(true);
@@ -78,32 +108,37 @@ describe("initCommand", () => {
     // Excluded template-development directory.
     expect(existsSync(join(target, "types"))).toBe(false);
     expect(existsSync(join(target, ".vscode"))).toBe(false);
+    // Move.toml gets a valid Move identifier.
+    const moveToml = readFileSync(join(target, "move", "Move.toml"), "utf-8");
+    expect(moveToml).toContain('name = "my_test_project"');
+    expect(moveToml).not.toContain("{{movePackageName}}");
+    expect(moveToml).not.toContain("{{projectName}}");
   });
 
   it("substitutes {{projectName}} placeholders inside template files", async () => {
-    await initCommand("substituted-project");
+    await initCommand("substituted_project");
 
     const pkg = readFileSync(
-      join(tmpParent, "substituted-project", "package.json"),
+      join(tmpParent, "substituted_project", "package.json"),
       "utf-8"
     );
-    expect(pkg).toContain("substituted-project");
+    expect(pkg).toContain("substituted_project");
     expect(pkg).not.toContain("{{projectName}}");
 
     const readme = readFileSync(
-      join(tmpParent, "substituted-project", "README.md"),
+      join(tmpParent, "substituted_project", "README.md"),
       "utf-8"
     );
-    expect(readme).toContain("substituted-project");
+    expect(readme).toContain("substituted_project");
   });
 
   it("prompts for project name when none is provided", async () => {
-    promptsMock.mockResolvedValueOnce({ projectName: "from-prompt" });
+    promptsMock.mockResolvedValueOnce({ projectName: "from_prompt" });
 
     await initCommand();
 
     expect(promptsMock).toHaveBeenCalledTimes(1);
-    expect(existsSync(join(tmpParent, "from-prompt"))).toBe(true);
+    expect(existsSync(join(tmpParent, "from_prompt"))).toBe(true);
   });
 
   it("exits 0 when the user Ctrl+Cs the prompt (no project created)", async () => {
@@ -116,10 +151,60 @@ describe("initCommand", () => {
   it("exits 1 when the template copy step hits an unwriteable target", async () => {
     // Plant a directory where the command will try to write package.json
     // as a file — fs.writeFile rejects with EISDIR.
-    const targetName = "blocked-project";
+    const targetName = "blocked_project";
     mkdirSync(join(tmpParent, targetName, "package.json"), { recursive: true });
 
     await expect(initCommand(targetName)).rejects.toThrow("__test_exit_1__");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  it("sanitizes Move.toml for hyphenated names but keeps package.json original", async () => {
+    await initCommand("my-project");
+
+    const target = join(tmpParent, "my-project");
+    expect(existsSync(target)).toBe(true);
+    // package.json keeps the original (npm allows hyphens).
+    const pkg = readFileSync(join(target, "package.json"), "utf-8");
+    expect(pkg).toContain('"my-project"');
+    // Move.toml gets the sanitized identifier.
+    const moveToml = readFileSync(join(target, "move", "Move.toml"), "utf-8");
+    expect(moveToml).toContain('name = "my_project"');
+    expect(moveToml).not.toContain('"my-project"');
+    // Warning was emitted.
+    expect(warnSpy).toHaveBeenCalled();
+    const warningText = warnSpy.mock.calls.flat().join(" ");
+    expect(warningText).toContain("my-project");
+    expect(warningText).toContain("my_project");
+  });
+
+  it("with a path argument, creates the dir at the full path and sanitizes Move.toml", async () => {
+    const nestedPath = join(tmpParent, "nested", "sub-project");
+
+    await initCommand(nestedPath);
+
+    expect(existsSync(nestedPath)).toBe(true);
+    const moveToml = readFileSync(join(nestedPath, "move", "Move.toml"), "utf-8");
+    expect(moveToml).toContain('name = "sub_project"');
+    const pkg = readFileSync(join(nestedPath, "package.json"), "utf-8");
+    expect(pkg).toContain('"sub-project"');
+  });
+
+  it("prefixes Move.toml package name with pkg_ for names that start with a digit", async () => {
+    await initCommand("123abc");
+
+    const moveToml = readFileSync(
+      join(tmpParent, "123abc", "move", "Move.toml"),
+      "utf-8"
+    );
+    expect(moveToml).toContain('name = "pkg_123abc"');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it.each([".", "..", "/", "   "])(
+    "rejects %j as an invalid project name and exits 1",
+    async (input) => {
+      await expect(initCommand(input)).rejects.toThrow("__test_exit_1__");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    }
+  );
 });

--- a/packages/movehat/src/commands/init.ts
+++ b/packages/movehat/src/commands/init.ts
@@ -8,6 +8,60 @@ import { logger, createSpinnerChain, formatCommand } from "../ui/index.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+export class InvalidProjectNameError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidProjectNameError";
+  }
+}
+
+export interface ProjectNames {
+  /** User input as-is (after trim) — used for the filesystem target. */
+  dirName: string;
+  /** Basename of the resolved path — used for package.json + README.md. */
+  npmName: string;
+  /** Valid Move identifier — used for Move.toml. */
+  moveName: string;
+  /** True when moveName had to diverge from npmName to satisfy Move identifier rules. */
+  sanitized: boolean;
+}
+
+/**
+ * Derive filesystem, npm, and Move identifier names from a single user input.
+ *
+ * Move identifiers must match `[a-zA-Z_][a-zA-Z0-9_]*`. npm package names are
+ * looser (hyphens allowed). The filesystem accepts almost anything. Rather
+ * than reject inputs that would compile fine for npm but not for Move, we
+ * sanitize the Move identifier and leave the npm name + dir unchanged.
+ */
+export function resolveProjectNames(input: string): ProjectNames {
+  const trimmed = input.trim();
+  if (
+    trimmed === "" ||
+    trimmed === "." ||
+    trimmed === ".." ||
+    /^\/+$/.test(trimmed)
+  ) {
+    throw new InvalidProjectNameError(
+      `Project name '${input}' must include at least one character besides path separators.`
+    );
+  }
+
+  const dirName = trimmed;
+  const npmName = path.basename(path.resolve(trimmed));
+  let moveName = npmName.replace(/[^a-zA-Z0-9_]/g, "_");
+  if (!/^[a-zA-Z_]/.test(moveName)) {
+    moveName = `pkg_${moveName}`;
+  }
+
+  return {
+    dirName,
+    npmName,
+    moveName,
+    sanitized: moveName !== npmName,
+  };
+}
+
 /**
  * Initialize a new Movehat project with template files
  *
@@ -49,8 +103,25 @@ export default async function initCommand(projectName?: string) {
     projectName = response.projectName;
   }
 
-  const targetDir = projectName!;
-  const projectPath = path.resolve(process.cwd(), targetDir);
+  let names: ProjectNames;
+  try {
+    names = resolveProjectNames(projectName!);
+  } catch (error) {
+    if (error instanceof InvalidProjectNameError) {
+      logger.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  const { dirName, npmName, moveName, sanitized } = names;
+  const projectPath = path.resolve(process.cwd(), dirName);
+
+  if (sanitized) {
+    logger.warning(
+      `'${npmName}' is not a valid Move identifier; using '${moveName}' for move/Move.toml. (package.json keeps '${npmName}'.)`
+    );
+  }
 
   logger.newline();
   logger.info(`Initializing new Movehat project in ${projectPath}...`);
@@ -67,7 +138,7 @@ export default async function initCommand(projectName?: string) {
       await copyFile(
         path.join(templatesDir, "package.json"),
         path.join(projectPath, "package.json"),
-        { projectName: projectName! }
+        { projectName: npmName }
       );
 
       await copyFile(
@@ -98,7 +169,7 @@ export default async function initCommand(projectName?: string) {
       await copyFile(
         path.join(templatesDir, "README.md"),
         path.join(projectPath, "README.md"),
-        { projectName: projectName! }
+        { projectName: npmName }
       );
     });
 
@@ -107,7 +178,7 @@ export default async function initCommand(projectName?: string) {
       await copyDir(
         path.join(templatesDir, "move"),
         path.join(projectPath, "move"),
-        { projectName: projectName! }
+        { projectName: npmName, movePackageName: moveName }
       );
     });
 
@@ -136,7 +207,7 @@ export default async function initCommand(projectName?: string) {
 
     // Next steps
     logger.section('Next steps');
-    logger.item(formatCommand(`cd ${projectName}`), 2);
+    logger.item(formatCommand(`cd ${dirName}`), 2);
     logger.item(formatCommand('cp .env.example .env'), 2);
     logger.plain('     # Edit .env with your credentials');
     logger.item(formatCommand('npm install'), 2);

--- a/packages/movehat/src/templates/move/Move.toml
+++ b/packages/movehat/src/templates/move/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "{{projectName}}"
+name = "{{movePackageName}}"
 version = "1.0.0"
 authors = []
 

--- a/scripts/dogfood-test.sh
+++ b/scripts/dogfood-test.sh
@@ -56,18 +56,16 @@ command -v movehat >/dev/null || fail "movehat not on PATH after global install"
 log "movehat version: $(movehat --version)"
 
 step "4/9 — Scaffold a new project via movehat init"
-# `movehat init <name>` uses the argument as both the directory AND the
-# Move package name. Pass a bare identifier (not a path) so Move.toml
-# gets a valid `name = "dogfood-project"`.
-PROJECT_NAME="$(basename "${PROJECT_DIR}")"
-PROJECT_PARENT="$(dirname "${PROJECT_DIR}")"
+# `movehat init <path>` accepts a full path; the Move package name is
+# auto-derived from the basename and sanitized into a valid Move
+# identifier (closes #195 — previously this path leaked into Move.toml
+# unchanged and broke compile with a cryptic "No such file or directory").
 rm -rf "${PROJECT_DIR}"
-cd "${PROJECT_PARENT}"
-movehat init "${PROJECT_NAME}" 2>&1 | tail -10
+movehat init "${PROJECT_DIR}" 2>&1 | tail -10
 cd "${PROJECT_DIR}"
 test -f move/sources/Counter.move || fail "Scaffold did not produce Counter.move"
 test -f tests/Counter.test.ts || fail "Scaffold did not produce Counter.test.ts"
-log "Project scaffolded at ${PROJECT_DIR} (package name: ${PROJECT_NAME})"
+log "Project scaffolded at ${PROJECT_DIR}"
 
 step "5/9 — Extend Counter with a user-authored reset() function + Move test"
 # Inject `reset()` entry function AND a corresponding #[test] right


### PR DESCRIPTION
## Summary

Closes #195.

\`movehat init <name>\` accepted any string as both the directory path and the Move package name, with no validation. Passing a path (e.g. \`/tmp/my-project\`) or a hyphenated identifier wrote that string verbatim into \`move/Move.toml\`'s \`name\` field, producing an invalid Move identifier and a cryptic compile failure downstream.

Sanitize-and-warn (cargo-style): filesystem directory = user input as-is; the Move package name is auto-derived from the basename and sanitized into a valid identifier; \`package.json\` keeps the original (npm allows hyphens).

## Behavior matrix

| Input | Directory | \`package.json\` name | \`Move.toml\` name | Warning |
|---|---|---|---|---|
| \`my_project\` | \`my_project\` | \`my_project\` | \`my_project\` | — |
| \`my-project\` | \`my-project\` | \`my-project\` | \`my_project\` | yes |
| \`/tmp/my-project\` | \`/tmp/my-project\` | \`my-project\` | \`my_project\` | yes |
| \`123abc\` | \`123abc\` | \`123abc\` | \`pkg_123abc\` | yes |
| \`.\` / \`..\` / \`\` / \`/\` | — | — | — | error (exit 1) |

## Changes

- \`packages/movehat/src/commands/init.ts\` — \`resolveProjectNames\` pure helper + \`InvalidProjectNameError\`. Wired into \`initCommand\`. Dual replacement map passed to \`copyDir(move, ...)\` so the same template position receives different values for \`package.json\` (npm-friendly) vs \`Move.toml\` (strict identifier).
- \`packages/movehat/src/templates/move/Move.toml\` — placeholder renamed \`{{projectName}}\` → \`{{movePackageName}}\`.
- \`packages/movehat/src/commands/__tests__/init.test.ts\` — table-driven unit tests for the helper (8 happy cases + 6 rejection cases) plus integration tests for hyphen, path, leading-digit, and dot/empty inputs.
- \`scripts/dogfood-test.sh\` — removes the \`cd parent; init basename\` workaround introduced in PR #194. \`init\` now handles paths natively.
- \`CHANGELOG.md\` — Unreleased → Changed entry.

## Verification (Tier 1)

| Check | Result |
|---|---|
| \`pnpm test\` (full unit suite) | 417/417 green (+21 new tests) |
| \`src/commands/init.ts\` coverage | **97.59% lines / 93.1% branches** (gate ≥80% per \`vitest.config.ts:49\`) |
| \`pnpm check:example\` | green (movehat builds; example tsc --noEmit clean) |

## Tier 2 / Tier 3

- Tier 2: \`pnpm test:smoke\` and \`pnpm test:example\` — not run in this PR (no packaging change; \`bin\` shim untouched, no template file additions/removals, only a placeholder rename inside a template). Will be exercised on the next packaging-touching PR or pre-publish.
- Tier 3: N/A — no \`bin/**\` change.

## Risks

- Existing user calling \`movehat init my-project\` non-interactively in CI would see a new warning line where there was none. Warning, not error. CI keeps working. The behavior change in \`Move.toml\` is the bug fix.
- Placeholder rename \`{{projectName}}\` → \`{{movePackageName}}\` in \`Move.toml\` is contained to the template (consumed only by \`init.ts\`); not a public surface.

## Out of scope (deferred)

- npm name lowercasing / reserved-word check (Movement CLI catches at compile, npm at publish).
- \`--package-name\` flag to override auto-derivation. Auto-derivation handles >95% of cases; flag would be useful only for collisions between basename and an existing Move identifier, which is rare and easy to work around by renaming the directory.

## Test plan

- [x] \`pnpm test\` 417/417 green.
- [x] init.ts per-file coverage 97.59% (≥80% gate).
- [x] \`pnpm check:example\` green.
- [x] Dogfood orchestrator workaround removed; CI on this PR will validate the rest.