### PR TITLE
develop → main: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - F2: Fork server closes CORS by default; opt-in via `corsAllowOrigins` config.
   - F3: `MovementApiClient` adds request timeout + `maxBytes` guard.
   - F4: `ChildProcessAdapter.run` adds a `maxBuffer` guard.
-  - F5: `withYamlLock` docstring tightened to make process-local scope explicit (mooted by the temp-key-file refactor that removed yamlLock entirely; cross-process hardening tracked separately in [#211](https://github.com/gilbertsahumada/movehat/issues/211)).
+  - F5: `withYamlLock` docstring tightened to make process-local scope explicit, with an `it.skip` test pinning the cross-process gap (the originally-shipped fix). The follow-up [#210](https://github.com/gilbertsahumada/movehat/pull/210) refactor in this same release subsequently removed `withYamlLock` entirely (replaced with per-deploy temp key files), which resolves the cross-process race incidentally — no shared yaml file remains to race on. Cross-process lock hardening for the yaml flow is therefore obsolete; the issue stays open at [#211](https://github.com/gilbertsahumada/movehat/issues/211) for any future code path that revives shared-file state.
   - F6: Removed stale `packages/movehat/package-lock.json` left over from a prior tooling change.
   - F7: Pinned `movehat compile` Move.toml mutation behavior with a regression test; product decision tracked in [#212](https://github.com/gilbertsahumada/movehat/issues/212).
   - F8: AccountManager's static-state lifecycle + import-time cwd capture documented + locked by behavioral tests; instance-per-Harness refactor tracked in [#213](https://github.com/gilbertsahumada/movehat/issues/213).
@@ -121,25 +121,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI E2E gate now installs the freshly-built tarball into the
   user-project under test (previously `npm install` resolved
   `"movehat"` from the npm registry, so the gate exercised stale
-  published code instead of the diff under review). This is the
-  fix that let the second batch confirm #210 actually resolves
-  #208 on Linux CI. ([#217](https://github.com/gilbertsahumada/movehat/pull/217))
+  published code instead of the diff under review). This fix is
+  what let CI on the second batch confirm that PR
+  [#210](https://github.com/gilbertsahumada/movehat/pull/210)
+  actually resolves
+  [#208](https://github.com/gilbertsahumada/movehat/issues/208) on
+  Linux CI. ([#217](https://github.com/gilbertsahumada/movehat/pull/217))
 - CI audit gate now triggers at `--audit-level critical` (was
-  default, which failed on any severity). 27 high/moderate/low
-  advisories in `packages/docs` transitive dependencies (Fumadocs,
-  Next.js, Vite, Rollup) are documented in `SECURITY.md` as
+  default, which failed on any severity). 27 advisories in total
+  (13 rated high severity, the remainder moderate/low) in
+  `packages/docs` transitive dependencies (Fumadocs, Next.js,
+  Vite, Rollup) are documented in `SECURITY.md` as
   known-not-impacting — none reach the published `movehat` package
-  on npm. The repo cannot upgrade Fumadocs until Next.js 16 is
-  compatible with the docs site's static-export configuration.
+  on npm. **Resolution path**: Next.js must first ship a release
+  that supports the docs site's static-export configuration, then
+  Fumadocs must release a version that depends on that Next.js. The
+  repo cannot upgrade Fumadocs unilaterally because today's
+  Fumadocs depends on Next.js 16 features that break our static
+  build, and patched Next.js versions live downstream of that.
   ([#217](https://github.com/gilbertsahumada/movehat/pull/217))
 
 ### Security
 
 - `SECURITY.md` adds a "Known advisories in development
-  dependencies" section enumerating the 13 high CVEs in
-  `packages/docs` build infrastructure that the audit gate
-  acknowledges. Resolution path: Fumadocs releasing a version
-  compatible with Next.js 16.
+  dependencies" section enumerating the 13 high-severity
+  advisories in `packages/docs` build infrastructure that the
+  audit gate acknowledges. Resolution path: Next.js must ship a
+  static-export-compatible release first, then Fumadocs must
+  release a version that depends on it.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [0.2.2] - 2026-05-16
+
+### Added
+
 - Re-export six Harness option/result types from the root `movehat`
   entry point (`DeployCodeObjectOptions`, `UpgradeCodeObjectOptions`,
   `CodeObjectInfo`, `RunViewFunctionOptions`, `RunMoveScriptOptions`,
@@ -91,8 +107,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compiler recognizes) to `//` (regular comment) so it doesn't
   trigger `invalid documentation comment` warnings on
   `movement move test`.
+- Audit findings (10 items, TDD-validated, [#215](https://github.com/gilbertsahumada/movehat/pull/215)):
+  - F1: `Harness.createFork` now honors the `network` argument (was silently routing all callers to testnet).
+  - F2: Fork server closes CORS by default; opt-in via `corsAllowOrigins` config.
+  - F3: `MovementApiClient` adds request timeout + `maxBytes` guard.
+  - F4: `ChildProcessAdapter.run` adds a `maxBuffer` guard.
+  - F5: `withYamlLock` docstring tightened to make process-local scope explicit (mooted by the temp-key-file refactor that removed yamlLock entirely; cross-process hardening tracked separately in [#211](https://github.com/gilbertsahumada/movehat/issues/211)).
+  - F6: Removed stale `packages/movehat/package-lock.json` left over from a prior tooling change.
+  - F7: Pinned `movehat compile` Move.toml mutation behavior with a regression test; product decision tracked in [#212](https://github.com/gilbertsahumada/movehat/issues/212).
+  - F8: AccountManager's static-state lifecycle + import-time cwd capture documented + locked by behavioral tests; instance-per-Harness refactor tracked in [#213](https://github.com/gilbertsahumada/movehat/issues/213).
+  - F9: `LocalNodeManager` refuses to misreport the REST API port; deprecated the misleading `apiPort` option.
+  - F10: CI audit gate hardened; publish workflow validates version input for both `release: published` and `workflow_dispatch` triggers.
+- CI E2E gate now installs the freshly-built tarball into the
+  user-project under test (previously `npm install` resolved
+  `"movehat"` from the npm registry, so the gate exercised stale
+  published code instead of the diff under review). This is the
+  fix that let the second batch confirm #210 actually resolves
+  #208 on Linux CI. ([#217](https://github.com/gilbertsahumada/movehat/pull/217))
+- CI audit gate now triggers at `--audit-level critical` (was
+  default, which failed on any severity). 27 high/moderate/low
+  advisories in `packages/docs` transitive dependencies (Fumadocs,
+  Next.js, Vite, Rollup) are documented in `SECURITY.md` as
+  known-not-impacting — none reach the published `movehat` package
+  on npm. The repo cannot upgrade Fumadocs until Next.js 16 is
+  compatible with the docs site's static-export configuration.
+  ([#217](https://github.com/gilbertsahumada/movehat/pull/217))
 
 ### Security
+
+- `SECURITY.md` adds a "Known advisories in development
+  dependencies" section enumerating the 13 high CVEs in
+  `packages/docs` build infrastructure that the audit gate
+  acknowledges. Resolution path: Fumadocs releasing a version
+  compatible with Next.js 16.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,10 +66,18 @@ Tracked advisories (2026-05-16):
 - **path-to-regexp** — DoS. Transitive via Next.js.
 - **picomatch** — ReDoS via extglob. Transitive via Rollup/Vite.
 
-These will be resolved when Fumadocs releases a version compatible with
-Next.js 16+ (which patches the Next CVEs and pulls in patched Vite/Rollup).
-The repo cannot upgrade Fumadocs unilaterally because Next.js 16 requires
-`useEffectEvent` semantics that break the docs site's static-export build
-on Next.js 15.
+Resolution path (in order):
+
+1. Next.js ships a release that supports the docs site's
+   static-export configuration (today's Next.js 16 introduces
+   `useEffectEvent` semantics that break static export on Next.js 15
+   APIs).
+2. Fumadocs releases a version that depends on that Next.js.
+3. We upgrade Fumadocs, which pulls in patched Next.js / Vite /
+   Rollup transitively and clears all 13 high advisories above.
+
+The repo cannot shortcut this chain (e.g. pin Next.js via
+`pnpm.overrides`) because Fumadocs has tight version expectations
+that breaking would crash the docs site build.
 
 The published `packages/movehat` package has zero advisories.

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {


### PR DESCRIPTION
## Summary

Batch merge of the v0.2.2 release prep:

| PR | Title | Commit |
|---|---|---|
| #218 | chore(release): prepare v0.2.2 | 343b7ae |

Develop is 1 commit ahead of main.

## What this batch enables

After this merges to \`main\`, creating a GitHub Release with tag \`v0.2.2\` (target commit on main) triggers \`publish.yml\` → \`npm publish\` with Trusted Publishers + SLSA v1 provenance.

\`movehat@0.2.2\` ships everything accumulated since 0.2.1:

- The user-facing bug fix: \`E_NOT_INITIALIZED\` on canonical \`movehat init && movehat run scripts/deploy-counter.ts\` happy path is resolved (template script calls \`init\`; module hardened with auto-init).
- \`movement move deploy-object\` works on fresh installs without \`~/.aptos/config.yaml\` (closes #208 — was P1 blocker for clean-machine UX).
- AIP-80 SDK deprecation warning suppressed (closes #207).
- 10 audit findings from #215 (F1-F10) shipped.
- 3 new example scripts demonstrating the full Forklift parity surface (upgrade-counter, run-script, demo-harness-fork).
- Templates: init sanitization (#195), Counter.move hardened, deploy-counter.ts fixed.
- CI hardening: e2e exercises built tarball; audit gate calibrated.

Full per-section breakdown in \`CHANGELOG.md\` under \`[0.2.2] - 2026-05-16\`.

## Tier 2 / Tier 3

Sub-PR #218 was pure metadata (version bump + CHANGELOG). The Tier 2/3 verification happened on PR #216 (the parent commit batch) where the same source state was exercised end-to-end including the canonical deploy script against Movement testnet. No code change in this batch.

## Test plan

- [x] PR #218 merged green to develop.
- [x] \`packages/movehat/package.json\` reports 0.2.2 at develop tip.
- [x] CHANGELOG \`[0.2.2]\` section is present (verified with \`check-changelog.js\`).
- [ ] CI on this batch runs the same 11 checks as #216 — expected all green.
- [ ] Post-merge: create GitHub release \`v0.2.2\` to trigger \`publish.yml\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added documentation of high-severity security advisories found in development dependencies
  * Enhanced CI security gate to detect critical-level advisories

* **Chores**
  * Version bumped to 0.2.2
  * Updated CI E2E test execution to use locally-built package tarball

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->