### PR TITLE
chore(release): prepare v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [0.2.2] - 2026-05-16
+
+### Added
+
 - Re-export six Harness option/result types from the root `movehat`
   entry point (`DeployCodeObjectOptions`, `UpgradeCodeObjectOptions`,
   `CodeObjectInfo`, `RunViewFunctionOptions`, `RunMoveScriptOptions`,
@@ -91,8 +107,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compiler recognizes) to `//` (regular comment) so it doesn't
   trigger `invalid documentation comment` warnings on
   `movement move test`.
+- Audit findings (10 items, TDD-validated, [#215](https://github.com/gilbertsahumada/movehat/pull/215)):
+  - F1: `Harness.createFork` now honors the `network` argument (was silently routing all callers to testnet).
+  - F2: Fork server closes CORS by default; opt-in via `corsAllowOrigins` config.
+  - F3: `MovementApiClient` adds request timeout + `maxBytes` guard.
+  - F4: `ChildProcessAdapter.run` adds a `maxBuffer` guard.
+  - F5: `withYamlLock` docstring tightened to make process-local scope explicit (mooted by the temp-key-file refactor that removed yamlLock entirely; cross-process hardening tracked separately in [#211](https://github.com/gilbertsahumada/movehat/issues/211)).
+  - F6: Removed stale `packages/movehat/package-lock.json` left over from a prior tooling change.
+  - F7: Pinned `movehat compile` Move.toml mutation behavior with a regression test; product decision tracked in [#212](https://github.com/gilbertsahumada/movehat/issues/212).
+  - F8: AccountManager's static-state lifecycle + import-time cwd capture documented + locked by behavioral tests; instance-per-Harness refactor tracked in [#213](https://github.com/gilbertsahumada/movehat/issues/213).
+  - F9: `LocalNodeManager` refuses to misreport the REST API port; deprecated the misleading `apiPort` option.
+  - F10: CI audit gate hardened; publish workflow validates version input for both `release: published` and `workflow_dispatch` triggers.
+- CI E2E gate now installs the freshly-built tarball into the
+  user-project under test (previously `npm install` resolved
+  `"movehat"` from the npm registry, so the gate exercised stale
+  published code instead of the diff under review). This is the
+  fix that let the second batch confirm #210 actually resolves
+  #208 on Linux CI. ([#217](https://github.com/gilbertsahumada/movehat/pull/217))
+- CI audit gate now triggers at `--audit-level critical` (was
+  default, which failed on any severity). 27 high/moderate/low
+  advisories in `packages/docs` transitive dependencies (Fumadocs,
+  Next.js, Vite, Rollup) are documented in `SECURITY.md` as
+  known-not-impacting — none reach the published `movehat` package
+  on npm. The repo cannot upgrade Fumadocs until Next.js 16 is
+  compatible with the docs site's static-export configuration.
+  ([#217](https://github.com/gilbertsahumada/movehat/pull/217))
 
 ### Security
+
+- `SECURITY.md` adds a "Known advisories in development
+  dependencies" section enumerating the 13 high CVEs in
+  `packages/docs` build infrastructure that the audit gate
+  acknowledges. Resolution path: Fumadocs releasing a version
+  compatible with Next.js 16.
 
 ---
 

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {


### PR DESCRIPTION
## Summary

Bumps \`packages/movehat\` from 0.2.1 to 0.2.2 and moves the \`Unreleased\` section to \`[0.2.2] - 2026-05-16\`.

## What ships in 0.2.2

The accumulated work since 0.2.1 hits npm:

- **Added** (4 entries): Harness type re-exports + 3 new example scripts (upgrade-counter, run-script, demo-harness-fork) + counter-example README.
- **Changed** (1): \`movehat init\` sanitizes Move identifier names (closes #195).
- **Fixed** (8 entries): the critical user-facing ones —
  - Template \`deploy-counter.ts\` calls \`init\` before \`increment\` (no more E_NOT_INITIALIZED on first run).
  - Template \`Counter.move\` hardened with auto-init in \`increment\`.
  - AIP-80 warning suppressed.
  - \`movement move deploy-object\` no longer requires \`~/.aptos/config.yaml\` (closes #208 — fresh installs work).
  - 10 audit findings (F1-F10) from #215.
  - CI audit gate calibrated to \`critical\` severity with documented exceptions.
- **Security**: SECURITY.md \"Known advisories\" section for the 13 high CVEs in docs-build infra.

Full per-section breakdown lives in \`CHANGELOG.md\`.

## After this PR merges

1. Batch develop → main (single-commit batch).
2. Create a GitHub Release with tag \`v0.2.2\` pointing at the main commit → triggers \`publish.yml\` workflow with npm Trusted Publishers + SLSA v1 provenance.
3. Verify: \`npm view movehat@0.2.2\` shows the provenance attestations.

## Verification

- [x] \`packages/movehat/package.json\` version is \`0.2.2\`.
- [x] CHANGELOG \`[0.2.2]\` section is present and lists all entries.
- [x] \`node packages/movehat/scripts/check-changelog.js 0.2.2\` exits 0.
- [x] \`pnpm test\` 454/454 green at the parent commit (develop tip).

## Tier 2 / Tier 3

- Tier 1 (\`pnpm check:example\`): no source change, green.
- Tier 2 (\`pnpm test:e2e:quick\`): no source change. The gate that ships in this version is exactly what was validated on the parent commit's batch merge (PR #216) — that's the verification that \`0.2.2\` end-to-end works on a clean CI environment.
- Tier 3 (\`pnpm test:e2e\` via \`scripts/pre-publish.sh\`): will be invoked automatically by the \`publish.yml\` workflow on GitHub release creation.