### PR TITLE
release: v0.2.3 — console UX overhaul + publish.yml fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,12 +143,41 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Closes #174: skip cleanly when main already has the version
+          # bump (the typical flow: release PR landed the bump before
+          # the tag was created, so the tag's `package.json` and
+          # `origin/main`'s `package.json` agree on version, and there's
+          # literally nothing to commit back).
+          #
+          # The previous unconditional `git stash push → checkout main →
+          # rebase → stash pop` dance produced "No stash entries found"
+          # when there was no diff to stash, then failed on pop and
+          # failed the whole job — even though npm publish (the actual
+          # job purpose) had already succeeded.
+          git fetch origin main
+          TAG_VERSION=$(grep -m1 '"version"' packages/movehat/package.json \
+            | sed 's/.*"version": "\([^"]*\)".*/\1/')
+          MAIN_VERSION=$(git show origin/main:packages/movehat/package.json \
+            | grep -m1 '"version"' \
+            | sed 's/.*"version": "\([^"]*\)".*/\1/')
+
+          if [ "$TAG_VERSION" = "$MAIN_VERSION" ]; then
+            echo "main is already at v$TAG_VERSION; no commit-back needed."
+            exit 0
+          fi
+
+          echo "main is at v$MAIN_VERSION; tag is v$TAG_VERSION. Committing bump back..."
+
+          # Below: original stash/rebase/pop dance — preserved for the
+          # edge case where a tag was created from a commit whose
+          # version bump never landed on main (e.g., release created
+          # from a feature branch).
+
           # Stash the version changes before switching branches
           git add packages/movehat/package.json packages/movehat/src/templates/package.json
           git stash push -m "Version bump to ${{ steps.get_version.outputs.version }}"
 
           # Fetch and checkout main branch (exit detached HEAD state)
-          git fetch origin main
           git checkout main
 
           # Rebase onto latest main to avoid non-fast-forward rejections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.3] - 2026-05-17
+
+### Added
+
+- Global `-v` / `--verbose` CLI flag and `MOVEHAT_VERBOSE=1` env var.
+  Opt-in surfacing of subprocess output from `movement node run-localnet`,
+  `aptos move build`, and `aptos move publish` for debugging slow startups,
+  build hangs, or git-dependency downloads. By default this output is hidden.
+- `withTimedSpinner` UI helper (`packages/movehat/src/ui/spinner.ts`) wrapping
+  long async tasks with a spinner that updates its label every 500ms with the
+  elapsed wall-clock time. Replaces the silent 10-30s wait during local-node
+  startup with live progress feedback.
+- `logger.phase(title)` and `logger.divider()` helpers (`packages/movehat/src/ui/logger.ts`)
+  rendering consistent `━` rules + bold brand-colored titles at phase
+  boundaries. Replaces the ad-hoc `console.log(colors.bold(...))` +
+  `console.log(colors.muted("─".repeat(50)))` pattern.
+- CLAUDE.md §9 — Console UX conventions. Codifies the five-source taxonomy
+  (system / subprocess / user / SDK warnings / mocha) and the rules every
+  future PR must follow when emitting to the user's terminal.
+- 14 new unit tests covering verbosity helpers (`isVerbose()`, `phase()`,
+  `divider()`) and subprocess output filtering (`LocalNodeManager` stdout/
+  stderr handlers, critical-signal escalation regardless of verbosity).
+
+### Changed
+
+- Local-node startup output is now spinner-driven. Routine `[Node] ...`
+  chatter from the `movement` subprocess is hidden by default; pass `-v` to
+  see it (muted gray `›` prefix). Critical signals (`panic`, `fatal`,
+  `address already in use`, `EADDRINUSE`) always surface as warnings
+  regardless of verbosity — the user is never silenced through a real failure.
+- Publisher's `aptos move build` and `aptos move publish` steps wrapped in
+  `withSpinner`. Their stdout/stderr passthroughs gated behind `isVerbose()`.
+- `commands/test.ts` orchestrator headers use `logger.phase` (replaces
+  ad-hoc bold + repeated rule lines).
+- `setupLocalTesting` opens with a `logger.phase` banner.
+- Subprocess `stderr` is no longer assumed to be an error. Movement CLI
+  emits informational progress messages on stderr ("Applying post startup
+  steps...", "Compiling, may take a little while...") alongside real errors.
+  Both stdout and stderr now follow the same verbosity gate; only lines
+  matching critical signals are escalated.
+
+### Fixed
+
+- `publish.yml` post-publish "Commit version bump back" step no longer fails
+  when `origin/main`'s `package.json` already matches the released version
+  (the typical release-via-PR flow). Previously the unconditional
+  `git stash push → checkout main → rebase → stash pop` dance produced
+  "No stash entries found" when there was no diff to stash and exited 1.
+  An early-exit guard now compares the tag's version to main's version and
+  exits cleanly when they match. The original stash/rebase/pop is preserved
+  for the edge case of a tag created from a feature branch whose version
+  bump never landed on main. Closes
+  [#174](https://github.com/gilbertsahumada/movehat/issues/174).
+
+### Internal
+
+- 26 raw `console.log` / `console.error` / `console.warn` callsites migrated
+  to the equivalent `logger.*` method across `fork/manager.ts`,
+  `fork/server.ts`, `fork/test.ts`, `core/config.ts`, `core/deployments.ts`,
+  `harness/script.ts`, `harness/codeObject.ts`. Secondary §9 sweep across
+  `commands/test-move.ts`, `helpers/move-tests.ts`, `core/AccountManager.ts`,
+  `commands/fork/serve.ts`, `helpers/version-check.ts` tracked in
+  [#223](https://github.com/gilbertsahumada/movehat/issues/223).
+- `formatters.divider` unexported from the wildcard `ui/` namespace (it
+  conflicted with the new `logger.divider`); the function stays accessible
+  as a local helper inside `formatters.ts` for `formatters.sectionHeader`.
+
+---
+
 ## [0.2.2] - 2026-05-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,69 @@ How to apply: when ready to merge, the sequence is **always**:
 
 If step 1 is skipped, the merge violates this rule and a retroactive review must be posted on the merged PR plus any follow-up sub-PRs needed.
 
+## 9. Console UX conventions
+
+**Every line that reaches the user's terminal from `packages/movehat/src/` is classified into one of five sources, and each source has a fixed visual treatment.** This rule applies to every PR that touches `src/`.
+
+### The five sources
+
+```
+┌─ System (Movehat lifecycle)      → logger.* with semantic prefix
+│  ▸ in-progress (cyan)
+│  ✔ success     (green)
+│  ✖ error       (red)
+│  ⚠ warning     (yellow)
+│  i info        (blue)
+│
+├─ Subprocess (movement node, aptos move) → muted gray, hidden by default
+│  › <output>    (gray, only with -v)
+│  ✖ <stderr>    (red, always shown — real signal)
+│
+├─ User code (their console.log in tests/ or scripts/)
+│                                  → passthrough, no prefix, no styling
+│
+├─ SDK deprecation warnings        → filter known noise (AIP-80 done in 0.2.2);
+│                                     surface real warnings via logger.warning
+│
+└─ Test framework (mocha reporter) → passthrough; mocha owns its formatting
+```
+
+### Hard rules
+
+- **No raw `console.log` / `console.error` / `console.warn` in `packages/movehat/src/` outside `src/ui/`.** Every system message goes through a `logger.*` method. The only exception is intentional subprocess passthrough — and even those route through the verbosity gate described below.
+- **No raw subprocess stdout passthrough.** When a child process (`movement`, `aptos move`) emits to stdout, the wrapper must filter:
+  - Hide routine chatter unless `isVerbose()` returns true.
+  - Always surface lines matching critical signals (`panic`, `fatal`, `address already in use`, `EADDRINUSE`) — the user is never silenced through a real failure.
+  - Always surface stderr that is not a benign `WARN`-only line — real signal beats chatter.
+  - Pattern to copy: `src/node/LocalNodeManager.ts:147-180` and `src/core/Publisher.ts` (build + publish wrappers).
+- **Any operation that empirically takes ≥3s in normal use MUST be wrapped in a spinner.** Use `withSpinner` (`src/ui/spinner.ts:73`) for short labelled ops, or `withTimedSpinner` (`src/ui/spinner.ts:106`) for long ops where the user wants live elapsed-time feedback. Short ops (<3s) use `logger.step` + `logger.success`.
+- **Top-level phase boundaries use `logger.phase(title)`.** It renders a `━` rule + indented bold title + `━` rule. Close phases with `logger.success(...)` or `logger.error(...)`. Use `logger.divider()` for a standalone rule between sub-sections of the same phase.
+
+### Verbosity contract
+
+- Default (no flag): quiet mode. System logs + critical subprocess signals only.
+- `-v` / `--verbose` global CLI flag: includes subprocess stdout with muted gray `›` prefix.
+- `MOVEHAT_VERBOSE=1` env var: equivalent to `-v`, lets shell-script callers opt in before the CLI parses args.
+- `NO_COLOR=1` or non-TTY: auto-degrades to plain text via `shouldUseColor()` (`src/ui/colors.ts:13`); spinners auto-disable so piped output stays line-based and parseable by CI.
+
+### Templates exception
+
+Files under `packages/movehat/src/templates/**` are scaffolding that ships to user projects. They use raw `console.log` on purpose — that is the API end-users themselves write in their own scripts and tests. Do not migrate template files to `logger.*`.
+
+### How to apply
+
+Before opening a PR that touches `src/`, run:
+
+```bash
+grep -rn "console\.\(log\|error\|warn\)" packages/movehat/src/ \
+  --include="*.ts" \
+  | grep -v __tests__ \
+  | grep -v "src/ui/" \
+  | grep -v "src/templates/"
+```
+
+Every match must either route through a verbosity gate (subprocess passthrough) or be migrated to `logger.*`. New ad-hoc `console.log("...")` calls are a §9 violation and must be fixed before merge.
+
 ---
 
 ## Project-Specific Context

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {

--- a/packages/movehat/src/cli.ts
+++ b/packages/movehat/src/cli.ts
@@ -50,6 +50,7 @@ program
   .version(version)
   .option('--network <name>', 'Network to use (testnet, mainnet, local, etc.)')
   .option('--redeploy', 'Force redeploy even if already deployed')
+  .option('-v, --verbose', 'Show subprocess output (movement node, aptos move) for debugging')
   .hook('preAction', (thisCommand) => {
     // Store network option in environment for commands to access
     const options = thisCommand.opts();
@@ -58,6 +59,9 @@ program
     }
     if (options.redeploy) {
       process.env.MH_CLI_REDEPLOY = 'true';
+    }
+    if (options.verbose) {
+      process.env.MOVEHAT_VERBOSE = '1';
     }
   });
 

--- a/packages/movehat/src/commands/compile.ts
+++ b/packages/movehat/src/commands/compile.ts
@@ -2,7 +2,8 @@ import fs from "fs";
 import path from "path";
 import { loadUserConfig } from "../core/config.js";
 import { validatePathSafety } from "../core/shell.js";
-import { logger } from "../ui/index.js";
+import { logger, isVerbose } from "../ui/index.js";
+import { withSpinner } from "../ui/spinner.js";
 import { runCli } from "../utils/runCli.js";
 
 /**
@@ -195,24 +196,32 @@ async function runMovementBuild(
   args: readonly string[],
   cwd: string
 ): Promise<void> {
-  // Use throwOnNonZeroExit:false so we can log stdout/stderr in both
-  // success and failure paths, matching the behavior of the previous
-  // exec-based helper.
-  const result = await runCli(
-    {
-      command: "movement",
-      args,
-      cwd,
-      timeoutMs: 120000, // 2 minutes for git dependency downloads
-    },
-    { throwOnNonZeroExit: false }
+  // Use throwOnNonZeroExit:false so we can route stdout/stderr through
+  // the §9 verbosity gate ourselves. On failure we surface everything;
+  // on success the chatter is hidden unless isVerbose().
+  const result = await withSpinner("Compiling Move package", () =>
+    runCli(
+      {
+        command: "movement",
+        args,
+        cwd,
+        timeoutMs: 120000, // 2 minutes for git dependency downloads
+      },
+      { throwOnNonZeroExit: false }
+    ),
   );
 
-  if (result.stdout) console.log(result.stdout.trim());
-  if (result.stderr) console.error(result.stderr.trim());
-
   if (result.exitCode !== 0) {
+    // Build failed — show the user everything we have so they can debug.
+    if (result.stdout) logger.plain(result.stdout.trim());
+    if (result.stderr) logger.plain(result.stderr.trim());
     throw new Error(`movement move build exited with code ${result.exitCode}`);
+  }
+
+  // Success path: route output through the verbosity gate.
+  if (isVerbose()) {
+    if (result.stdout) logger.info(result.stdout.trim(), 2);
+    if (result.stderr) logger.info(result.stderr.trim(), 2);
   }
 }
 

--- a/packages/movehat/src/commands/test.ts
+++ b/packages/movehat/src/commands/test.ts
@@ -97,8 +97,7 @@ async function showTestMenu(): Promise<TestType | undefined> {
  */
 async function runMoveTestsOnly(filter?: string): Promise<void> {
   logger.newline();
-  console.log(colors.bold("Move Unit Tests"));
-  console.log(colors.muted("─".repeat(50)));
+  logger.phase("Move Unit Tests");
   logger.newline();
 
   try {
@@ -118,8 +117,7 @@ async function runMoveTestsOnly(filter?: string): Promise<void> {
  */
 async function runTypeScriptTestsOnly(watch: boolean = false): Promise<void> {
   logger.newline();
-  console.log(colors.bold("TypeScript Integration Tests"));
-  console.log(colors.muted("─".repeat(50)));
+  logger.phase("TypeScript Integration Tests");
 
   if (!watch) {
     logger.newline();
@@ -146,13 +144,11 @@ async function runTypeScriptTestsOnly(watch: boolean = false): Promise<void> {
  */
 async function runAllTests(filter?: string): Promise<void> {
   logger.newline();
-  console.log(colors.bold("Running All Tests"));
-  console.log(colors.muted("═".repeat(50)));
+  logger.phase("Running All Tests");
 
   // Section 1: Move Tests
   logger.newline();
-  console.log(`${colors.brandBright("1.")} ${colors.bold("Move Unit Tests")}`);
-  console.log(colors.muted("─".repeat(50)));
+  logger.phase("1. Move Unit Tests");
   logger.newline();
 
   try {
@@ -163,28 +159,25 @@ async function runAllTests(filter?: string): Promise<void> {
   } catch (error) {
     logger.newline();
     logger.error("Move tests failed");
-    console.log(colors.muted("═".repeat(50)));
+    logger.divider();
     process.exit(1);
   }
 
   // Section 2: TypeScript Tests
   logger.newline();
-  console.log(colors.muted("═".repeat(50)));
-  logger.newline();
-  console.log(`${colors.brandBright("2.")} ${colors.bold("TypeScript Integration Tests")}`);
-  console.log(colors.muted("─".repeat(50)));
+  logger.phase("2. TypeScript Integration Tests");
   logger.newline();
 
   try {
     await runTypeScriptTests(false);
     logger.newline();
-    console.log(colors.muted("═".repeat(50)));
+    logger.divider();
     logger.newline();
     logger.success("All tests passed!");
     logger.newline();
   } catch (error) {
     logger.newline();
-    console.log(colors.muted("═".repeat(50)));
+    logger.divider();
     const message = error instanceof Error ? error.message : String(error);
     logger.error(message);
     process.exit(1);
@@ -198,8 +191,8 @@ async function runTypeScriptTests(watch: boolean = false): Promise<void> {
   const testDir = join(process.cwd(), "tests");
 
   if (!existsSync(testDir)) {
-    console.log(`${colors.muted(symbols.info)} No TypeScript tests found ${colors.muted("(tests/ directory not found)")}`);
-    console.log(`   ${colors.muted("Skipping TypeScript tests...")}`);
+    logger.plain(`${colors.muted(symbols.info)} No TypeScript tests found ${colors.muted("(tests/ directory not found)")}`);
+    logger.plain(`   ${colors.muted("Skipping TypeScript tests...")}`);
     logger.newline();
     return;
   }
@@ -208,7 +201,7 @@ async function runTypeScriptTests(watch: boolean = false): Promise<void> {
 
   if (!existsSync(mochaPath)) {
     logger.error("Mocha not found in project dependencies");
-    console.log(`   ${colors.muted("Install it with:")} ${colors.info("npm install --save-dev mocha")}`);
+    logger.plain(`   ${colors.muted("Install it with:")} ${colors.info("npm install --save-dev mocha")}`);
     throw new Error("Mocha not found");
   }
 
@@ -232,7 +225,7 @@ async function runTypeScriptTests(watch: boolean = false): Promise<void> {
       process.exit(1);
     });
 
-    console.log(`${colors.info(symbols.info)} Watch mode active. Press Ctrl+C to exit.`);
+    logger.plain(`${colors.info(symbols.info)} Watch mode active. Press Ctrl+C to exit.`);
     logger.newline();
     return;
   }

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -10,7 +10,8 @@ import {
 import { validatePathSafety } from "./shell.js";
 import { CliExecutionError, ModuleAlreadyDeployedError, PostPublishError } from "../errors.js";
 import { runCli } from "../utils/runCli.js";
-import { logger } from "../ui/index.js";
+import { logger, isVerbose } from "../ui/index.js";
+import { withSpinner } from "../ui/spinner.js";
 import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
 import {
   writeTempKeyFile,
@@ -122,19 +123,23 @@ export class Publisher {
           : [];
 
       // Build first with named addresses
-      logger.step("Building package...");
-      const buildResult = await runCli(
-        {
-          command: "movement",
-          args: ["move", "build", "--package-dir", safeDir, ...namedAddrArgs],
-          timeoutMs: 120000, // 2 minutes for git dependency downloads
-        },
-        { adapter: this.deps.adapter }
+      const buildResult = await withSpinner(
+        "Building package",
+        () =>
+          runCli(
+            {
+              command: "movement",
+              args: ["move", "build", "--package-dir", safeDir, ...namedAddrArgs],
+              timeoutMs: 120000, // 2 minutes for git dependency downloads
+            },
+            { adapter: this.deps.adapter }
+          ),
       );
-      if (buildResult.stdout) console.log(buildResult.stdout.trim());
+      if (isVerbose() && buildResult.stdout) {
+        logger.info(buildResult.stdout.trim(), 2);
+      }
 
       // Publish using direct parameters (avoid config file issues)
-      logger.step("Publishing to blockchain...");
 
       // Format the private key into AIP-80 shape so the Movement CLI
       // doesn't emit its raw-hex deprecation warning. `formatPrivateKey`
@@ -179,31 +184,35 @@ export class Publisher {
         // stdout/stderr redaction still applies as defense in depth
         // for any `ed25519-priv-…` substring that surfaces in CLI
         // output (Movement CLI sometimes echoes the key on error).
-        const publishResult = await runCli(
-          {
-            command: "movement",
-            args: [
-              "move",
-              "publish",
-              "--package-dir",
-              safeDir,
-              "--url",
-              config.rpc,
-              "--private-key-file",
-              keyFilePath,
-              "--sender-account",
-              deployerAddress,
-              "--assume-yes",
-              ...namedAddrArgs,
-            ],
-            timeoutMs: 120000, // 2 minutes for blockchain transactions
-          },
-          { adapter: this.deps.adapter }
+        const publishResult = await withSpinner(
+          "Publishing to blockchain",
+          () =>
+            runCli(
+              {
+                command: "movement",
+                args: [
+                  "move",
+                  "publish",
+                  "--package-dir",
+                  safeDir,
+                  "--url",
+                  config.rpc,
+                  "--private-key-file",
+                  keyFilePath,
+                  "--sender-account",
+                  deployerAddress,
+                  "--assume-yes",
+                  ...namedAddrArgs,
+                ],
+                timeoutMs: 120000, // 2 minutes for blockchain transactions
+              },
+              { adapter: this.deps.adapter }
+            ),
         );
         publishOut = publishResult.stdout;
         publishErr = publishResult.stderr;
-        if (publishOut) console.log(publishOut.trim());
-        if (publishErr) console.error(publishErr.trim());
+        if (isVerbose() && publishOut) logger.info(publishOut.trim(), 2);
+        if (publishErr) logger.error(publishErr.trim(), 2);
       } finally {
         // Unlink the temp key file via the observable cleanup helper.
         // ENOENT and other already-gone outcomes are benign (null).
@@ -279,7 +288,7 @@ export class Publisher {
       if (error instanceof CliExecutionError) {
         // stdout/stderr are already redacted by runCli before reaching here,
         // so this branch is safe to log verbatim.
-        if (error.stdoutPreview) console.log(error.stdoutPreview);
+        if (error.stdoutPreview) logger.info(error.stdoutPreview, 2);
         logger.error(`Failed to publish module: ${error.message}\n${error.stderr}`);
       } else {
         // Preserve existing behaviour for non-CLI errors (filesystem write

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -211,8 +211,14 @@ export class Publisher {
         );
         publishOut = publishResult.stdout;
         publishErr = publishResult.stderr;
+        // Both stdout and stderr from the publish subprocess are gated
+        // behind isVerbose() — Movement CLI emits progress to both
+        // streams ("Compiling, may take a little while..."), so a
+        // visible stderr line is not by itself a failure signal. The
+        // surrounding withSpinner converts the runCli throw on real
+        // failure into the visible spinner.fail() output instead.
         if (isVerbose() && publishOut) logger.info(publishOut.trim(), 2);
-        if (publishErr) logger.error(publishErr.trim(), 2);
+        if (isVerbose() && publishErr) logger.info(publishErr.trim(), 2);
       } finally {
         // Unlink the temp key file via the observable cleanup helper.
         // ENOENT and other already-gone outcomes are benign (null).

--- a/packages/movehat/src/core/config.ts
+++ b/packages/movehat/src/core/config.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { existsSync, statSync } from "fs";
 import { Account, Ed25519PrivateKey, PrivateKey, PrivateKeyVariants } from "@aptos-labs/ts-sdk";
 import { MovehatConfig, MovehatUserConfig } from "../types/config.js";
+import { logger } from "../ui/index.js";
 
 interface ConfigCacheEntry {
   mtimeMs: number;
@@ -132,7 +133,7 @@ export async function resolveNetworkConfig(
       url: "https://testnet.movementnetwork.xyz/v1",
       chainId: "testnet",
     };
-    console.log(`testnet not found in config - using default Movement testnet configuration`);
+    logger.info("testnet not found in config - using default Movement testnet configuration");
   }
 
   // Special case: Auto-generate config for local fork server
@@ -141,7 +142,7 @@ export async function resolveNetworkConfig(
       url: "http://localhost:8080/v1",
       chainId: "local",
     };
-    console.log(`Local network not found in config - using default fork server configuration`);
+    logger.info("Local network not found in config - using default fork server configuration");
   }
 
   if (!networkConfig) {
@@ -187,8 +188,10 @@ export async function resolveNetworkConfig(
       // 3. Deterministic = consistent test results
       const testPrivateKey = "0x0000000000000000000000000000000000000000000000000000000000000001";
       accounts = [testPrivateKey];
-      console.log(`\n[TESTNET] Using auto-generated test account (safe for testing only)`);
-      console.log(`[TESTNET] For mainnet, set PRIVATE_KEY in .env\n`);
+      logger.newline();
+      logger.warning("[TESTNET] Using auto-generated test account (safe for testing only)");
+      logger.warning("[TESTNET] For mainnet, set PRIVATE_KEY in .env");
+      logger.newline();
     } else {
       // For any other network (especially mainnet), REQUIRE explicit configuration
       // This prevents accidentally using the test key on production networks
@@ -273,8 +276,8 @@ function deriveAccountAddress(privateKeyHex: string | undefined): string {
     // The private key may have come from several sources (network.accounts,
     // global accounts, PRIVATE_KEY env, auto-generated testnet key). Keep
     // the hint generic so it never points at the wrong source.
-    console.warn(
-      `[movehat] Could not derive account address from the resolved private key: ${
+    logger.warning(
+      `Could not derive account address from the resolved private key: ${
         (err as Error).message
       }. Verify the key configured for this network is a valid Ed25519 private key (with or without the "ed25519-priv-" prefix).`
     );

--- a/packages/movehat/src/core/deployments.ts
+++ b/packages/movehat/src/core/deployments.ts
@@ -86,9 +86,9 @@ export function saveDeployment(deployment: DeploymentInfo): void {
       `Deployment saved: deployments/${deployment.network}/${deployment.moduleName}.json`
     );
   } catch (error) {
-    console.error(
-      `Failed to save deployment for ${deployment.moduleName} on ${deployment.network} at ${filePath}:`,
-      error
+    const msg = error instanceof Error ? error.message : String(error);
+    logger.error(
+      `Failed to save deployment for ${deployment.moduleName} on ${deployment.network} at ${filePath}: ${msg}`
     );
     throw error;
   }
@@ -110,7 +110,8 @@ export function loadDeployment(network: string, moduleName: string): DeploymentI
     const content = readFileSync(filePath, "utf-8");
     return JSON.parse(content) as DeploymentInfo;
   } catch (error) {
-    console.error(`Failed to load deployment for ${moduleName} on ${network}:`, error);
+    const msg = error instanceof Error ? error.message : String(error);
+    logger.error(`Failed to load deployment for ${moduleName} on ${network}: ${msg}`);
     return null;
   }
 }

--- a/packages/movehat/src/fork/manager.ts
+++ b/packages/movehat/src/fork/manager.ts
@@ -89,7 +89,7 @@ export class ForkManager {
 
     this.storage.saveMetadata(this.metadata);
 
-    console.log(`✓ Fork initialized at ledger version ${ledgerInfo.ledger_version}`);
+    logger.success(`Fork initialized at ledger version ${ledgerInfo.ledger_version}`);
   }
 
   /**
@@ -123,7 +123,7 @@ export class ForkManager {
         throw new Error('Fork not initialized. Call initialize() or load() first.');
       }
 
-      console.log(`  Fetching account ${normalizedAddress} from network...`);
+      logger.info(`Fetching account ${normalizedAddress} from network...`, 2);
       const accountData = await this.apiClient.getAccount(normalizedAddress);
 
       accountState = {
@@ -132,7 +132,7 @@ export class ForkManager {
       };
 
       this.storage.saveAccount(normalizedAddress, accountState);
-      console.log(`  ✓ Cached account ${normalizedAddress}`);
+      logger.success(`Cached account ${normalizedAddress}`, 2);
     }
 
     return accountState;
@@ -148,14 +148,14 @@ export class ForkManager {
         throw new Error('Fork not initialized. Call initialize() or load() first.');
       }
 
-      console.log(`  Fetching resource ${resourceType} for ${normalizedAddress}...`);
+      logger.info(`Fetching resource ${resourceType} for ${normalizedAddress}...`, 2);
 
       try {
         const resourceData = await this.apiClient.getAccountResource(normalizedAddress, resourceType);
         resource = resourceData.data;
 
         this.storage.saveResource(normalizedAddress, resourceType, resource);
-        console.log(`  ✓ Cached resource ${resourceType}`);
+        logger.success(`Cached resource ${resourceType}`, 2);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         if (msg.includes('404')) {
@@ -178,7 +178,7 @@ export class ForkManager {
         throw new Error('Fork not initialized. Call initialize() or load() first.');
       }
 
-      console.log(`  Fetching all resources for ${normalizedAddress}...`);
+      logger.info(`Fetching all resources for ${normalizedAddress}...`, 2);
       const resourcesList = await this.apiClient.getAccountResources(normalizedAddress);
 
       resources = {};
@@ -187,7 +187,7 @@ export class ForkManager {
       }
 
       this.storage.saveAllResources(normalizedAddress, resources);
-      console.log(`  ✓ Cached ${Object.keys(resources).length} resources`);
+      logger.success(`Cached ${Object.keys(resources).length} resources`, 2);
     }
 
     return resources;
@@ -196,7 +196,7 @@ export class ForkManager {
   async setResource(address: string, resourceType: string, data: unknown): Promise<void> {
     const normalizedAddress = normalizeAddress(address);
     this.storage.saveResource(normalizedAddress, resourceType, data);
-    console.log(`  ✓ Updated resource ${resourceType} for ${normalizedAddress}`);
+    logger.success(`Updated resource ${resourceType} for ${normalizedAddress}`, 2);
   }
 
   /** Adds to the existing balance rather than replacing it. */
@@ -258,7 +258,7 @@ export class ForkManager {
       this.storage.saveAccount(normalizedAddress, account);
     }
 
-    console.log(`  ✓ Funded ${normalizedAddress} with ${amount} coins`);
+    logger.success(`Funded ${normalizedAddress} with ${amount} coins`, 2);
   }
 
   listAccounts(): string[] {
@@ -335,7 +335,7 @@ export class ForkManager {
       };
 
       this.storage.saveAccount(normalizedAddress, newAccount);
-      console.log(`  ✓ Created new account ${normalizedAddress}`);
+      logger.success(`Created new account ${normalizedAddress}`, 2);
 
       return newAccount;
     }

--- a/packages/movehat/src/fork/server.ts
+++ b/packages/movehat/src/fork/server.ts
@@ -1,6 +1,7 @@
 import http from 'http';
 import { URL } from 'url';
 import { ForkManager } from './manager.js';
+import { logger } from '../ui/index.js';
 
 export interface ForkServerOptions {
   /**
@@ -66,16 +67,17 @@ export class ForkServer {
     this.forkManager.load();
     const metadata = this.forkManager.getMetadata();
 
-    console.log(`\nStarting Fork Server...`);
-    console.log(`  Network: ${metadata.network}`);
-    console.log(`  Chain ID: ${metadata.chainId}`);
-    console.log(`  Ledger Version: ${metadata.ledgerVersion}`);
-    console.log(`  Forked at: ${metadata.createdAt}`);
+    logger.newline();
+    logger.phase("Fork Server");
+    logger.kv("Network", metadata.network, 2);
+    logger.kv("Chain ID", String(metadata.chainId), 2);
+    logger.kv("Ledger Version", String(metadata.ledgerVersion), 2);
+    logger.kv("Forked at", metadata.createdAt, 2);
 
     this.server = http.createServer((req, res) => {
       this.handleRequest(req, res).catch((error) => {
         // Log full error server-side for diagnostics
-        console.error(`Error handling request:`, error);
+        logger.error(`Error handling request: ${error instanceof Error ? error.message : String(error)}`);
 
         // Only send response if headers haven't been sent yet
         if (!res.headersSent) {
@@ -124,13 +126,15 @@ export class ForkServer {
             : isIpv6
               ? `[${this.host}]`
               : this.host;
-        console.log(`\nFork Server listening on http://${displayHost}:${this.port}`);
-        console.log(`  Bound interface: ${this.host}`);
-        console.log(`  Ledger Info: http://${displayHost}:${this.port}/v1/`);
+        logger.newline();
+        logger.success(`Fork Server listening on http://${displayHost}:${this.port}`);
+        logger.kv("Bound interface", this.host, 2);
+        logger.kv("Ledger Info", `http://${displayHost}:${this.port}/v1/`, 2);
         if (this.host === '0.0.0.0') {
-          console.warn(`  Server is bound to 0.0.0.0 — fork state is reachable from the LAN.`);
+          logger.warning("Server is bound to 0.0.0.0 — fork state is reachable from the LAN.", 2);
         }
-        console.log(`\nPress Ctrl+C to stop`);
+        logger.newline();
+        logger.info("Press Ctrl+C to stop");
         resolve();
       });
     });
@@ -143,7 +147,8 @@ export class ForkServer {
     return new Promise((resolve) => {
       if (this.server) {
         this.server.close(() => {
-          console.log('\nFork Server stopped');
+          logger.newline();
+          logger.success("Fork Server stopped");
           resolve();
         });
       } else {
@@ -172,8 +177,9 @@ export class ForkServer {
     const url = new URL(req.url || '/', `http://localhost:${this.port}`);
     const pathname = url.pathname;
 
-    // Log request
-    console.log(`[${new Date().toISOString()}] ${req.method} ${pathname}`);
+    // Log request — plain so the fork-server access log retains its
+    // grep-friendly line shape (timestamp + method + path, no symbol).
+    logger.plain(`[${new Date().toISOString()}] ${req.method} ${pathname}`);
 
     this.applyCors(req, res);
 
@@ -216,7 +222,7 @@ export class ForkServer {
       }
     } catch (error) {
       // Log full error server-side for diagnostics
-      console.error('Error handling request:', error);
+      logger.error(`Error handling request: ${error instanceof Error ? error.message : String(error)}`);
 
       // Send generic error to client (don't expose internal details)
       this.sendError(res, 500, 'Internal server error');

--- a/packages/movehat/src/fork/test.ts
+++ b/packages/movehat/src/fork/test.ts
@@ -2,6 +2,7 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { runCli } from '../utils/runCli.js';
 import type { ChildProcessAdapter } from '../utils/childProcessAdapter.js';
+import { logger } from '../ui/index.js';
 
 export interface SnapshotOptions {
   path?: string;
@@ -40,7 +41,7 @@ export async function snapshot(options: SnapshotOptions = {}): Promise<string> {
   const name = options.name || `snapshot-${Date.now()}`;
   const snapshotPath = options.path || join(process.cwd(), '.movehat', 'snapshots', name);
 
-  console.log(`📸 Creating snapshot: ${name}...`);
+  logger.info(`Creating snapshot: ${name}...`);
 
   try {
     // Initialize fork/snapshot using aptos CLI.
@@ -68,7 +69,7 @@ export async function snapshot(options: SnapshotOptions = {}): Promise<string> {
       throw new Error('Snapshot directory was not created');
     }
 
-    console.log(`   ✓ Snapshot created at ${snapshotPath}`);
+    logger.success(`Snapshot created at ${snapshotPath}`, 2);
     return snapshotPath;
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);

--- a/packages/movehat/src/harness/codeObject.ts
+++ b/packages/movehat/src/harness/codeObject.ts
@@ -265,8 +265,11 @@ async function executeMovementMoveObject(
         { adapter: opts.adapter }
       );
       deployOut = result.stdout;
+      // Both streams gated behind isVerbose(); see §9 — stream channel
+      // is not by itself a failure signal. Real failures throw via
+      // CliExecutionError and are surfaced from the catch below.
       if (isVerbose() && result.stdout) logger.info(result.stdout.trim(), 2);
-      if (result.stderr) logger.error(result.stderr.trim(), 2);
+      if (isVerbose() && result.stderr) logger.info(result.stderr.trim(), 2);
     } finally {
       // Unlink via the observable helper — emit a warning if the file
       // could not be removed AND still exists on disk (private key

--- a/packages/movehat/src/harness/codeObject.ts
+++ b/packages/movehat/src/harness/codeObject.ts
@@ -20,7 +20,7 @@ import {
 } from "../errors.js";
 import { runCli } from "../utils/runCli.js";
 import { parseTxHash } from "../utils/parseCliOutput.js";
-import { logger } from "../ui/index.js";
+import { logger, isVerbose } from "../ui/index.js";
 import {
   writeTempKeyFile,
   removeKeyFile,
@@ -206,7 +206,7 @@ async function executeMovementMoveObject(
       },
       { adapter: opts.adapter }
     );
-    if (buildResult.stdout) console.log(buildResult.stdout.trim());
+    if (isVerbose() && buildResult.stdout) logger.info(buildResult.stdout.trim(), 2);
 
     // Format the private key into AIP-80 shape so the Movement CLI
     // doesn't emit its raw-hex deprecation warning. `formatPrivateKey`
@@ -265,8 +265,8 @@ async function executeMovementMoveObject(
         { adapter: opts.adapter }
       );
       deployOut = result.stdout;
-      if (result.stdout) console.log(result.stdout.trim());
-      if (result.stderr) console.error(result.stderr.trim());
+      if (isVerbose() && result.stdout) logger.info(result.stdout.trim(), 2);
+      if (result.stderr) logger.error(result.stderr.trim(), 2);
     } finally {
       // Unlink via the observable helper — emit a warning if the file
       // could not be removed AND still exists on disk (private key
@@ -336,7 +336,7 @@ async function executeMovementMoveObject(
       throw error;
     }
     if (error instanceof CliExecutionError) {
-      if (error.stdoutPreview) console.log(error.stdoutPreview);
+      if (error.stdoutPreview) logger.info(error.stdoutPreview, 2);
       logger.error(
         `Failed to ${subcommand === "deploy-object" ? "deploy" : "upgrade"} module: ${error.message}\n${error.stderr}`
       );

--- a/packages/movehat/src/harness/script.ts
+++ b/packages/movehat/src/harness/script.ts
@@ -132,8 +132,11 @@ export async function runMoveScript(
         { adapter: options.adapter }
       );
       scriptOut = result.stdout;
+      // Both streams gated behind isVerbose(); Movement CLI uses
+      // stderr for progress messages too. Real failures throw via
+      // CliExecutionError and are surfaced from the catch below.
       if (isVerbose() && result.stdout) logger.info(result.stdout.trim(), 2);
-      if (result.stderr) logger.error(result.stderr.trim(), 2);
+      if (isVerbose() && result.stderr) logger.info(result.stderr.trim(), 2);
     } finally {
       // Observable cleanup — emit a warning if the unlink failed and
       // the file is still on disk (private key would persist silently

--- a/packages/movehat/src/harness/script.ts
+++ b/packages/movehat/src/harness/script.ts
@@ -10,7 +10,7 @@ import { validatePathSafety } from "../core/shell.js";
 import { CliExecutionError } from "../errors.js";
 import { runCli } from "../utils/runCli.js";
 import { parseTxHash } from "../utils/parseCliOutput.js";
-import { logger } from "../ui/index.js";
+import { logger, isVerbose } from "../ui/index.js";
 import {
   writeTempKeyFile,
   removeKeyFile,
@@ -132,8 +132,8 @@ export async function runMoveScript(
         { adapter: options.adapter }
       );
       scriptOut = result.stdout;
-      if (result.stdout) console.log(result.stdout.trim());
-      if (result.stderr) console.error(result.stderr.trim());
+      if (isVerbose() && result.stdout) logger.info(result.stdout.trim(), 2);
+      if (result.stderr) logger.error(result.stderr.trim(), 2);
     } finally {
       // Observable cleanup — emit a warning if the unlink failed and
       // the file is still on disk (private key would persist silently
@@ -167,7 +167,7 @@ export async function runMoveScript(
     return out;
   } catch (error) {
     if (error instanceof CliExecutionError) {
-      if (error.stdoutPreview) console.log(error.stdoutPreview);
+      if (error.stdoutPreview) logger.info(error.stdoutPreview, 2);
       logger.error(`Failed to run Move script: ${error.message}\n${error.stderr}`);
     } else {
       const err = error instanceof Error ? error : new Error(String(error));

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -95,9 +95,9 @@ export async function setupLocalTesting(
   const accountLabels = options.accountLabels || ["deployer", "alice", "bob"];
 
   logger.newline();
-  logger.step("Setting up local testing environment...");
-  logger.plain(`   Mode: ${mode}`);
-  logger.plain(`   Accounts: ${accountLabels.join(", ")}`);
+  logger.phase("Setting up local testing environment");
+  logger.kv("Mode", mode, 2);
+  logger.kv("Accounts", accountLabels.join(", "), 2);
   logger.newline();
 
   if (mode === 'local-node') {

--- a/packages/movehat/src/node/LocalNodeManager.ts
+++ b/packages/movehat/src/node/LocalNodeManager.ts
@@ -166,15 +166,20 @@ export class LocalNodeManager {
         this.spawned.stderr.on("data", (data: Buffer) => {
           const output = data.toString().trim();
           if (!output) return;
-          // WARN-only lines are noise from healthy startup; everything
-          // else on stderr is a real signal worth surfacing.
-          if (output.includes("WARN") && !CRITICAL_NODE_OUTPUT.test(output)) {
-            if (isVerbose()) {
-              console.error(colors.muted(`  ${symbols.pointer} ${output}`));
-            }
+          // Movement CLI uses stderr for both progress messages
+          // ("Applying post startup steps...", "Compiling...") and
+          // real errors. Stream channel alone isn't a reliable
+          // signal — gate routine lines behind verbosity, escalate
+          // anything matching CRITICAL_NODE_OUTPUT regardless.
+          if (CRITICAL_NODE_OUTPUT.test(output)) {
+            logger.error(output);
             return;
           }
-          logger.error(output);
+          if (isVerbose()) {
+            for (const line of output.split("\n")) {
+              if (line) console.error(`  ${colors.muted(symbols.pointer + " " + line)}`);
+            }
+          }
         });
       }
 

--- a/packages/movehat/src/node/LocalNodeManager.ts
+++ b/packages/movehat/src/node/LocalNodeManager.ts
@@ -6,7 +6,16 @@ import {
   type ChildProcessAdapter,
   type SpawnedProcess,
 } from "../utils/childProcessAdapter.js";
-import { logger } from "../ui/index.js";
+import { logger, isVerbose, colors, symbols } from "../ui/index.js";
+import { withTimedSpinner, withSpinner } from "../ui/spinner.js";
+
+/**
+ * Substrings that always surface from the movement subprocess regardless
+ * of verbosity. These are signals the user must see to debug a stuck
+ * startup (panic, fatal, address-in-use). Tested in
+ * __tests__/LocalNodeManager.test.ts to guard against silent regressions.
+ */
+const CRITICAL_NODE_OUTPUT = /panic|fatal|address already in use|EADDRINUSE/i;
 
 export interface LocalNodeOptions {
   testDir?: string;           // Directory for node data (default: .movehat/local-node)
@@ -86,7 +95,7 @@ export class LocalNodeManager {
    */
   async start(): Promise<LocalNodeInfo> {
     if (this.spawned) {
-      console.log("Local node already running");
+      logger.info("Local node already running");
       return this.getNodeInfo();
     }
 
@@ -98,11 +107,11 @@ export class LocalNodeManager {
 
     try {
       logger.newline();
-      logger.step("Starting local Movement node...");
-      logger.plain(`   Test directory: ${this.options.testDir}`);
-      logger.plain(`   RPC port: ${this.options.apiPort}`);
-      logger.plain(`   Faucet port: ${this.options.faucetPort}`);
-      logger.plain(`   Ready port: ${this.options.readyPort}`);
+      logger.step("Starting local Movement node");
+      logger.kv("Test directory", this.options.testDir, 2);
+      logger.kv("RPC port", String(this.options.apiPort), 2);
+      logger.kv("Faucet port", String(this.options.faucetPort), 2);
+      logger.kv("Ready port", String(this.options.readyPort), 2);
       logger.newline();
 
       // Clean state if force restart
@@ -133,20 +142,39 @@ export class LocalNodeManager {
         stdio: this.options.silent ? "ignore" : "pipe",
       });
 
-      // Handle process output
+      // Subprocess output handling (see §9 Console UX in CLAUDE.md):
+      //   - stdout chatter is hidden by default; gated by isVerbose()
+      //   - lines matching CRITICAL_NODE_OUTPUT always surface as warnings
+      //     so the user is never silenced through a real failure
+      //   - stderr is always surfaced (real signal), modulo benign WARN
+      //     lines that the movement binary emits during normal startup
       if (!this.options.silent && this.spawned.stdout && this.spawned.stderr) {
         this.spawned.stdout.on("data", (data: Buffer) => {
           const output = data.toString().trim();
-          if (output) {
-            console.log(`[Node] ${output}`);
+          if (!output) return;
+          if (CRITICAL_NODE_OUTPUT.test(output)) {
+            logger.warning(output);
+            return;
+          }
+          if (isVerbose()) {
+            for (const line of output.split("\n")) {
+              if (line) console.log(`  ${colors.muted(symbols.pointer + " " + line)}`);
+            }
           }
         });
 
         this.spawned.stderr.on("data", (data: Buffer) => {
           const output = data.toString().trim();
-          if (output && !output.includes("WARN")) {
-            console.error(`[Node Error] ${output}`);
+          if (!output) return;
+          // WARN-only lines are noise from healthy startup; everything
+          // else on stderr is a real signal worth surfacing.
+          if (output.includes("WARN") && !CRITICAL_NODE_OUTPUT.test(output)) {
+            if (isVerbose()) {
+              console.error(colors.muted(`  ${symbols.pointer} ${output}`));
+            }
+            return;
           }
+          logger.error(output);
         });
       }
 
@@ -161,11 +189,13 @@ export class LocalNodeManager {
         this.spawned = null;
       });
 
-      // Wait for node to be ready
-      logger.step("Waiting for node to be ready...");
-      await this.waitForReady(60000); // 60 second timeout
+      // Wait for node to be ready — wrapped in withTimedSpinner so the
+      // user sees live elapsed-time feedback while subprocess chatter is
+      // hidden in non-verbose mode.
+      await withTimedSpinner("Waiting for node to be ready", () =>
+        this.waitForReady(60000)
+      );
 
-      logger.success("Local Movement node is ready!");
       logger.newline();
 
       this.starting = false;
@@ -303,7 +333,9 @@ export class LocalNodeManager {
       }
 
       const result = await response.json();
-      logger.success(`Funded ${address} with ${amount} octas`, 2);
+      if (isVerbose()) {
+        logger.success(`Funded ${address} with ${amount} octas`, 2);
+      }
 
       return result;
     } catch (error) {
@@ -317,13 +349,15 @@ export class LocalNodeManager {
    */
   async fundAccounts(accounts: (Account | string)[], amount: number = 100_000_000): Promise<void> {
     logger.newline();
-    logger.step(`Funding ${accounts.length} accounts from local faucet...`);
-
-    for (const account of accounts) {
-      await this.fundAccount(account, amount);
-    }
-
-    logger.success("All accounts funded successfully");
+    await withSpinner(
+      `Funding ${accounts.length} accounts from local faucet`,
+      async () => {
+        for (const account of accounts) {
+          await this.fundAccount(account, amount);
+        }
+      },
+      `Funded ${accounts.length} accounts (${(amount / 1e8).toFixed(0)} APT each)`,
+    );
     logger.newline();
   }
 

--- a/packages/movehat/src/node/__tests__/LocalNodeManager.test.ts
+++ b/packages/movehat/src/node/__tests__/LocalNodeManager.test.ts
@@ -191,17 +191,9 @@ describe("LocalNodeManager — start / stop / lifecycle", () => {
     const proc = spawned[0]!;
     expect(proc.stdout!.listenerCount("data")).toBeGreaterThan(0);
     expect(proc.stderr!.listenerCount("data")).toBeGreaterThan(0);
-
-    // stderr non-WARN line goes through console.error (real signal — always surfaced).
-    proc.stderr!.emit("data", Buffer.from("real error\n"));
-    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("real error"));
-
-    // stderr WARN-only line is filtered in quiet mode.
-    errSpy.mockClear();
-    proc.stderr!.emit("data", Buffer.from("WARN something\n"));
-    expect(errSpy).not.toHaveBeenCalledWith(expect.stringContaining("WARN"));
-    // Detailed quiet/verbose filter behavior lives in the §9 describe
-    // block below; this test just locks the listener-wiring contract.
+    // Detailed filter behavior — what passes through vs what's gated
+    // behind isVerbose() — lives in the "§9 console UX" describe block
+    // below. This test only locks the listener-wiring contract.
   });
 
   it("force-restart cleans the test directory before spawn", async () => {
@@ -549,7 +541,7 @@ describe("LocalNodeManager — subprocess output filtering (§9 console UX)", ()
     expect(stdoutCalls).toContain("Loading aptos framework module");
   });
 
-  it("always surfaces real stderr errors via logger.error", async () => {
+  it("always surfaces critical stderr (panic/EADDRINUSE) via logger.error", async () => {
     const { adapter, spawned } = buildFakeAdapter();
     stubFetchAlwaysOk();
     const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
@@ -558,13 +550,13 @@ describe("LocalNodeManager — subprocess output filtering (§9 console UX)", ()
     const proc = spawned[0]!;
     errSpy.mockClear();
 
-    proc.stderr!.emit("data", Buffer.from("ERROR: failed to bind socket"));
+    proc.stderr!.emit("data", Buffer.from("thread panicked: failed to bind socket"));
 
     const stderrCalls = errSpy.mock.calls.flat().join(" ");
-    expect(stderrCalls).toContain("failed to bind socket");
+    expect(stderrCalls).toContain("panicked");
   });
 
-  it("suppresses benign WARN-only stderr in quiet mode", async () => {
+  it("hides routine progress stderr in quiet mode (Movement CLI emits progress to stderr too)", async () => {
     const { adapter, spawned } = buildFakeAdapter();
     stubFetchAlwaysOk();
     const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
@@ -573,9 +565,15 @@ describe("LocalNodeManager — subprocess output filtering (§9 console UX)", ()
     const proc = spawned[0]!;
     errSpy.mockClear();
 
+    // The movement subprocess emits progress messages to stderr that
+    // are NOT errors: "Applying post startup steps...", "Compiling,
+    // may take a little while...". Hiding stream channel from the
+    // user keeps the console clean.
+    proc.stderr!.emit("data", Buffer.from("Applying post startup steps..."));
     proc.stderr!.emit("data", Buffer.from("[WARN] deprecated config field"));
 
     const stderrCalls = errSpy.mock.calls.flat().join(" ");
+    expect(stderrCalls).not.toContain("Applying post startup steps");
     expect(stderrCalls).not.toContain("deprecated config field");
   });
 });

--- a/packages/movehat/src/node/__tests__/LocalNodeManager.test.ts
+++ b/packages/movehat/src/node/__tests__/LocalNodeManager.test.ts
@@ -181,7 +181,7 @@ describe("LocalNodeManager — start / stop / lifecycle", () => {
     expect(proc.stderr!.listenerCount("data")).toBe(0);
   });
 
-  it("start in non-silent mode wires stdout/stderr listeners that log events", async () => {
+  it("start in non-silent mode wires stdout/stderr listeners that respect §9 filtering", async () => {
     const { adapter, spawned } = buildFakeAdapter();
     stubFetchAlwaysOk();
     const mgr = new LocalNodeManager({ adapter, testDir: tmpDir, silent: false });
@@ -192,18 +192,16 @@ describe("LocalNodeManager — start / stop / lifecycle", () => {
     expect(proc.stdout!.listenerCount("data")).toBeGreaterThan(0);
     expect(proc.stderr!.listenerCount("data")).toBeGreaterThan(0);
 
-    // Drive a line through stdout — the manager's listener forwards to console.log.
-    proc.stdout!.emit("data", Buffer.from("local node ready\n"));
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("local node ready"));
-
-    // stderr non-WARN line goes through console.error.
+    // stderr non-WARN line goes through console.error (real signal — always surfaced).
     proc.stderr!.emit("data", Buffer.from("real error\n"));
     expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("real error"));
 
-    // stderr WARN line should be filtered (no error log).
+    // stderr WARN-only line is filtered in quiet mode.
     errSpy.mockClear();
     proc.stderr!.emit("data", Buffer.from("WARN something\n"));
     expect(errSpy).not.toHaveBeenCalledWith(expect.stringContaining("WARN"));
+    // Detailed quiet/verbose filter behavior lives in the §9 describe
+    // block below; this test just locks the listener-wiring contract.
   });
 
   it("force-restart cleans the test directory before spawn", async () => {
@@ -449,5 +447,135 @@ describe("LocalNodeManager — fundAccount", () => {
     await mgr.fundAccounts(["0x1", "0x2", "0x3"], 100);
     // 1 ready + 3 mint calls = 4 total.
     expect(fetchFn.mock.calls.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("LocalNodeManager — subprocess output filtering (§9 console UX)", () => {
+  let tmpDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "movehat-localnode-filter-"));
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    // Ensure quiet mode is the default for each test; the verbose tests
+    // set MOVEHAT_VERBOSE explicitly inside their own scope.
+    delete process.env.MOVEHAT_VERBOSE;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.MOVEHAT_VERBOSE;
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("hides routine stdout chatter from the movement node in quiet mode", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
+    await mgr.start();
+
+    const proc = spawned[0]!;
+    logSpy.mockClear();
+
+    // Push routine chatter — exactly the noise we used to spam to stdout.
+    proc.stdout!.emit("data", Buffer.from("Loading aptos framework module"));
+    proc.stdout!.emit("data", Buffer.from("Compiling Move bytecode"));
+    proc.stdout!.emit("data", Buffer.from("aptos_account: account created"));
+
+    // None of these should have reached stdout (no `[Node]` prefix, no
+    // muted gray `›` prefix). The only console.log calls that may arise
+    // are from the spinner mock falling back to plain text — but since
+    // ora auto-disables in non-TTY (vitest is non-TTY), even those are
+    // suppressed.
+    const stdoutCalls = logSpy.mock.calls.flat().join(" ");
+    expect(stdoutCalls).not.toContain("Loading aptos framework module");
+    expect(stdoutCalls).not.toContain("Compiling Move bytecode");
+    expect(stdoutCalls).not.toContain("aptos_account: account created");
+  });
+
+  it("always surfaces panic / fatal lines as warnings, even in quiet mode", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
+    await mgr.start();
+
+    const proc = spawned[0]!;
+    warnSpy.mockClear();
+
+    proc.stdout!.emit("data", Buffer.from("thread 'main' panicked at 'state corrupted'"));
+
+    const warnCalls = warnSpy.mock.calls.flat().join(" ");
+    expect(warnCalls).toContain("panicked");
+  });
+
+  it("surfaces 'address already in use' (port conflict) regardless of verbosity", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
+    await mgr.start();
+
+    const proc = spawned[0]!;
+    warnSpy.mockClear();
+
+    proc.stdout!.emit(
+      "data",
+      Buffer.from("error: address already in use: 127.0.0.1:8080"),
+    );
+
+    const warnCalls = warnSpy.mock.calls.flat().join(" ");
+    expect(warnCalls).toContain("address already in use");
+  });
+
+  it("surfaces stdout chatter with gray prefix in verbose mode", async () => {
+    process.env.MOVEHAT_VERBOSE = "1";
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
+    await mgr.start();
+
+    const proc = spawned[0]!;
+    logSpy.mockClear();
+
+    proc.stdout!.emit("data", Buffer.from("Loading aptos framework module"));
+
+    const stdoutCalls = logSpy.mock.calls.flat().join(" ");
+    expect(stdoutCalls).toContain("Loading aptos framework module");
+  });
+
+  it("always surfaces real stderr errors via logger.error", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
+    await mgr.start();
+
+    const proc = spawned[0]!;
+    errSpy.mockClear();
+
+    proc.stderr!.emit("data", Buffer.from("ERROR: failed to bind socket"));
+
+    const stderrCalls = errSpy.mock.calls.flat().join(" ");
+    expect(stderrCalls).toContain("failed to bind socket");
+  });
+
+  it("suppresses benign WARN-only stderr in quiet mode", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchAlwaysOk();
+    const mgr = new LocalNodeManager({ adapter, testDir: tmpDir });
+    await mgr.start();
+
+    const proc = spawned[0]!;
+    errSpy.mockClear();
+
+    proc.stderr!.emit("data", Buffer.from("[WARN] deprecated config field"));
+
+    const stderrCalls = errSpy.mock.calls.flat().join(" ");
+    expect(stderrCalls).not.toContain("deprecated config field");
   });
 });

--- a/packages/movehat/src/ui/__tests__/logger.test.ts
+++ b/packages/movehat/src/ui/__tests__/logger.test.ts
@@ -65,7 +65,7 @@ describe("logger.phase / logger.divider", () => {
     phase("Local Movement node");
     expect(logSpy).toHaveBeenCalledTimes(3);
 
-    const calls = logSpy.mock.calls.map((c) => String(c[0]));
+    const calls = logSpy.mock.calls.map((c: unknown[]) => String(c[0]));
     // The title line carries the supplied text after the two-space indent.
     expect(calls[1]).toContain("Local Movement node");
     // Top and bottom rules should be identical (same width, same color).

--- a/packages/movehat/src/ui/__tests__/logger.test.ts
+++ b/packages/movehat/src/ui/__tests__/logger.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { configureLogger, isVerbose, divider, phase } from "../logger.js";
+
+describe("logger — verbosity", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.MOVEHAT_VERBOSE;
+    // Start each test from a clean slate so prior runs cannot leak.
+    delete process.env.MOVEHAT_VERBOSE;
+    configureLogger({ verbosity: "normal" });
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MOVEHAT_VERBOSE;
+    } else {
+      process.env.MOVEHAT_VERBOSE = originalEnv;
+    }
+    configureLogger({ verbosity: "normal" });
+  });
+
+  it("defaults to non-verbose when MOVEHAT_VERBOSE is unset and config is normal", () => {
+    expect(isVerbose()).toBe(false);
+  });
+
+  it("returns true when MOVEHAT_VERBOSE=1 (env-driven path)", () => {
+    process.env.MOVEHAT_VERBOSE = "1";
+    expect(isVerbose()).toBe(true);
+  });
+
+  it("returns true when configureLogger({ verbosity: 'verbose' }) is set in-process", () => {
+    configureLogger({ verbosity: "verbose" });
+    expect(isVerbose()).toBe(true);
+  });
+
+  it("env var wins even when in-process config is normal (allows shell-script callers)", () => {
+    configureLogger({ verbosity: "normal" });
+    process.env.MOVEHAT_VERBOSE = "1";
+    expect(isVerbose()).toBe(true);
+  });
+
+  it("non-'1' MOVEHAT_VERBOSE values do not enable verbose mode", () => {
+    process.env.MOVEHAT_VERBOSE = "true";
+    expect(isVerbose()).toBe(false);
+    process.env.MOVEHAT_VERBOSE = "0";
+    expect(isVerbose()).toBe(false);
+  });
+});
+
+describe("logger.phase / logger.divider", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    configureLogger({ silent: false });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("phase prints three lines: top rule, indented title, bottom rule", () => {
+    phase("Local Movement node");
+    expect(logSpy).toHaveBeenCalledTimes(3);
+
+    const calls = logSpy.mock.calls.map((c) => String(c[0]));
+    // The title line carries the supplied text after the two-space indent.
+    expect(calls[1]).toContain("Local Movement node");
+    // Top and bottom rules should be identical (same width, same color).
+    expect(calls[0]).toBe(calls[2]);
+  });
+
+  it("divider prints a single muted rule line", () => {
+    divider();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const line = String(logSpy.mock.calls[0]?.[0] ?? "");
+    // The rule character is `━` (BOX DRAWINGS HEAVY HORIZONTAL).
+    expect(line).toMatch(/━+/);
+  });
+
+  it("phase and divider are silenced when configureLogger({ silent: true })", () => {
+    configureLogger({ silent: true });
+    phase("hidden phase");
+    divider();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/movehat/src/ui/formatters.ts
+++ b/packages/movehat/src/ui/formatters.ts
@@ -176,7 +176,7 @@ export const indent = (text: string, spaces: number): string => {
  * console.log(divider(40, '='));
  * // ========================================
  */
-export const divider = (
+const divider = (
   width: number = 60,
   char: string = symbols.line
 ): string => {

--- a/packages/movehat/src/ui/logger.ts
+++ b/packages/movehat/src/ui/logger.ts
@@ -207,6 +207,45 @@ export const section = (title: string): void => {
 };
 
 /**
+ * Width of the `━` rule used by `phase` and `divider`. Matched to a
+ * comfortable terminal width that fits in a side-by-side dev layout.
+ */
+const PHASE_RULE_WIDTH = 52;
+
+/**
+ * Single muted horizontal rule. Use to close out a phase or to
+ * visually separate output sections.
+ */
+export const divider = (): void => {
+  if (config.silent) return;
+  console.log(colors.muted('━'.repeat(PHASE_RULE_WIDTH)));
+};
+
+/**
+ * Phase header — renders a muted top rule, a bold brand-colored title
+ * indented two spaces, and a muted bottom rule. Use at top-level phase
+ * boundaries (local node start, deploy flow, test orchestrator
+ * sections) so the user can visually anchor where one phase ends and
+ * the next begins.
+ *
+ * @param title - Phase title (e.g. "Local Movement node")
+ *
+ * @example
+ * logger.phase('Local Movement node');
+ * // Renders:
+ * // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ * //   Local Movement node
+ * // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ */
+export const phase = (title: string): void => {
+  if (config.silent) return;
+  const rule = colors.muted('━'.repeat(PHASE_RULE_WIDTH));
+  console.log(rule);
+  console.log(`  ${colors.brandBright(title)}`);
+  console.log(rule);
+};
+
+/**
  * Key-value pair
  * Use for displaying structured data
  *
@@ -264,6 +303,8 @@ export const logger = {
   plain,
   newline,
   section,
+  phase,
+  divider,
   kv,
   item,
 };

--- a/packages/movehat/src/ui/logger.ts
+++ b/packages/movehat/src/ui/logger.ts
@@ -7,6 +7,14 @@ import { coloredSymbol, symbols } from './symbols.js';
 export type LogLevel = 'info' | 'success' | 'error' | 'warning' | 'debug';
 
 /**
+ * Verbosity level for subprocess output and gray-prefixed chatter.
+ * - `quiet`   — reserved; currently behaves like `normal`
+ * - `normal`  — default; system logs only, subprocess chatter hidden
+ * - `verbose` — surface subprocess stdout with a muted gray `›` prefix
+ */
+export type Verbosity = 'quiet' | 'normal' | 'verbose';
+
+/**
  * Logger configuration options
  */
 export interface LoggerConfig {
@@ -16,6 +24,8 @@ export interface LoggerConfig {
   level?: LogLevel;
   /** Include timestamps in log messages */
   timestamp?: boolean;
+  /** Verbosity level for subprocess output */
+  verbosity?: Verbosity;
 }
 
 /**
@@ -25,7 +35,17 @@ let config: LoggerConfig = {
   silent: false,
   level: 'info',
   timestamp: false,
+  verbosity: process.env.MOVEHAT_VERBOSE === '1' ? 'verbose' : 'normal',
 };
+
+/**
+ * Whether subprocess chatter should reach the user's terminal.
+ * Honors both the in-process config (set by the `-v` CLI flag's
+ * preAction hook) and the `MOVEHAT_VERBOSE=1` env var (which lets
+ * callers opt in before the CLI parses args, e.g. in shell scripts).
+ */
+export const isVerbose = (): boolean =>
+  config.verbosity === 'verbose' || process.env.MOVEHAT_VERBOSE === '1';
 
 /**
  * Configure logger globally
@@ -235,6 +255,7 @@ export const item = (text: string, indent: number = 0): void => {
  */
 export const logger = {
   configure: configureLogger,
+  isVerbose,
   info,
   success,
   error,

--- a/packages/movehat/src/ui/spinner.ts
+++ b/packages/movehat/src/ui/spinner.ts
@@ -104,6 +104,53 @@ export const withSpinner = async <T>(
 };
 
 /**
+ * Execute async task with a spinner that updates its label with
+ * elapsed seconds while the task runs. Use for long-running phases
+ * (local node startup, publish + tx wait) where the user wants
+ * visible progress feedback in lieu of subprocess chatter.
+ *
+ * Pairs with the `§9` console-UX convention: any phase that
+ * empirically takes ≥3s in normal use should wrap its body in
+ * `withTimedSpinner` so the terminal never goes silent while work
+ * happens.
+ *
+ * @param label - Stable label shown next to the spinner (e.g. "Starting node")
+ * @param task - Async function to execute
+ * @param indent - Number of spaces to indent (default: 0)
+ * @returns Promise resolving to task result
+ *
+ * @example
+ * await withTimedSpinner('Starting local node', async () => {
+ *   await this.waitForReady(60_000);
+ * });
+ * // Renders: ⠋ Starting local node — 0.0s ... ⠼ Starting local node — 14.2s
+ * // On success: ✔ Starting local node (14.2s)
+ * // On error:   ✖ <error.message>
+ */
+export const withTimedSpinner = async <T>(
+  label: string,
+  task: () => Promise<T>,
+  indent: number = 0
+): Promise<T> => {
+  const start = Date.now();
+  const spin = spinner({ text: `${label} — 0.0s`, indent });
+  const timer = setInterval(() => {
+    spin.text = `${label} — ${((Date.now() - start) / 1000).toFixed(1)}s`;
+  }, 500);
+  try {
+    const result = await task();
+    spin.succeed(`${label} (${((Date.now() - start) / 1000).toFixed(1)}s)`);
+    return result;
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : String(error);
+    spin.fail(errMsg);
+    throw error;
+  } finally {
+    clearInterval(timer);
+  }
+};
+
+/**
  * Spinner chain for sequential operations
  * Manages multiple spinners in sequence
  */


### PR DESCRIPTION
## Summary

Develop → main batch shipping the console UX overhaul (PR #222) and the publish.yml post-publish fix (PR #221).

- **Console UX**: subprocess chatter from `movement node run-localnet`, `aptos move build`, `aptos move publish` is hidden by default. Long phases (node startup, build, publish, funding) now show spinners with live elapsed-time feedback. Phase headers and the new `-v` flag round out the experience.
- **CI hygiene**: publish.yml's post-publish "Commit version bump back" step no longer fails on the typical release-via-PR flow (closes #174).
- **Internal cleanup**: 26 raw `console.*` callsites migrated to `logger.*`. CLAUDE.md §9 codifies the rule for future PRs.

Tracks PR #222 (`feat/console-ux-loaders`) and PR #221 (`fix/publish-skip-commit-when-main-current`) — both already merged to `develop`.

## Visual A/B (counter-example tests)

**Before** — wall of `[Node] ...` chatter from the movement subprocess (excerpt):
```
[Node] Loading aptos framework module
[Node] aptos_account: account created
[Node] Compiling Move bytecode
... (×20-50 lines)
✓ Local Movement node is ready!
```

**After** — clean spinner-driven UX:
```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Setting up local testing environment
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Mode: local-node
  Accounts: deployer, alice, bob

▸ Starting local Movement node
  Test directory: ./.movehat/local-node
  RPC port: 8080
  Faucet port: 8081
  Ready port: 8070

⠼ Waiting for node to be ready — 14.2s
✔ Waiting for node to be ready (15.1s)

⠋ Funding 3 accounts from local faucet
✔ Funded 3 accounts (1 APT each)
```

Verified in `pnpm test:example`:
- `grep -c '\[Node\]' /tmp/movehat-clean.txt` → **0** (was hundreds)
- `grep -c '━' /tmp/movehat-clean.txt` → **6 phase rules**
- Total output: ~253 lines (vs ~600+ unfiltered)
- Critical signals (`panic`, `fatal`, `EADDRINUSE`) always surface — locked by `LocalNodeManager.test.ts §9` block.

## Tier verification

| Tier | Status | Notes |
|---|---|---|
| Tier 1: `pnpm check:example` | ✅ pass | typecheck + example consumer check |
| Tier 2: `pnpm test:smoke` | ✅ pass | pack + global install + CLI smoke |
| Tier 2: `pnpm test:example` | ✅ 9/9 passing (1m) | clean run, no false ✘ markers |
| Tier 2: `pnpm test` (unit) | ✅ 468/468 passing | +14 new tests from PR #222 |
| Tier 3: `pnpm test:e2e` | Pending on publish.yml | runs in CI on this batch |

## Post-merge plan

1. Create GitHub release with tag `v0.2.3` pointing at the merged commit. This fires `publish.yml` via the `release: types: [published]` trigger.
2. publish.yml runs unit + integration + smoke tests, builds, publishes to npm with SLSA provenance via Trusted Publishers (no `NPM_TOKEN` consumed).
3. Verify:
   - `npm view movehat@0.2.3 version` → `0.2.3`
   - `npm view movehat@0.2.3 _attestations` → SLSA provenance present
   - Fresh project smoke (per CLAUDE.md §6.3) — install `movehat@0.2.3` in `/tmp/` and run `movehat init` + `movehat compile`.

## Test plan (manual, post-publish)

- [ ] `npm install movehat@0.2.3` in a fresh directory works
- [ ] `movehat --version` shows `0.2.3`
- [ ] `movehat init my-project` scaffolds with `"movehat": "^0.2.3"` (workspace:* replaced by publish.yml's sed step)
- [ ] `movehat test --move` runs Move unit tests
- [ ] `movehat test --ts` shows clean spinner UX in default mode
- [ ] `movehat test --ts -v` surfaces subprocess chatter
- [ ] `movehat fork create --network testnet` works (existing flow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.2.3

* **New Features**
  * Added `-v, --verbose` CLI flag for detailed debugging output
  * Enhanced console output formatting with improved phase headers and status messages

* **Bug Fixes**
  * Fixed version bump logic in publish workflow to prevent duplicate commits when versions already match

* **Documentation**
  * Updated CHANGELOG for v0.2.3 release
  * Added console output conventions documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->