### PR TITLE
docs(changelog): address CodeRabbit nits on v0.2.2 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - F2: Fork server closes CORS by default; opt-in via `corsAllowOrigins` config.
   - F3: `MovementApiClient` adds request timeout + `maxBytes` guard.
   - F4: `ChildProcessAdapter.run` adds a `maxBuffer` guard.
-  - F5: `withYamlLock` docstring tightened to make process-local scope explicit (mooted by the temp-key-file refactor that removed yamlLock entirely; cross-process hardening tracked separately in [#211](https://github.com/gilbertsahumada/movehat/issues/211)).
+  - F5: `withYamlLock` docstring tightened to make process-local scope explicit, with an `it.skip` test pinning the cross-process gap (the originally-shipped fix). The follow-up [#210](https://github.com/gilbertsahumada/movehat/pull/210) refactor in this same release subsequently removed `withYamlLock` entirely (replaced with per-deploy temp key files), which resolves the cross-process race incidentally — no shared yaml file remains to race on. Cross-process lock hardening for the yaml flow is therefore obsolete; the issue stays open at [#211](https://github.com/gilbertsahumada/movehat/issues/211) for any future code path that revives shared-file state.
   - F6: Removed stale `packages/movehat/package-lock.json` left over from a prior tooling change.
   - F7: Pinned `movehat compile` Move.toml mutation behavior with a regression test; product decision tracked in [#212](https://github.com/gilbertsahumada/movehat/issues/212).
   - F8: AccountManager's static-state lifecycle + import-time cwd capture documented + locked by behavioral tests; instance-per-Harness refactor tracked in [#213](https://github.com/gilbertsahumada/movehat/issues/213).
@@ -121,25 +121,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI E2E gate now installs the freshly-built tarball into the
   user-project under test (previously `npm install` resolved
   `"movehat"` from the npm registry, so the gate exercised stale
-  published code instead of the diff under review). This is the
-  fix that let the second batch confirm #210 actually resolves
-  #208 on Linux CI. ([#217](https://github.com/gilbertsahumada/movehat/pull/217))
+  published code instead of the diff under review). This fix is
+  what let CI on the second batch confirm that PR
+  [#210](https://github.com/gilbertsahumada/movehat/pull/210)
+  actually resolves
+  [#208](https://github.com/gilbertsahumada/movehat/issues/208) on
+  Linux CI. ([#217](https://github.com/gilbertsahumada/movehat/pull/217))
 - CI audit gate now triggers at `--audit-level critical` (was
-  default, which failed on any severity). 27 high/moderate/low
-  advisories in `packages/docs` transitive dependencies (Fumadocs,
-  Next.js, Vite, Rollup) are documented in `SECURITY.md` as
+  default, which failed on any severity). 27 advisories in total
+  (13 rated high severity, the remainder moderate/low) in
+  `packages/docs` transitive dependencies (Fumadocs, Next.js,
+  Vite, Rollup) are documented in `SECURITY.md` as
   known-not-impacting — none reach the published `movehat` package
-  on npm. The repo cannot upgrade Fumadocs until Next.js 16 is
-  compatible with the docs site's static-export configuration.
+  on npm. **Resolution path**: Next.js must first ship a release
+  that supports the docs site's static-export configuration, then
+  Fumadocs must release a version that depends on that Next.js. The
+  repo cannot upgrade Fumadocs unilaterally because today's
+  Fumadocs depends on Next.js 16 features that break our static
+  build, and patched Next.js versions live downstream of that.
   ([#217](https://github.com/gilbertsahumada/movehat/pull/217))
 
 ### Security
 
 - `SECURITY.md` adds a "Known advisories in development
-  dependencies" section enumerating the 13 high CVEs in
-  `packages/docs` build infrastructure that the audit gate
-  acknowledges. Resolution path: Fumadocs releasing a version
-  compatible with Next.js 16.
+  dependencies" section enumerating the 13 high-severity
+  advisories in `packages/docs` build infrastructure that the
+  audit gate acknowledges. Resolution path: Next.js must ship a
+  static-export-compatible release first, then Fumadocs must
+  release a version that depends on it.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,10 +66,18 @@ Tracked advisories (2026-05-16):
 - **path-to-regexp** — DoS. Transitive via Next.js.
 - **picomatch** — ReDoS via extglob. Transitive via Rollup/Vite.
 
-These will be resolved when Fumadocs releases a version compatible with
-Next.js 16+ (which patches the Next CVEs and pulls in patched Vite/Rollup).
-The repo cannot upgrade Fumadocs unilaterally because Next.js 16 requires
-`useEffectEvent` semantics that break the docs site's static-export build
-on Next.js 15.
+Resolution path (in order):
+
+1. Next.js ships a release that supports the docs site's
+   static-export configuration (today's Next.js 16 introduces
+   `useEffectEvent` semantics that break static export on Next.js 15
+   APIs).
+2. Fumadocs releases a version that depends on that Next.js.
+3. We upgrade Fumadocs, which pulls in patched Next.js / Vite /
+   Rollup transitively and clears all 13 high advisories above.
+
+The repo cannot shortcut this chain (e.g. pin Next.js via
+`pnpm.overrides`) because Fumadocs has tight version expectations
+that breaking would crash the docs site build.
 
 The published `packages/movehat` package has zero advisories.


### PR DESCRIPTION
## Summary

Addresses the 4 CodeRabbit nitpicks on PR #219 (the v0.2.2 release batch):

| # | Issue | Fix |
|---|---|---|
| 1 | F5 \"mooted\" status ambiguous — was it fixed by #215 or rendered moot by #210? | Rewrote F5 entry to make the two-step history explicit: #215 fixed it (docstring + it.skip), then #210's refactor made yamlLock disappear entirely. |
| 2 | \`#210\` referenced without prior intro in that section | Added explicit \"PR [#210]\" prefix + linked the issue \`#208\` it resolves. |
| 3 | \"27 high/moderate/low advisories\" + \"13 high CVEs\" terminology inconsistent | Standardized to \"advisories\" everywhere (CHANGELOG + SECURITY.md). \"27 advisories in total (13 rated high severity, the remainder moderate/low)\". |
| 4 | Resolution path for docs-deps CVEs was ambiguous about dependency chain (Next.js vs Fumadocs as blocker) | Made the chain explicit as numbered steps in both CHANGELOG and SECURITY.md: Next.js → Fumadocs → us. |

## Why land this separately from #219

#219 (the v0.2.2 batch develop → main) was opened, CI ran, all 11 checks went green BEFORE CodeRabbit's review came in. The clarifications here are pure documentation polish — no source change, no behavior change, just readability of the CHANGELOG that ships in the release.

After this lands on develop, the path is:
1. Open a fresh batch PR develop → main (or update #219 to pick up these commits if not yet merged).
2. Then create the v0.2.2 GitHub release to trigger publish.yml.

## Verification

- [x] \`node packages/movehat/scripts/check-changelog.js 0.2.2\` returns \`CHANGELOG.md has section for version 0.2.2\`.
- [x] No source changes; \`pnpm test\` not affected.
- [x] All 4 CodeRabbit nits addressed; no new clarifications needed.

## Tier 2 / Tier 3

N/A — docs only.