### PR TITLE
develop → main: KPI 1 closeout (init sanitization + Forklift parity examples + type exports)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Re-export six Harness option/result types from the root `movehat`
+  entry point (`DeployCodeObjectOptions`, `UpgradeCodeObjectOptions`,
+  `CodeObjectInfo`, `RunViewFunctionOptions`, `RunMoveScriptOptions`,
+  `MoveScriptResult`). Closes
+  [#200](https://github.com/gilbertsahumada/movehat/issues/200) —
+  callers can now type wrappers around Harness methods without
+  deep-importing from internal paths.
+- `examples/counter-example/scripts/upgrade-counter.ts` demonstrates
+  `harness.upgradeCodeObject` against an existing deployment.
+- `examples/counter-example/scripts/run-script.ts` plus
+  `move/scripts/echo.move` demonstrate `harness.runMoveScript` against
+  a local node.
+- `examples/counter-example/scripts/demo-harness-fork.ts` demonstrates
+  the high-level `Harness.createFork` factory (read-only view +
+  write-rejection contract + post-cleanup poisoning via
+  `HarnessDisposedError`). Complements the existing low-level
+  `demo-fork.ts`. Closes
+  [#199](https://github.com/gilbertsahumada/movehat/issues/199).
+- `examples/counter-example/README.md` documenting the npm script
+  surface.
+
 ### Changed
 
 - `movehat init <name>` now sanitizes the project name into a valid Move

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `movehat init <name>` now sanitizes the project name into a valid Move
+  identifier when writing `move/Move.toml`, preserving the original name for
+  `package.json` and the directory. Invalid characters (hyphens, slashes,
+  dots) are replaced with underscores; names starting with a digit are
+  prefixed with `pkg_`. A warning is printed when sanitization changes the
+  name. Names that resolve to nothing usable (`.`, `..`, empty, only
+  separators) are now rejected with a clear error. Previously, passing a
+  path like `/tmp/my-project` produced a malformed `Move.toml` and a cryptic
+  `"No such file or directory"` compile failure. Closes
+  [#195](https://github.com/gilbertsahumada/movehat/issues/195).
+
 ### Deprecated
 
 ### Removed

--- a/examples/counter-example/README.md
+++ b/examples/counter-example/README.md
@@ -1,0 +1,34 @@
+# counter-example
+
+A working Movehat project scaffolded around a minimal Move module (`hello_blockchain::counter`). Each script in `scripts/` exercises a different Movehat primitive end-to-end against the example contract.
+
+## Scripts
+
+| Script | Demonstrates | Network |
+|---|---|---|
+| `npm run compile` | `movehat compile` — Movement CLI build wrapper. | n/a |
+| `npm test` | `Harness.createLocal` + `runViewFunction` + auto-deploy in tests. | local-node |
+| `npm run deploy` | `Harness.createLive` + `harness.deployCodeObject` against a real network. | live (`MOVEHAT_NETWORK`, default `testnet`) |
+| `npm run upgrade` | `harness.upgradeCodeObject` — re-publishes the package into the existing code object (requires a prior `npm run deploy`). | live |
+| `npm run run-script` | `harness.runMoveScript` — submits an on-the-fly compiled Move script as a one-shot tx. | local-node |
+| `npm run demo-fork` | Low-level `ForkManager` API — manual init/load + direct resource read/write. | fork |
+| `npm run demo-harness-fork` | `Harness.createFork` — high-level factory; read-only `runViewFunction` + write-rejection contract + post-cleanup poisoning via `HarnessDisposedError`. | fork |
+
+## Prerequisites
+
+- Node 20+, npm or pnpm, Movement CLI installed (see [movehat.org docs](https://movehat.org)).
+- For `deploy` / `upgrade`: `.env` with `PRIVATE_KEY` and optional `MOVEHAT_NETWORK`.
+- For `demo-fork` / `demo-harness-fork`: optional `MOVEMENT_API_KEY` to avoid public-endpoint rate limits.
+
+## Layout
+
+```
+counter-example/
+├── move/
+│   ├── Move.toml
+│   ├── sources/        # Move modules (Counter, Greeting, ...)
+│   └── scripts/        # One-shot Move scripts (echo.move)
+├── scripts/            # TypeScript orchestration scripts
+├── tests/              # Mocha test suite (Harness.createLocal + auto-deploy)
+└── movehat.config.ts   # Network + accounts config consumed by Movehat
+```

--- a/examples/counter-example/move/scripts/echo.move
+++ b/examples/counter-example/move/scripts/echo.move
@@ -1,0 +1,11 @@
+script {
+    // Minimal demonstration of `harness.runMoveScript`. Move scripts are
+    // one-shot transactions that ship compiled bytecode inline rather
+    // than installing a module on-chain. The CLI takes the .move source,
+    // compiles it on the fly, and submits the resulting transaction.
+    //
+    // This script is intentionally inert (no module imports, no state
+    // mutation) so the example doesn't depend on prior deployments. The
+    // u64 argument exercises the typed-arg path of `runMoveScript`.
+    fun echo(_account: signer, _value: u64) {}
+}

--- a/examples/counter-example/package.json
+++ b/examples/counter-example/package.json
@@ -7,6 +7,10 @@
     "test": "mocha",
     "test:watch": "mocha --watch",
     "deploy": "movehat run scripts/deploy-counter.ts",
+    "upgrade": "movehat run scripts/upgrade-counter.ts",
+    "run-script": "movehat run scripts/run-script.ts",
+    "demo-fork": "movehat run scripts/demo-fork.ts",
+    "demo-harness-fork": "movehat run scripts/demo-harness-fork.ts",
     "compile": "movehat compile"
   },
   "dependencies": {

--- a/examples/counter-example/scripts/demo-harness-fork.ts
+++ b/examples/counter-example/scripts/demo-harness-fork.ts
@@ -1,0 +1,92 @@
+import { Harness, HarnessDisposedError } from "movehat";
+
+/**
+ * Canonical example of `Harness.createFork` — the higher-level factory
+ * that wraps `ForkManager` lifecycle (init / load / cleanup) behind
+ * the same Harness surface used for local and live mode.
+ *
+ * What this demonstrates:
+ *
+ * 1. `createFork(network, apiKey?)` snapshots remote state and returns
+ *    a read-only Harness pointed at the local fork RPC.
+ * 2. `runViewFunction` works against the fork exactly as it does on
+ *    live mode — same API, no replay-attack risk.
+ * 3. Write methods (`deployCodeObject`, `upgradeCodeObject`,
+ *    `runMoveScript`) throw synchronously on a fork Harness, with an
+ *    error message pointing at `createLocal` / `createLive`.
+ * 4. After `cleanup()`, the Proxy/Poisoning pattern rejects any
+ *    further method call with `HarnessDisposedError`.
+ *
+ * Compare with `demo-fork.ts`, which exercises the lower-level
+ * `ForkManager` API directly. Both are valid; the Harness path is the
+ * recommended entrypoint for code that wants the same shape across
+ * local / fork / live.
+ *
+ * Run: `npm run demo-harness-fork` (no PRIVATE_KEY required — forks
+ * are read-only and don't need a signer).
+ */
+
+const COUNTER_ADDRESS =
+  "0x662a2aa90fdf2b8e400640a49fc922b713fe4baaec8c37b088ecef315561e4d9";
+
+async function main() {
+  console.log("Creating Harness against a testnet fork (read-only)...\n");
+
+  const apiKey = process.env.MOVEMENT_API_KEY;
+  const harness = await Harness.createFork("testnet", apiKey);
+
+  try {
+    console.log(`   Mode:    ${harness.mode}`);
+    console.log(`   Network: ${harness.runtime.network.name}`);
+    console.log(`   RPC:     ${harness.runtime.network.rpc}\n`);
+
+    console.log("Querying the on-fork Counter state with runViewFunction...");
+    const [value] = await harness.runViewFunction({
+      function: `${COUNTER_ADDRESS}::counter::get`,
+      functionArguments: [COUNTER_ADDRESS],
+    });
+    console.log(`   ${COUNTER_ADDRESS.slice(0, 12)}...::counter::get -> ${value}\n`);
+
+    console.log("Confirming the write-rejection contract...");
+    try {
+      await harness.deployCodeObject({
+        moduleName: "counter",
+        addressName: "hello_blockchain",
+      });
+      console.error("   FAIL: deployCodeObject should have thrown");
+      process.exit(1);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.log(`   deployCodeObject rejected as expected: ${msg.split(";")[0]}\n`);
+    }
+
+    console.log("Cleaning up...");
+    await harness.cleanup();
+
+    console.log("Confirming post-cleanup poisoning...");
+    try {
+      await harness.runViewFunction({
+        function: `${COUNTER_ADDRESS}::counter::get`,
+        functionArguments: [COUNTER_ADDRESS],
+      });
+      console.error("   FAIL: post-cleanup call should have thrown");
+      process.exit(1);
+    } catch (error) {
+      if (error instanceof HarnessDisposedError) {
+        console.log(`   Post-cleanup call rejected with HarnessDisposedError`);
+      } else {
+        throw error;
+      }
+    }
+
+    console.log("\nFork harness demo complete.");
+  } catch (error) {
+    await harness.cleanup().catch(() => undefined);
+    throw error;
+  }
+}
+
+main().catch((error) => {
+  console.error("Fork demo failed:", error?.message || error);
+  process.exit(1);
+});

--- a/examples/counter-example/scripts/run-script.ts
+++ b/examples/counter-example/scripts/run-script.ts
@@ -1,0 +1,48 @@
+import { Harness } from "movehat";
+
+/**
+ * Canonical example of `harness.runMoveScript`. Move scripts are
+ * one-shot transactions that bundle compiled bytecode in the
+ * transaction itself — useful for orchestrating multi-step state
+ * changes that don't justify a new module deployment.
+ *
+ * This example targets the inert `move/scripts/echo.move` script and
+ * passes a typed `u64` argument. The CLI compiles the `.move` source
+ * on the fly; no prior `movehat compile` step is required.
+ *
+ * `runMoveScript` is unavailable on fork-mode harnesses (forks are
+ * read-only). Use `createLocal` for self-contained demos or
+ * `createLive` for production submissions.
+ *
+ * Run: `npm run run-script`.
+ */
+async function main() {
+  console.log("Running echo.move script on a local Movement node...\n");
+
+  const harness = await Harness.createLocal();
+
+  try {
+    console.log(`   Signer: ${harness.runtime.account.accountAddress.toString()}`);
+
+    const result = await harness.runMoveScript({
+      scriptPath: "./move/scripts/echo.move",
+      args: ["u64:42"],
+    });
+
+    console.log(`Script executed.`);
+    console.log(`   tx:      ${result.txHash}`);
+    if (result.success !== undefined) {
+      console.log(`   success: ${result.success}`);
+    }
+    if (result.vmStatus) {
+      console.log(`   status:  ${result.vmStatus}`);
+    }
+  } finally {
+    await harness.cleanup();
+  }
+}
+
+main().catch((error) => {
+  console.error("Script failed:", error?.message || error);
+  process.exit(1);
+});

--- a/examples/counter-example/scripts/upgrade-counter.ts
+++ b/examples/counter-example/scripts/upgrade-counter.ts
@@ -1,0 +1,58 @@
+import { Harness } from "movehat";
+
+/**
+ * Canonical example of `harness.upgradeCodeObject` — re-publishes the
+ * compiled Move package into an existing code object on-chain.
+ *
+ * Prerequisite: a prior run of `scripts/deploy-counter.ts` against the
+ * same network. That run writes `deployments/{network}/counter.json`
+ * with the object address; this script reads it back to derive the
+ * `objectAddress` argument.
+ *
+ * The `addressName: "hello_blockchain"` mirrors `deploy-counter.ts` —
+ * Move.toml's named address slot differs from the on-chain module id,
+ * so the upgrade has to bind the same way the original deploy did.
+ *
+ * Run: `npm run upgrade` (after a successful `npm run deploy`).
+ */
+async function main() {
+  console.log("Upgrading Counter contract...\n");
+
+  const network = process.env.MOVEHAT_NETWORK ?? "testnet";
+  const harness = await Harness.createLive(network);
+  try {
+    const objectAddress = harness.runtime.getDeploymentAddress("counter");
+    if (!objectAddress) {
+      throw new Error(
+        `No prior deployment found for "counter" on ${network}. ` +
+        `Run \`npm run deploy\` first.`
+      );
+    }
+
+    console.log(`   Network:  ${harness.runtime.network.name}`);
+    console.log(`   Object:   ${objectAddress}`);
+    console.log(`   Deployer: ${harness.runtime.account.accountAddress.toString()}\n`);
+
+    const upgrade = await harness.upgradeCodeObject({
+      moduleName: "counter",
+      addressName: "hello_blockchain",
+      objectAddress,
+    });
+
+    console.log(`Upgrade tx: ${upgrade.txHash ?? "(unknown)"}`);
+    console.log(`Module still reachable at: ${upgrade.address}::counter`);
+
+    const [value] = await harness.runViewFunction({
+      function: `${upgrade.address}::counter::get`,
+      functionArguments: [harness.runtime.account.accountAddress.toString()],
+    });
+    console.log(`Counter state preserved through upgrade. value=${value}`);
+  } finally {
+    await harness.cleanup();
+  }
+}
+
+main().catch((error) => {
+  console.error("Upgrade failed:", error?.message || error);
+  process.exit(1);
+});

--- a/packages/movehat/src/__tests__/exports.test.ts
+++ b/packages/movehat/src/__tests__/exports.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import * as publicSurface from "../index.js";
+
+/**
+ * Locks the public export surface of `movehat`. Adding a new symbol
+ * is a deliberate API change; removing one is a breaking change.
+ * Update this list (and the CHANGELOG) when the surface evolves.
+ */
+const EXPECTED_RUNTIME_EXPORTS = [
+  "Harness",
+  "HarnessDisposedError",
+  "ForkManager",
+  "MovementApiClient",
+  "ForkStorage",
+  "ForkServer",
+  "ModuleAlreadyDeployedError",
+  "PostPublishError",
+  "initRuntime",
+] as const;
+
+describe("public export surface (movehat root)", () => {
+  it.each(EXPECTED_RUNTIME_EXPORTS)("exports %s as a runtime value", (name) => {
+    expect(publicSurface[name as keyof typeof publicSurface]).toBeDefined();
+  });
+
+  // Type-only exports cannot be probed at runtime; the assertion is
+  // that the module imports successfully (failing types-only export
+  // would surface as a TS error in `pnpm check:example`).
+  it("imports without errors", () => {
+    expect(typeof publicSurface).toBe("object");
+  });
+});

--- a/packages/movehat/src/commands/__tests__/init.test.ts
+++ b/packages/movehat/src/commands/__tests__/init.test.ts
@@ -13,7 +13,8 @@ vi.mock("../../helpers/banner.js", () => ({
   printMovehatBanner: () => undefined,
 }));
 
-const { default: initCommand } = await import("../init.js");
+const initModule = await import("../init.js");
+const { default: initCommand, resolveProjectNames, InvalidProjectNameError } = initModule;
 
 /**
  * Strategy: real tmpdir + real fs ops (matches §6.1's example-as-canonical
@@ -28,10 +29,38 @@ const { default: initCommand } = await import("../init.js");
  * to `src/templates/` cleanly. No bundling step required.
  */
 
+describe("resolveProjectNames", () => {
+  const cases: Array<[
+    string,
+    { dirName: string; npmName: string; moveName: string; sanitized: boolean }
+  ]> = [
+    ["my_project", { dirName: "my_project", npmName: "my_project", moveName: "my_project", sanitized: false }],
+    ["my-project", { dirName: "my-project", npmName: "my-project", moveName: "my_project", sanitized: true }],
+    ["/tmp/my-project", { dirName: "/tmp/my-project", npmName: "my-project", moveName: "my_project", sanitized: true }],
+    ["123abc", { dirName: "123abc", npmName: "123abc", moveName: "pkg_123abc", sanitized: true }],
+    ["_underscore", { dirName: "_underscore", npmName: "_underscore", moveName: "_underscore", sanitized: false }],
+    ["UPPER", { dirName: "UPPER", npmName: "UPPER", moveName: "UPPER", sanitized: false }],
+    ["  spaced  ", { dirName: "spaced", npmName: "spaced", moveName: "spaced", sanitized: false }],
+    ["with spaces", { dirName: "with spaces", npmName: "with spaces", moveName: "with_spaces", sanitized: true }],
+  ];
+
+  it.each(cases)("derives names for %j", (input, expected) => {
+    expect(resolveProjectNames(input)).toEqual(expected);
+  });
+
+  it.each(["", "   ", ".", "..", "/", "////"])(
+    "rejects %j as an invalid project name",
+    (input) => {
+      expect(() => resolveProjectNames(input)).toThrow(InvalidProjectNameError);
+    }
+  );
+});
+
 describe("initCommand", () => {
   let tmpParent: string;
   let origCwd: string;
   let exitSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     promptsMock.mockReset();
@@ -48,6 +77,7 @@ describe("initCommand", () => {
       }) as never);
     vi.spyOn(console, "log").mockImplementation(() => undefined);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -59,9 +89,9 @@ describe("initCommand", () => {
   });
 
   it("happy path: scaffolds a project from the canonical template", async () => {
-    await initCommand("my-test-project");
+    await initCommand("my_test_project");
 
-    const target = join(tmpParent, "my-test-project");
+    const target = join(tmpParent, "my_test_project");
     expect(existsSync(target)).toBe(true);
     // Canonical files at the project root.
     expect(existsSync(join(target, "package.json"))).toBe(true);
@@ -78,32 +108,37 @@ describe("initCommand", () => {
     // Excluded template-development directory.
     expect(existsSync(join(target, "types"))).toBe(false);
     expect(existsSync(join(target, ".vscode"))).toBe(false);
+    // Move.toml gets a valid Move identifier.
+    const moveToml = readFileSync(join(target, "move", "Move.toml"), "utf-8");
+    expect(moveToml).toContain('name = "my_test_project"');
+    expect(moveToml).not.toContain("{{movePackageName}}");
+    expect(moveToml).not.toContain("{{projectName}}");
   });
 
   it("substitutes {{projectName}} placeholders inside template files", async () => {
-    await initCommand("substituted-project");
+    await initCommand("substituted_project");
 
     const pkg = readFileSync(
-      join(tmpParent, "substituted-project", "package.json"),
+      join(tmpParent, "substituted_project", "package.json"),
       "utf-8"
     );
-    expect(pkg).toContain("substituted-project");
+    expect(pkg).toContain("substituted_project");
     expect(pkg).not.toContain("{{projectName}}");
 
     const readme = readFileSync(
-      join(tmpParent, "substituted-project", "README.md"),
+      join(tmpParent, "substituted_project", "README.md"),
       "utf-8"
     );
-    expect(readme).toContain("substituted-project");
+    expect(readme).toContain("substituted_project");
   });
 
   it("prompts for project name when none is provided", async () => {
-    promptsMock.mockResolvedValueOnce({ projectName: "from-prompt" });
+    promptsMock.mockResolvedValueOnce({ projectName: "from_prompt" });
 
     await initCommand();
 
     expect(promptsMock).toHaveBeenCalledTimes(1);
-    expect(existsSync(join(tmpParent, "from-prompt"))).toBe(true);
+    expect(existsSync(join(tmpParent, "from_prompt"))).toBe(true);
   });
 
   it("exits 0 when the user Ctrl+Cs the prompt (no project created)", async () => {
@@ -116,10 +151,60 @@ describe("initCommand", () => {
   it("exits 1 when the template copy step hits an unwriteable target", async () => {
     // Plant a directory where the command will try to write package.json
     // as a file — fs.writeFile rejects with EISDIR.
-    const targetName = "blocked-project";
+    const targetName = "blocked_project";
     mkdirSync(join(tmpParent, targetName, "package.json"), { recursive: true });
 
     await expect(initCommand(targetName)).rejects.toThrow("__test_exit_1__");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  it("sanitizes Move.toml for hyphenated names but keeps package.json original", async () => {
+    await initCommand("my-project");
+
+    const target = join(tmpParent, "my-project");
+    expect(existsSync(target)).toBe(true);
+    // package.json keeps the original (npm allows hyphens).
+    const pkg = readFileSync(join(target, "package.json"), "utf-8");
+    expect(pkg).toContain('"my-project"');
+    // Move.toml gets the sanitized identifier.
+    const moveToml = readFileSync(join(target, "move", "Move.toml"), "utf-8");
+    expect(moveToml).toContain('name = "my_project"');
+    expect(moveToml).not.toContain('"my-project"');
+    // Warning was emitted.
+    expect(warnSpy).toHaveBeenCalled();
+    const warningText = warnSpy.mock.calls.flat().join(" ");
+    expect(warningText).toContain("my-project");
+    expect(warningText).toContain("my_project");
+  });
+
+  it("with a path argument, creates the dir at the full path and sanitizes Move.toml", async () => {
+    const nestedPath = join(tmpParent, "nested", "sub-project");
+
+    await initCommand(nestedPath);
+
+    expect(existsSync(nestedPath)).toBe(true);
+    const moveToml = readFileSync(join(nestedPath, "move", "Move.toml"), "utf-8");
+    expect(moveToml).toContain('name = "sub_project"');
+    const pkg = readFileSync(join(nestedPath, "package.json"), "utf-8");
+    expect(pkg).toContain('"sub-project"');
+  });
+
+  it("prefixes Move.toml package name with pkg_ for names that start with a digit", async () => {
+    await initCommand("123abc");
+
+    const moveToml = readFileSync(
+      join(tmpParent, "123abc", "move", "Move.toml"),
+      "utf-8"
+    );
+    expect(moveToml).toContain('name = "pkg_123abc"');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it.each([".", "..", "/", "   "])(
+    "rejects %j as an invalid project name and exits 1",
+    async (input) => {
+      await expect(initCommand(input)).rejects.toThrow("__test_exit_1__");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    }
+  );
 });

--- a/packages/movehat/src/commands/init.ts
+++ b/packages/movehat/src/commands/init.ts
@@ -8,6 +8,60 @@ import { logger, createSpinnerChain, formatCommand } from "../ui/index.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+export class InvalidProjectNameError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidProjectNameError";
+  }
+}
+
+export interface ProjectNames {
+  /** User input as-is (after trim) — used for the filesystem target. */
+  dirName: string;
+  /** Basename of the resolved path — used for package.json + README.md. */
+  npmName: string;
+  /** Valid Move identifier — used for Move.toml. */
+  moveName: string;
+  /** True when moveName had to diverge from npmName to satisfy Move identifier rules. */
+  sanitized: boolean;
+}
+
+/**
+ * Derive filesystem, npm, and Move identifier names from a single user input.
+ *
+ * Move identifiers must match `[a-zA-Z_][a-zA-Z0-9_]*`. npm package names are
+ * looser (hyphens allowed). The filesystem accepts almost anything. Rather
+ * than reject inputs that would compile fine for npm but not for Move, we
+ * sanitize the Move identifier and leave the npm name + dir unchanged.
+ */
+export function resolveProjectNames(input: string): ProjectNames {
+  const trimmed = input.trim();
+  if (
+    trimmed === "" ||
+    trimmed === "." ||
+    trimmed === ".." ||
+    /^\/+$/.test(trimmed)
+  ) {
+    throw new InvalidProjectNameError(
+      `Project name '${input}' must include at least one character besides path separators.`
+    );
+  }
+
+  const dirName = trimmed;
+  const npmName = path.basename(path.resolve(trimmed));
+  let moveName = npmName.replace(/[^a-zA-Z0-9_]/g, "_");
+  if (!/^[a-zA-Z_]/.test(moveName)) {
+    moveName = `pkg_${moveName}`;
+  }
+
+  return {
+    dirName,
+    npmName,
+    moveName,
+    sanitized: moveName !== npmName,
+  };
+}
+
 /**
  * Initialize a new Movehat project with template files
  *
@@ -49,8 +103,25 @@ export default async function initCommand(projectName?: string) {
     projectName = response.projectName;
   }
 
-  const targetDir = projectName!;
-  const projectPath = path.resolve(process.cwd(), targetDir);
+  let names: ProjectNames;
+  try {
+    names = resolveProjectNames(projectName!);
+  } catch (error) {
+    if (error instanceof InvalidProjectNameError) {
+      logger.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  const { dirName, npmName, moveName, sanitized } = names;
+  const projectPath = path.resolve(process.cwd(), dirName);
+
+  if (sanitized) {
+    logger.warning(
+      `'${npmName}' is not a valid Move identifier; using '${moveName}' for move/Move.toml. (package.json keeps '${npmName}'.)`
+    );
+  }
 
   logger.newline();
   logger.info(`Initializing new Movehat project in ${projectPath}...`);
@@ -67,7 +138,7 @@ export default async function initCommand(projectName?: string) {
       await copyFile(
         path.join(templatesDir, "package.json"),
         path.join(projectPath, "package.json"),
-        { projectName: projectName! }
+        { projectName: npmName }
       );
 
       await copyFile(
@@ -98,7 +169,7 @@ export default async function initCommand(projectName?: string) {
       await copyFile(
         path.join(templatesDir, "README.md"),
         path.join(projectPath, "README.md"),
-        { projectName: projectName! }
+        { projectName: npmName }
       );
     });
 
@@ -107,7 +178,7 @@ export default async function initCommand(projectName?: string) {
       await copyDir(
         path.join(templatesDir, "move"),
         path.join(projectPath, "move"),
-        { projectName: projectName! }
+        { projectName: npmName, movePackageName: moveName }
       );
     });
 
@@ -136,7 +207,7 @@ export default async function initCommand(projectName?: string) {
 
     // Next steps
     logger.section('Next steps');
-    logger.item(formatCommand(`cd ${projectName}`), 2);
+    logger.item(formatCommand(`cd ${dirName}`), 2);
     logger.item(formatCommand('cp .env.example .env'), 2);
     logger.plain('     # Edit .env with your credentials');
     logger.item(formatCommand('npm install'), 2);

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -20,3 +20,11 @@ export { ModuleAlreadyDeployedError, PostPublishError } from "./errors.js";
 
 export { Harness, HarnessDisposedError } from "./harness/index.js";
 export type { HarnessMode } from "./harness/index.js";
+export type {
+  DeployCodeObjectOptions,
+  UpgradeCodeObjectOptions,
+  CodeObjectInfo,
+  RunViewFunctionOptions,
+  RunMoveScriptOptions,
+  MoveScriptResult,
+} from "./types/harness.js";

--- a/packages/movehat/src/templates/move/Move.toml
+++ b/packages/movehat/src/templates/move/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "{{projectName}}"
+name = "{{movePackageName}}"
 version = "1.0.0"
 authors = []
 

--- a/scripts/dogfood-test.sh
+++ b/scripts/dogfood-test.sh
@@ -56,18 +56,16 @@ command -v movehat >/dev/null || fail "movehat not on PATH after global install"
 log "movehat version: $(movehat --version)"
 
 step "4/9 — Scaffold a new project via movehat init"
-# `movehat init <name>` uses the argument as both the directory AND the
-# Move package name. Pass a bare identifier (not a path) so Move.toml
-# gets a valid `name = "dogfood-project"`.
-PROJECT_NAME="$(basename "${PROJECT_DIR}")"
-PROJECT_PARENT="$(dirname "${PROJECT_DIR}")"
+# `movehat init <path>` accepts a full path; the Move package name is
+# auto-derived from the basename and sanitized into a valid Move
+# identifier (closes #195 — previously this path leaked into Move.toml
+# unchanged and broke compile with a cryptic "No such file or directory").
 rm -rf "${PROJECT_DIR}"
-cd "${PROJECT_PARENT}"
-movehat init "${PROJECT_NAME}" 2>&1 | tail -10
+movehat init "${PROJECT_DIR}" 2>&1 | tail -10
 cd "${PROJECT_DIR}"
 test -f move/sources/Counter.move || fail "Scaffold did not produce Counter.move"
 test -f tests/Counter.test.ts || fail "Scaffold did not produce Counter.test.ts"
-log "Project scaffolded at ${PROJECT_DIR} (package name: ${PROJECT_NAME})"
+log "Project scaffolded at ${PROJECT_DIR}"
 
 step "5/9 — Extend Counter with a user-authored reset() function + Move test"
 # Inject `reset()` entry function AND a corresponding #[test] right


### PR DESCRIPTION
## Summary

Batch merge of two sub-PRs that together close GRANT MOU **KPI 1** ("Forklift API Parity").

| PR | Title | Closes |
|---|---|---|
| #198 | feat(init): sanitize project name as Move identifier | #195 |
| #203 | feat: KPI 1 closeout — re-export Harness types + example coverage for upgradeCodeObject / runMoveScript / Harness.createFork | #199, #200 |

After this batch lands on \`main\`, the KPI 1 audit matrix is 8/8 on every Forklift parity axis (impl + export + docs + example), and three issues auto-close via the \`Closes\` keyword.

## What this batch ships

### KPI 1 closeout

**API surface — 6 new type re-exports** from \`packages/movehat/src/index.ts\`:

- \`DeployCodeObjectOptions\`, \`UpgradeCodeObjectOptions\`, \`CodeObjectInfo\`
- \`RunViewFunctionOptions\`, \`RunMoveScriptOptions\`, \`MoveScriptResult\`

Plus a new \`exports.test.ts\` that locks the public runtime export list (9 symbols) — accidental drift becomes a CI fail rather than a silent regression.

**Example coverage** — three new scripts under \`examples/counter-example/\`:

- \`scripts/upgrade-counter.ts\` — \`harness.upgradeCodeObject\` against an existing deployment.
- \`scripts/run-script.ts\` + \`move/scripts/echo.move\` — \`harness.runMoveScript\` with typed args.
- \`scripts/demo-harness-fork.ts\` — \`Harness.createFork\` + read-only \`runViewFunction\` + write-rejection contract + post-cleanup \`HarnessDisposedError\` poisoning.

Plus \`examples/counter-example/README.md\` mapping each npm script to the Movehat primitive it exercises.

### DX fix (paper-cut from KPI 1 audit)

\`movehat init <name>\` now sanitizes the project name into a valid Move identifier when writing \`move/Move.toml\`, preserving the original name for \`package.json\` and the filesystem directory. Cargo-style: paths and hyphens land in \`Move.toml\` as underscored identifiers; names starting with a digit get \`pkg_\` prefixed; \`.\` / \`..\` / empty are rejected with a clear error. Previously, passing a path like \`/tmp/my-project\` produced a malformed \`Move.toml\` and a cryptic \`"No such file or directory"\` compile failure.

## Follow-ups (not in this batch)

- **#201** — document the pre-commit hook policy in CONTRIBUTING.md (KPI 2 audit P3, cosmetic).
- **#202** — add \`CODE_OF_CONDUCT.md\` (KPI 2 audit P4, cosmetic).
- **#192** — writable-fork support for Tier C dogfood (long-term).

## Tier 2 / Tier 3

- **Sub-PR #198** (init sanitization): Tier 2 / Tier 3 N/A per its PR body — \`bin\` shim untouched, template file count unchanged, only a placeholder rename inside an existing template file.
- **Sub-PR #203** (KPI 1 closeout): Tier 2 / Tier 3 N/A per its PR body — no packaging change, no runtime behavior touched.
- **This batch**: would re-run the validation already exercised on each sub-PR. \`pnpm test\` (full unit suite) was green on both sub-PRs (427/427). \`pnpm check:example\` green on both.

## Test plan

- [x] Sub-PRs #198 + #203 merged green to develop with §8 reviews posted.
- [x] \`pnpm test\` 427/427 on develop tip.
- [x] \`pnpm check:example\` green on develop tip.
- [x] Three issues set to auto-close on this batch merge (#195, #199, #200).