### PR TITLE
fix: rename APT → MOVE in user-facing strings

### DIFF
--- a/packages/movehat/src/fork/manager.ts
+++ b/packages/movehat/src/fork/manager.ts
@@ -275,7 +275,7 @@ export class ForkManager {
    * @example
    * await forkManager.fundMultipleAccounts(
    *   ["0x123...", "0x456..."],
-   *   100_000_000 // 100 APT
+   *   100_000_000 // 1 MOVE
    * );
    */
   async fundMultipleAccounts(

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -239,7 +239,7 @@ async function setupWithLocalNode(
     logger.plain(`   RPC: ${nodeInfo.rpcUrl}/v1`);
     logger.plain(`   Faucet: ${nodeInfo.faucetUrl}`);
     logger.plain(`   Accounts: ${Array.from(accountLabels).join(", ")}`);
-    logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} APT`);
+    logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} MOVE`);
     logger.newline();
 
     return { runtime, localNode };
@@ -376,7 +376,7 @@ async function setupWithFork(
     logger.plain(`   Mode: fork (read-only)`);
     logger.plain(`   RPC: http://localhost:${forkPort}/v1`);
     logger.plain(`   Accounts: ${Array.from(accountLabels).join(", ")}`);
-    logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} APT`);
+    logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} MOVE`);
     logger.newline();
 
     return { runtime, forkServer, forkManager };

--- a/packages/movehat/src/node/LocalNodeManager.ts
+++ b/packages/movehat/src/node/LocalNodeManager.ts
@@ -312,7 +312,7 @@ export class LocalNodeManager {
    * Fund an account using the local faucet
    *
    * @param account Account instance or address to fund
-   * @param amount Amount in octas (default: 100_000_000 = 100 APT)
+   * @param amount Amount in octas (default: 100_000_000 = 1 MOVE)
    */
   async fundAccount(account: Account | string, amount: number = 100_000_000): Promise<void> {
     if (!this.isRunning()) {
@@ -361,7 +361,7 @@ export class LocalNodeManager {
           await this.fundAccount(account, amount);
         }
       },
-      `Funded ${accounts.length} accounts (${(amount / 1e8).toFixed(0)} APT each)`,
+      `Funded ${accounts.length} accounts (${(amount / 1e8).toFixed(0)} MOVE each)`,
     );
     logger.newline();
   }

--- a/packages/movehat/src/types/config.ts
+++ b/packages/movehat/src/types/config.ts
@@ -77,7 +77,7 @@ export interface LocalTestOptions {
 
     // Common options (both modes)
     autoFund?: boolean;                 // Auto-fund accounts (default: true)
-    defaultBalance?: number;            // Default balance in octas (default: 100_000_000 = 100 APT)
+    defaultBalance?: number;            // Default balance in octas (default: 100_000_000 = 1 MOVE)
     autoDeploy?: readonly string[];     // Modules to auto-deploy (accepts readonly arrays)
     accountLabels?: readonly string[];  // Labels for pre-generated accounts (default: ['deployer', 'alice', 'bob'])
 }


### PR DESCRIPTION
## Summary

Movement L1's native token is **MOVE**, not APT (Aptos). The display strings emitted during faucet funding and local-testing setup were using APT, which is incorrect rebranding for a Movement-native dev framework. Caught by the user during the v0.2.3 smoke test:

> ✔ Funded 3 accounts (1 APT each)
>
> — lo que dice funded 3 accounts 1 apt each, es **MOVE** el token

## Changes

| File | Before | After |
|---|---|---|
| \`LocalNodeManager.ts:364\` (fundAccounts success) | \`X APT each\` | \`X MOVE each\` |
| \`setupLocalTesting.ts:242, 379\` (balance log) | \`Balance per account: X APT\` | \`X MOVE\` |
| \`LocalNodeManager.ts:315\` (JSDoc) | \`100 APT\` | \`1 MOVE\` |
| \`types/config.ts:80\` (JSDoc) | \`100 APT\` | \`1 MOVE\` |
| \`fork/manager.ts:278\` (JSDoc example) | \`100 APT\` | \`1 MOVE\` |

Also corrects a math error in the comments: \`100_000_000\` octas is \`1 MOVE\` (10^8 octas), not 100. The runtime math was always correct (\`amount / 1e8\`); only the comments were wrong about the unit count.

## Out of scope

- TypeDoc-generated reference pages (\`packages/docs/content/docs/api/reference/classes/*.mdx\`) are not tracked by git and will pick up the fix on next docs build.
- Broader \"Movement-not-Aptos\" branding audit (e.g. internal Aptos refs in subprocess output) — separate from user-facing display strings.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm test\` 468/468 passing
- [ ] Will surface in the next release (v0.2.4 batch)

## §8 self-review

🔴 / 🟡 / 🟢 — none. Six-line mechanical string substitution caught by user smoke test, no behavior change.