### PR TITLE
feat: KPI 1 closeout — re-export Harness types + example coverage for upgradeCodeObject / runMoveScript / Harness.createFork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Re-export six Harness option/result types from the root `movehat`
+  entry point (`DeployCodeObjectOptions`, `UpgradeCodeObjectOptions`,
+  `CodeObjectInfo`, `RunViewFunctionOptions`, `RunMoveScriptOptions`,
+  `MoveScriptResult`). Closes
+  [#200](https://github.com/gilbertsahumada/movehat/issues/200) —
+  callers can now type wrappers around Harness methods without
+  deep-importing from internal paths.
+- `examples/counter-example/scripts/upgrade-counter.ts` demonstrates
+  `harness.upgradeCodeObject` against an existing deployment.
+- `examples/counter-example/scripts/run-script.ts` plus
+  `move/scripts/echo.move` demonstrate `harness.runMoveScript` against
+  a local node.
+- `examples/counter-example/scripts/demo-harness-fork.ts` demonstrates
+  the high-level `Harness.createFork` factory (read-only view +
+  write-rejection contract + post-cleanup poisoning via
+  `HarnessDisposedError`). Complements the existing low-level
+  `demo-fork.ts`. Closes
+  [#199](https://github.com/gilbertsahumada/movehat/issues/199).
+- `examples/counter-example/README.md` documenting the npm script
+  surface.
+
 ### Changed
 
 - `movehat init <name>` now sanitizes the project name into a valid Move

--- a/examples/counter-example/README.md
+++ b/examples/counter-example/README.md
@@ -1,0 +1,34 @@
+# counter-example
+
+A working Movehat project scaffolded around a minimal Move module (`hello_blockchain::counter`). Each script in `scripts/` exercises a different Movehat primitive end-to-end against the example contract.
+
+## Scripts
+
+| Script | Demonstrates | Network |
+|---|---|---|
+| `npm run compile` | `movehat compile` — Movement CLI build wrapper. | n/a |
+| `npm test` | `Harness.createLocal` + `runViewFunction` + auto-deploy in tests. | local-node |
+| `npm run deploy` | `Harness.createLive` + `harness.deployCodeObject` against a real network. | live (`MOVEHAT_NETWORK`, default `testnet`) |
+| `npm run upgrade` | `harness.upgradeCodeObject` — re-publishes the package into the existing code object (requires a prior `npm run deploy`). | live |
+| `npm run run-script` | `harness.runMoveScript` — submits an on-the-fly compiled Move script as a one-shot tx. | local-node |
+| `npm run demo-fork` | Low-level `ForkManager` API — manual init/load + direct resource read/write. | fork |
+| `npm run demo-harness-fork` | `Harness.createFork` — high-level factory; read-only `runViewFunction` + write-rejection contract + post-cleanup poisoning via `HarnessDisposedError`. | fork |
+
+## Prerequisites
+
+- Node 20+, npm or pnpm, Movement CLI installed (see [movehat.org docs](https://movehat.org)).
+- For `deploy` / `upgrade`: `.env` with `PRIVATE_KEY` and optional `MOVEHAT_NETWORK`.
+- For `demo-fork` / `demo-harness-fork`: optional `MOVEMENT_API_KEY` to avoid public-endpoint rate limits.
+
+## Layout
+
+```
+counter-example/
+├── move/
+│   ├── Move.toml
+│   ├── sources/        # Move modules (Counter, Greeting, ...)
+│   └── scripts/        # One-shot Move scripts (echo.move)
+├── scripts/            # TypeScript orchestration scripts
+├── tests/              # Mocha test suite (Harness.createLocal + auto-deploy)
+└── movehat.config.ts   # Network + accounts config consumed by Movehat
+```

--- a/examples/counter-example/move/scripts/echo.move
+++ b/examples/counter-example/move/scripts/echo.move
@@ -1,0 +1,11 @@
+script {
+    // Minimal demonstration of `harness.runMoveScript`. Move scripts are
+    // one-shot transactions that ship compiled bytecode inline rather
+    // than installing a module on-chain. The CLI takes the .move source,
+    // compiles it on the fly, and submits the resulting transaction.
+    //
+    // This script is intentionally inert (no module imports, no state
+    // mutation) so the example doesn't depend on prior deployments. The
+    // u64 argument exercises the typed-arg path of `runMoveScript`.
+    fun echo(_account: signer, _value: u64) {}
+}

--- a/examples/counter-example/package.json
+++ b/examples/counter-example/package.json
@@ -7,6 +7,10 @@
     "test": "mocha",
     "test:watch": "mocha --watch",
     "deploy": "movehat run scripts/deploy-counter.ts",
+    "upgrade": "movehat run scripts/upgrade-counter.ts",
+    "run-script": "movehat run scripts/run-script.ts",
+    "demo-fork": "movehat run scripts/demo-fork.ts",
+    "demo-harness-fork": "movehat run scripts/demo-harness-fork.ts",
     "compile": "movehat compile"
   },
   "dependencies": {

--- a/examples/counter-example/scripts/demo-harness-fork.ts
+++ b/examples/counter-example/scripts/demo-harness-fork.ts
@@ -1,0 +1,92 @@
+import { Harness, HarnessDisposedError } from "movehat";
+
+/**
+ * Canonical example of `Harness.createFork` — the higher-level factory
+ * that wraps `ForkManager` lifecycle (init / load / cleanup) behind
+ * the same Harness surface used for local and live mode.
+ *
+ * What this demonstrates:
+ *
+ * 1. `createFork(network, apiKey?)` snapshots remote state and returns
+ *    a read-only Harness pointed at the local fork RPC.
+ * 2. `runViewFunction` works against the fork exactly as it does on
+ *    live mode — same API, no replay-attack risk.
+ * 3. Write methods (`deployCodeObject`, `upgradeCodeObject`,
+ *    `runMoveScript`) throw synchronously on a fork Harness, with an
+ *    error message pointing at `createLocal` / `createLive`.
+ * 4. After `cleanup()`, the Proxy/Poisoning pattern rejects any
+ *    further method call with `HarnessDisposedError`.
+ *
+ * Compare with `demo-fork.ts`, which exercises the lower-level
+ * `ForkManager` API directly. Both are valid; the Harness path is the
+ * recommended entrypoint for code that wants the same shape across
+ * local / fork / live.
+ *
+ * Run: `npm run demo-harness-fork` (no PRIVATE_KEY required — forks
+ * are read-only and don't need a signer).
+ */
+
+const COUNTER_ADDRESS =
+  "0x662a2aa90fdf2b8e400640a49fc922b713fe4baaec8c37b088ecef315561e4d9";
+
+async function main() {
+  console.log("Creating Harness against a testnet fork (read-only)...\n");
+
+  const apiKey = process.env.MOVEMENT_API_KEY;
+  const harness = await Harness.createFork("testnet", apiKey);
+
+  try {
+    console.log(`   Mode:    ${harness.mode}`);
+    console.log(`   Network: ${harness.runtime.network.name}`);
+    console.log(`   RPC:     ${harness.runtime.network.rpc}\n`);
+
+    console.log("Querying the on-fork Counter state with runViewFunction...");
+    const [value] = await harness.runViewFunction({
+      function: `${COUNTER_ADDRESS}::counter::get`,
+      functionArguments: [COUNTER_ADDRESS],
+    });
+    console.log(`   ${COUNTER_ADDRESS.slice(0, 12)}...::counter::get -> ${value}\n`);
+
+    console.log("Confirming the write-rejection contract...");
+    try {
+      await harness.deployCodeObject({
+        moduleName: "counter",
+        addressName: "hello_blockchain",
+      });
+      console.error("   FAIL: deployCodeObject should have thrown");
+      process.exit(1);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.log(`   deployCodeObject rejected as expected: ${msg.split(";")[0]}\n`);
+    }
+
+    console.log("Cleaning up...");
+    await harness.cleanup();
+
+    console.log("Confirming post-cleanup poisoning...");
+    try {
+      await harness.runViewFunction({
+        function: `${COUNTER_ADDRESS}::counter::get`,
+        functionArguments: [COUNTER_ADDRESS],
+      });
+      console.error("   FAIL: post-cleanup call should have thrown");
+      process.exit(1);
+    } catch (error) {
+      if (error instanceof HarnessDisposedError) {
+        console.log(`   Post-cleanup call rejected with HarnessDisposedError`);
+      } else {
+        throw error;
+      }
+    }
+
+    console.log("\nFork harness demo complete.");
+  } catch (error) {
+    await harness.cleanup().catch(() => undefined);
+    throw error;
+  }
+}
+
+main().catch((error) => {
+  console.error("Fork demo failed:", error?.message || error);
+  process.exit(1);
+});

--- a/examples/counter-example/scripts/run-script.ts
+++ b/examples/counter-example/scripts/run-script.ts
@@ -1,0 +1,48 @@
+import { Harness } from "movehat";
+
+/**
+ * Canonical example of `harness.runMoveScript`. Move scripts are
+ * one-shot transactions that bundle compiled bytecode in the
+ * transaction itself — useful for orchestrating multi-step state
+ * changes that don't justify a new module deployment.
+ *
+ * This example targets the inert `move/scripts/echo.move` script and
+ * passes a typed `u64` argument. The CLI compiles the `.move` source
+ * on the fly; no prior `movehat compile` step is required.
+ *
+ * `runMoveScript` is unavailable on fork-mode harnesses (forks are
+ * read-only). Use `createLocal` for self-contained demos or
+ * `createLive` for production submissions.
+ *
+ * Run: `npm run run-script`.
+ */
+async function main() {
+  console.log("Running echo.move script on a local Movement node...\n");
+
+  const harness = await Harness.createLocal();
+
+  try {
+    console.log(`   Signer: ${harness.runtime.account.accountAddress.toString()}`);
+
+    const result = await harness.runMoveScript({
+      scriptPath: "./move/scripts/echo.move",
+      args: ["u64:42"],
+    });
+
+    console.log(`Script executed.`);
+    console.log(`   tx:      ${result.txHash}`);
+    if (result.success !== undefined) {
+      console.log(`   success: ${result.success}`);
+    }
+    if (result.vmStatus) {
+      console.log(`   status:  ${result.vmStatus}`);
+    }
+  } finally {
+    await harness.cleanup();
+  }
+}
+
+main().catch((error) => {
+  console.error("Script failed:", error?.message || error);
+  process.exit(1);
+});

--- a/examples/counter-example/scripts/upgrade-counter.ts
+++ b/examples/counter-example/scripts/upgrade-counter.ts
@@ -1,0 +1,58 @@
+import { Harness } from "movehat";
+
+/**
+ * Canonical example of `harness.upgradeCodeObject` — re-publishes the
+ * compiled Move package into an existing code object on-chain.
+ *
+ * Prerequisite: a prior run of `scripts/deploy-counter.ts` against the
+ * same network. That run writes `deployments/{network}/counter.json`
+ * with the object address; this script reads it back to derive the
+ * `objectAddress` argument.
+ *
+ * The `addressName: "hello_blockchain"` mirrors `deploy-counter.ts` —
+ * Move.toml's named address slot differs from the on-chain module id,
+ * so the upgrade has to bind the same way the original deploy did.
+ *
+ * Run: `npm run upgrade` (after a successful `npm run deploy`).
+ */
+async function main() {
+  console.log("Upgrading Counter contract...\n");
+
+  const network = process.env.MOVEHAT_NETWORK ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    const objectAddress = harness.runtime.getDeploymentAddress("counter");
+    if (!objectAddress) {
+      throw new Error(
+        `No prior deployment found for "counter" on ${network}. ` +
+        `Run \`npm run deploy\` first.`
+      );
+    }
+
+    console.log(`   Network:  ${harness.runtime.network.name}`);
+    console.log(`   Object:   ${objectAddress}`);
+    console.log(`   Deployer: ${harness.runtime.account.accountAddress.toString()}\n`);
+
+    const upgrade = await harness.upgradeCodeObject({
+      moduleName: "counter",
+      addressName: "hello_blockchain",
+      objectAddress,
+    });
+
+    console.log(`Upgrade tx: ${upgrade.txHash ?? "(unknown)"}`);
+    console.log(`Module still reachable at: ${upgrade.address}::counter`);
+
+    const [value] = await harness.runViewFunction({
+      function: `${upgrade.address}::counter::get`,
+      functionArguments: [harness.runtime.account.accountAddress.toString()],
+    });
+    console.log(`Counter state preserved through upgrade. value=${value}`);
+  } finally {
+    await harness.cleanup();
+  }
+}
+
+main().catch((error) => {
+  console.error("Upgrade failed:", error?.message || error);
+  process.exit(1);
+});

--- a/packages/movehat/src/__tests__/exports.test.ts
+++ b/packages/movehat/src/__tests__/exports.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import * as publicSurface from "../index.js";
+
+/**
+ * Locks the public export surface of `movehat`. Adding a new symbol
+ * is a deliberate API change; removing one is a breaking change.
+ * Update this list (and the CHANGELOG) when the surface evolves.
+ */
+const EXPECTED_RUNTIME_EXPORTS = [
+  "Harness",
+  "HarnessDisposedError",
+  "ForkManager",
+  "MovementApiClient",
+  "ForkStorage",
+  "ForkServer",
+  "ModuleAlreadyDeployedError",
+  "PostPublishError",
+  "initRuntime",
+] as const;
+
+describe("public export surface (movehat root)", () => {
+  it.each(EXPECTED_RUNTIME_EXPORTS)("exports %s as a runtime value", (name) => {
+    expect(publicSurface[name as keyof typeof publicSurface]).toBeDefined();
+  });
+
+  // Type-only exports cannot be probed at runtime; the assertion is
+  // that the module imports successfully (failing types-only export
+  // would surface as a TS error in `pnpm check:example`).
+  it("imports without errors", () => {
+    expect(typeof publicSurface).toBe("object");
+  });
+});

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -20,3 +20,11 @@ export { ModuleAlreadyDeployedError, PostPublishError } from "./errors.js";
 
 export { Harness, HarnessDisposedError } from "./harness/index.js";
 export type { HarnessMode } from "./harness/index.js";
+export type {
+  DeployCodeObjectOptions,
+  UpgradeCodeObjectOptions,
+  CodeObjectInfo,
+  RunViewFunctionOptions,
+  RunMoveScriptOptions,
+  MoveScriptResult,
+} from "./types/harness.js";


### PR DESCRIPTION
## Summary

Closes the last two open items from the GRANT KPI 1 audit (2026-05-15):

- **#200** — type re-exports so callers can typecheck Harness wrappers without deep-importing.
- **#199** — example scripts demonstrating \`upgradeCodeObject\`, \`runMoveScript\`, and the high-level \`Harness.createFork\` factory.

After this PR merges, the KPI 1 audit matrix is 8/8 on every Forklift parity axis (impl, export, docs, example).

## Audit deltas closed

| Audit gap (2026-05-15) | Resolution |
|---|---|
| 6/8 example coverage | Now 8/8 — three new scripts under \`examples/counter-example/scripts/\` |
| Option/result types not on public surface | 6 new type re-exports from \`packages/movehat/src/index.ts\` |
| Public surface drift risk | New \`exports.test.ts\` locks the runtime export list |

## Changes

### packages/movehat

- \`src/index.ts\` — re-export \`DeployCodeObjectOptions\`, \`UpgradeCodeObjectOptions\`, \`CodeObjectInfo\`, \`RunViewFunctionOptions\`, \`RunMoveScriptOptions\`, \`MoveScriptResult\`.
- \`src/__tests__/exports.test.ts\` (new) — locks the public runtime export surface (9 symbols today). Adding/removing a symbol is now a deliberate test update.

### examples/counter-example

- \`scripts/upgrade-counter.ts\` (new) — \`harness.upgradeCodeObject\` against an existing deployment loaded via \`runtime.getDeploymentAddress\`.
- \`scripts/run-script.ts\` + \`move/scripts/echo.move\` (new) — \`harness.runMoveScript\` against a minimal inert Move script with a typed u64 arg.
- \`scripts/demo-harness-fork.ts\` (new) — \`Harness.createFork\` + \`runViewFunction\` + write-rejection contract + post-cleanup \`HarnessDisposedError\` poisoning. Complements (does not replace) the existing low-level \`demo-fork.ts\`.
- \`package.json\` — npm scripts: \`upgrade\`, \`run-script\`, \`demo-harness-fork\`.
- \`README.md\` (new) — script-by-script mapping to the Movehat primitive each one exercises plus the network mode required.

### CHANGELOG.md

Two new bullets under \`Unreleased → Added\`.

## Verification (Tier 1)

| Check | Result |
|---|---|
| \`pnpm test\` (full unit suite) | 427/427 green (+10 new exports tests) |
| \`pnpm check:example\` | green (movehat builds; counter-example tsc --noEmit clean against the new re-exports) |

## Tier 2 / Tier 3

- **Tier 2 (\`pnpm test:smoke\` / \`pnpm test:example\`)**: not run on this PR.
  - \`test:smoke\` would re-validate the global-install path; no packaging change touches that gate (no \`bin/\` shim change, no template file addition or removal — only the public \`index.ts\` and the example workspace).
  - \`test:example\` would replay the mocha suite under \`examples/counter-example/tests/\`; the existing test file (\`tests/Counter.test.ts\`) was not modified, only sibling \`scripts/\` and a sibling \`README.md\` were added.
- **Tier 3 (\`pnpm test:e2e\`)**: N/A — no packaging or CLI behavior change.

The new example scripts themselves are runnable but not part of any automated gate yet (CI integration for the example scripts is a future-milestone item, tracked in #192 / dogfood Tier C). The next \`develop → main\` batch PR will pick this up alongside the dogfood test.

## Risks

| Risk | Likelihood | Mitigation |
|---|---|---|
| New \`exports.test.ts\` becomes a maintenance burden — every legitimate API addition needs a test update | Low | The list is short (9 symbols today); the cost is exactly what you want — accidental drift surfaces as a CI fail rather than as a silent missing export at runtime. |
| \`run-script.ts\` example requires Movement CLI installed (spawns local-node) | Low | Documented in the example's README. Same prerequisite as \`tests/\` and \`deploy-counter.ts\`. |
| \`echo.move\` script noise — adds a near-empty file under \`move/scripts/\` | Negligible | Inline comment explains its purpose. Movement CLI handles \`scripts/\` directory alongside \`sources/\` natively. |

## Out of scope

- KPI 2 closeout items (CODE_OF_CONDUCT, pre-commit doc policy) — tracked in #201 and #202. Not blocking KPI 1.
- CI integration of the new example scripts — depends on the dogfood test maturity / a writable-fork story (issue #192).

## Test plan

- [x] \`pnpm test\` 427/427 green.
- [x] \`exports.test.ts\` locks 9 runtime symbols.
- [x] \`pnpm check:example\` green with new type re-exports.
- [x] Three new scripts compile under \`pnpm check:example\` (tsc --noEmit catches type errors against the workspace-symlink \`movehat\`).
- [ ] Manual runtime smoke (deferred to post-merge — requires live PRIVATE_KEY for \`upgrade\` and a local Movement node for \`run-script\`).