### PR TITLE
fix(templates): deploy script must init before increment + AIP-80 + Tier 2/3 prevention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Template `scripts/deploy-counter.ts` previously attempted
+  `counter::increment` immediately after deploy, before the required
+  `counter::init` call. New users running the canonical happy path
+  (`movehat init <name>` → `movehat run scripts/deploy-counter.ts`)
+  hit `E_NOT_INITIALIZED(0x2)` on their first script execution. The
+  script now calls `init` before `increment` with an explanatory
+  comment about the Move resource pattern.
+- Template `move/sources/Counter.move` hardened with auto-init in
+  `increment` as defense in depth. A new Move-level test
+  (`test_increment_auto_inits`) locks the auto-init behavior so a
+  future refactor can't accidentally remove the defense.
+- `[Aptos SDK]` AIP-80 deprecation warning suppressed in
+  `AccountManager.loadAccountFromPrivateKey` and `core/config.ts`
+  `deriveAccountAddress` by formatting raw hex private keys with
+  `PrivateKey.formatPrivateKey` before passing them to
+  `Ed25519PrivateKey`. Cosmetic; no behavior change.
+- `scripts/e2e-local.sh` (which feeds `pnpm test:e2e:quick` on every
+  PR and `scripts/pre-publish.sh` for releases) now actually executes
+  `deploy-counter.ts` against Movement testnet and asserts that
+  "Counter value: 1" appears in the output. Previously the script
+  only validated template files exist, which is how the
+  `E_NOT_INITIALIZED` regression slipped through.
+
 ### Security
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ Two scripts, both run before opening / re-requesting review on every sub-PR that
 
 - **`pnpm test:smoke`** — packs movehat into a tarball, installs it globally, exercises `movehat --version` / `--help` / `init`. ~20s. Catches packaging issues that the workspace symlink hides: missing files in `dist/`, missing `bin` shim, missing template files. Mandatory because Tier 1 cannot see "what's actually in the tarball" — only what's in the workspace.
 
+- **Mandatory end-to-end execution of canonical template scripts** — Any PR that adds or modifies a file under `packages/movehat/src/templates/scripts/**` MUST be exercised end-to-end via `pnpm test:e2e:quick` before merge. The script in `scripts/e2e-local.sh` runs `MOVEHAT_NETWORK=testnet movehat run scripts/deploy-counter.ts` from a freshly-initialized project and asserts the script reaches its terminal "Counter value: 1" line. Type-validity is necessary but not sufficient: the script must actually run successfully against a real Movement node, with assertions on its observable output. This rule exists because a `deploy-counter.ts` template shipped with a runtime-breaking missing-init bug despite passing all unit tests and Tier 1 typecheck — caught only on a user smoke test of the canonical happy path.
+
 What Tier 2 still doesn't cover: the end-to-end install-then-use flow against the published artifact (e.g. would `pnpm install movehat` followed by `movehat compile` + `mocha tests/*` actually work?). That's Tier 3.
 
 ### 6.3 Tier 3 — Full install-experience E2E (slow, before publish or develop→main batch)

--- a/packages/movehat/src/core/AccountManager.ts
+++ b/packages/movehat/src/core/AccountManager.ts
@@ -1,6 +1,8 @@
 import {
   Account,
   Ed25519PrivateKey,
+  PrivateKey,
+  PrivateKeyVariants,
 } from "@aptos-labs/ts-sdk";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
@@ -131,7 +133,14 @@ export class AccountManager {
    * const account = AccountManager.loadAccountFromPrivateKey("0xabc123...");
    */
   static loadAccountFromPrivateKey(privateKeyHex: string): Account {
-    const privateKey = new Ed25519PrivateKey(privateKeyHex);
+    // Format into AIP-80 shape (`ed25519-priv-0x…`) before constructing
+    // the SDK type. Without this, raw-hex inputs trigger a noisy
+    // deprecation warning from `@aptos-labs/ts-sdk` on every call.
+    const formatted = PrivateKey.formatPrivateKey(
+      privateKeyHex,
+      PrivateKeyVariants.Ed25519,
+    );
+    const privateKey = new Ed25519PrivateKey(formatted);
     const account = Account.fromPrivateKey({ privateKey });
     const address = account.accountAddress.toString();
 

--- a/packages/movehat/src/core/config.ts
+++ b/packages/movehat/src/core/config.ts
@@ -1,7 +1,7 @@
 import { pathToFileURL } from "url";
 import { join } from "path";
 import { existsSync, statSync } from "fs";
-import { Account, Ed25519PrivateKey } from "@aptos-labs/ts-sdk";
+import { Account, Ed25519PrivateKey, PrivateKey, PrivateKeyVariants } from "@aptos-labs/ts-sdk";
 import { MovehatConfig, MovehatUserConfig } from "../types/config.js";
 
 interface ConfigCacheEntry {
@@ -258,11 +258,15 @@ export async function resolveNetworkConfig(
 function deriveAccountAddress(privateKeyHex: string | undefined): string {
   if (!privateKeyHex) return "";
   try {
-    const stripped = privateKeyHex.startsWith("ed25519-priv-")
-      ? privateKeyHex.slice("ed25519-priv-".length)
-      : privateKeyHex;
+    // Format into AIP-80 shape so the SDK doesn't emit a deprecation
+    // warning on each derivation. `formatPrivateKey` is idempotent for
+    // already-prefixed inputs.
+    const formatted = PrivateKey.formatPrivateKey(
+      privateKeyHex,
+      PrivateKeyVariants.Ed25519,
+    );
     const account = Account.fromPrivateKey({
-      privateKey: new Ed25519PrivateKey(stripped),
+      privateKey: new Ed25519PrivateKey(formatted),
     });
     return account.accountAddress.toString();
   } catch (err) {

--- a/packages/movehat/src/templates/move/sources/Counter.move
+++ b/packages/movehat/src/templates/move/sources/Counter.move
@@ -33,7 +33,16 @@ module counter::counter {
 
     public entry fun increment(account: &signer) acquires Counter {
         let account_addr = signer::address_of(account);
-        assert!(exists<Counter>(account_addr), E_NOT_INITIALIZED);
+
+        // Auto-init: create Counter if it doesn't exist yet. Defense in
+        // depth so the module stays usable even if a caller skips the
+        // dedicated `init` entry function.
+        if (!exists<Counter>(account_addr)) {
+            move_to(account, Counter {
+                value: 0,
+                increment_events: account::new_event_handle<IncrementEvent>(account),
+            });
+        };
 
         let counter = borrow_global_mut<Counter>(account_addr);
         let old_value = counter.value;
@@ -56,14 +65,32 @@ module counter::counter {
     public fun test_increment(account: &signer) acquires Counter {
         let addr = signer::address_of(account);
         aptos_framework::account::create_account_for_test(addr);
-        
+
         init(account);
         assert!(get(addr) == 0, 0);
-        
+
         increment(account);
         assert!(get(addr) == 1, 1);
-        
+
         increment(account);
         assert!(get(addr) == 2, 2);
+    }
+
+    /// Regression guard: increment must auto-create the Counter resource
+    /// when called against a never-initialized account. Locks the
+    /// defense-in-depth behavior so a future refactor can't accidentally
+    /// remove it.
+    #[test(account = @0x2)]
+    public fun test_increment_auto_inits(account: &signer) acquires Counter {
+        let addr = signer::address_of(account);
+        aptos_framework::account::create_account_for_test(addr);
+
+        // Skip init entirely — increment must create the resource.
+        increment(account);
+        assert!(get(addr) == 1, 0);
+
+        // Idempotent: a second increment uses the now-existing resource.
+        increment(account);
+        assert!(get(addr) == 2, 1);
     }
 }

--- a/packages/movehat/src/templates/scripts/deploy-counter.ts
+++ b/packages/movehat/src/templates/scripts/deploy-counter.ts
@@ -31,6 +31,16 @@ async function main() {
     // Interact with the freshly deployed module via the runtime helper.
     const counter = harness.runtime.getContract(deployment.address, "counter");
 
+    // Counter is a Move resource — it must be created explicitly per
+    // account before any method that reads or mutates it. The dedicated
+    // `init` entry function does this once per signer. (The module also
+    // auto-inits inside `increment` as defense in depth, so this call is
+    // technically optional today, but kept for pedagogy: real-world Move
+    // modules usually require an explicit init step.)
+    console.log("\n🔧 Initializing counter resource for this account...");
+    const initTx = await counter.call(harness.runtime.account, "init", []);
+    console.log(`   Init tx: ${initTx.hash}`);
+
     console.log("\n📝 Incrementing counter...");
     const txResult = await counter.call(harness.runtime.account, "increment", []);
     console.log(`✅ Transaction hash: ${txResult.hash}`);

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -288,11 +288,48 @@ else
 fi
 
 # ===========================================
+# Test: Canonical deploy-counter.ts end-to-end against Movement testnet
+# ===========================================
+# Catches the class of bug where the template's deploy script is
+# type-valid but fails at runtime (e.g., skipping a required `init`
+# call). Uses Movement testnet because:
+#   - It matches the path real users hit on first install.
+#   - The runtime auto-generates and faucet-funds a test account for
+#     testnet, so this works without any CI secret.
+#   - Avoids the upstream MintFunder bug on Linux x86_64 that gates
+#     the local-node spawn behind MOVEHAT_SKIP_LOCAL_NODE.
+#
+# The step is NOT gated by --quick. The whole point of this gate is
+# to run on every PR, since unit tests can't catch a missing init()
+# in a template script.
+step "Testing: canonical deploy-counter.ts against Movement testnet"
+
+DEPLOY_LOG="$TEST_DIR/deploy.log"
+
+if MOVEHAT_NETWORK=testnet npx movehat run scripts/deploy-counter.ts > "$DEPLOY_LOG" 2>&1; then
+    # Exit code 0 is necessary but not sufficient — assert the script
+    # actually reached the final view-function call. The "Counter
+    # value: 1" line is emitted only after deploy + init + increment
+    # + view all succeed.
+    if grep -q "Counter value: 1" "$DEPLOY_LOG"; then
+        pass "Canonical deploy script succeeded end-to-end (deploy + init + increment + view)"
+    else
+        fail "Deploy script exited 0 but did not print 'Counter value: 1'"
+        echo "--- deploy.log (tail) ---"
+        tail -30 "$DEPLOY_LOG"
+    fi
+else
+    fail "Canonical deploy-counter.ts failed at runtime"
+    echo "--- deploy.log (tail) ---"
+    tail -30 "$DEPLOY_LOG"
+fi
+
+# ===========================================
 # Test: npm test (Move unit tests)
 # ===========================================
 if [ "$QUICK_MODE" = false ]; then
     step "Testing: movehat test --move"
-    
+
     if npx movehat test --move 2>&1; then
         pass "Move unit tests passed"
     else


### PR DESCRIPTION
## Summary

Closes a user-reported runtime bug in the canonical happy path:

\`\`\`
movehat init first-project
cd first-project
movehat run scripts/deploy-counter.ts
# → ❌ Move abort: E_NOT_INITIALIZED(0x2)
\`\`\`

Root cause: the template \`deploy-counter.ts\` called \`counter::increment\` without calling \`counter::init\` first, but the template's \`Counter.move\` requires explicit initialization. Every new user hit this on their first script run. The bug was missed because Tier 1 typecheck passes, unit tests use a test path that *does* call init, and the existing Tier 2/Tier 3 e2e (\`scripts/e2e-local.sh\`) validated template files exist but never executed them.

User directive (2026-05-16): "que no vuelva a ocurrir."

Locked decisions:
- **Tier 2 (per-PR) + Tier 3 (pre-publish)** for max prevention coverage.
- **Opción A + B**: fix the script AND harden the module with auto-init as defense in depth.

## What ships in this PR

### Commit 1 — \`fix(templates): deploy script must init before increment; harden module with auto-init\`

| File | Change |
|---|---|
| \`packages/movehat/src/templates/scripts/deploy-counter.ts\` | \`init\` call added before \`increment\` with pedagogical comment |
| \`packages/movehat/src/templates/move/sources/Counter.move\` | \`increment\` auto-creates Counter if missing (defense in depth); new \`test_increment_auto_inits\` regression test locks the behavior |

### Commit 2 — \`fix(core): format private keys as AIP-80 compliant before constructing Ed25519PrivateKey\`

| File | Change |
|---|---|
| \`packages/movehat/src/core/AccountManager.ts\` | \`loadAccountFromPrivateKey\` runs input through \`PrivateKey.formatPrivateKey\` before \`new Ed25519PrivateKey\` |
| \`packages/movehat/src/core/config.ts\` | \`deriveAccountAddress\` same fix |

Suppresses the noisy \`[Aptos SDK] private keys are AIP-80 compliant\` warning that appeared twice on every \`movehat run\` invocation.

### Commit 3 — \`test(e2e): exercise canonical deploy-counter.ts end-to-end against testnet\`

| File | Change |
|---|---|
| \`scripts/e2e-local.sh\` | New step runs \`MOVEHAT_NETWORK=testnet npx movehat run scripts/deploy-counter.ts\` and asserts the script reaches "Counter value: 1" |

This step:
- Is NOT gated by \`--quick\` (so it runs on every PR via \`pnpm test:e2e:quick\`).
- Uses testnet because (a) it matches the real user path, (b) Movement runtime auto-funds testnet accounts so no CI secrets needed, (c) avoids the upstream MintFunder bug that gates local-node on Linux x86_64.
- Adds ~30-60 s to PR CI — acceptable price for catching this class of bug.

### Commit 4 — \`docs(claude,changelog): mandate end-to-end execution of canonical template scripts\`

| File | Change |
|---|---|
| \`CLAUDE.md\` §6.2 | New mandatory bullet: PRs touching \`templates/scripts/**\` MUST be exercised via \`pnpm test:e2e:quick\` before merge |
| \`CHANGELOG.md\` Unreleased → Fixed | 4 entries describing what this batch fixes |

## Verification

- [x] \`pnpm test\` — **427/427 green** (no behavior change on the TS path).
- [x] \`pnpm check:example\` — green (Tier 1 typecheck clean).
- [ ] \`pnpm test:e2e:quick\` — **CI will verify this** as the very gate this PR introduces. The new step makes the canonical user flow part of every PR.

## Risks

| Risk | Likelihood | Mitigation |
|---|---|---|
| Auto-init in \`increment\` adds 1 \`exists<>\` check per call | Negligible gas cost (~1 μgas) | Acceptable — the robustness gain is worth it |
| Testnet rate-limits / downtime breaks the new e2e step on a particularly bad day | Low | One step out of many; if testnet is down at publish-time, maintainer waits or overrides manually. No silent shipping |
| \`PrivateKey.formatPrivateKey\` not exposed in older SDK | Verified | Confirmed exported from \`@aptos-labs/ts-sdk\` (\`packages/movehat/node_modules/@aptos-labs/ts-sdk/dist/esm/index.d.mts:12\`) |

## Tier 2 / Tier 3

- **Tier 1** (typecheck): green via \`pnpm check:example\`.
- **Tier 2** (per-PR runtime): the new step inside \`pnpm test:e2e:quick\` *is* this PR's Tier 2 coverage. Will run in CI on this PR itself.
- **Tier 3** (pre-publish): same e2e script extension. No separate change needed; \`scripts/pre-publish.sh\` already calls \`pnpm test:e2e\`.

## Plan reference

Full plan with rationale and tradeoffs: \`grant/ROADMAP_ANVIL_LIKE.md\` is separate (it's the post-KPI-1 Camino 1/2 roadmap); this PR's plan lives at \`/Users/gilbertsahumada/.claude/plans/planifiquemos-la-implementacion-del-logical-pebble.md\` (local working copy).