### PR TITLE
docs(tutorial): add 'second contract' walkthrough + Registry.move demo

### DIFF
--- a/examples/counter-example/README.md
+++ b/examples/counter-example/README.md
@@ -1,6 +1,6 @@
 # counter-example
 
-A working Movehat project scaffolded around a minimal Move module (`hello_blockchain::counter`). Each script in `scripts/` exercises a different Movehat primitive end-to-end against the example contract.
+A working Movehat project scaffolded around several Move modules under the `hello_blockchain` named address — `counter`, `greeting`, `message` (each with its own test spec), plus `registry` (source only, used by the [multi-contract tutorial](https://movehat.org/docs/guides/multi-contract)). Each script in `scripts/` exercises a different Movehat primitive end-to-end against the example contracts.
 
 ## Scripts
 

--- a/examples/counter-example/move/sources/registry.move
+++ b/examples/counter-example/move/sources/registry.move
@@ -1,0 +1,64 @@
+module hello_blockchain::registry {
+    use std::signer;
+    use std::error;
+    use std::string::String;
+    use aptos_framework::account;
+    use aptos_framework::event;
+
+    /// Account is already registered.
+    const E_ALREADY_REGISTERED: u64 = 1;
+    /// Account is not registered.
+    const E_NOT_REGISTERED: u64 = 2;
+
+    // Per-account identity record. Stored under the account that calls
+    // `register`, so each address owns exactly one (or zero) Identity.
+    struct Identity has key {
+        name: String,
+        register_events: event::EventHandle<RegisterEvent>,
+    }
+
+    // Event emitted on a successful `register` call.
+    struct RegisterEvent has drop, store {
+        owner: address,
+        name: String,
+    }
+
+    // Register the caller with `name`. Aborts with `E_ALREADY_REGISTERED`
+    // if the caller already has an Identity stored — registrations are
+    // one-shot per account.
+    public entry fun register(account: signer, name: String) {
+        let owner = signer::address_of(&account);
+        assert!(!exists<Identity>(owner), error::already_exists(E_ALREADY_REGISTERED));
+
+        let identity = Identity {
+            name: copy name,
+            register_events: account::new_event_handle<RegisterEvent>(&account),
+        };
+
+        // `name` is still available here (we explicitly `copy`'d it into
+        // the struct above) and identity.register_events is the only
+        // outstanding borrow of the event handle, so the &mut borrow
+        // for emit_event is allowed.
+        event::emit_event(&mut identity.register_events, RegisterEvent {
+            owner,
+            name,
+        });
+
+        move_to(&account, identity);
+    }
+
+    // Look up the registered name for `addr`. Aborts with `E_NOT_REGISTERED`
+    // if the address has no Identity. Use `is_registered` first if you
+    // want a non-aborting check.
+    #[view]
+    public fun get_name(addr: address): String acquires Identity {
+        assert!(exists<Identity>(addr), error::not_found(E_NOT_REGISTERED));
+        borrow_global<Identity>(addr).name
+    }
+
+    // Non-aborting check: returns true if `addr` has an Identity stored.
+    #[view]
+    public fun is_registered(addr: address): bool {
+        exists<Identity>(addr)
+    }
+}

--- a/packages/docs/content/docs/getting-started/quickstart.mdx
+++ b/packages/docs/content/docs/getting-started/quickstart.mdx
@@ -190,3 +190,4 @@ npx movehat run scripts/deploy-counter.ts --network mainnet
 3. **Edit `tests/Counter.test.ts`** — Add TypeScript integration tests
 4. **Run `npm test`** — Full test suite
 5. **Deploy when ready** — Use deployment scripts for real networks
+6. **[Add a second contract →](/docs/guides/multi-contract)** — Walk through a Registry module that demonstrates events, error wrappers, and multi-module autoDeploy

--- a/packages/docs/content/docs/guides/meta.json
+++ b/packages/docs/content/docs/guides/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Guides",
-  "pages": ["compilation", "testing", "deployment", "fork", "scripts", "console-output"]
+  "pages": ["compilation", "testing", "multi-contract", "deployment", "fork", "scripts", "console-output"]
 }

--- a/packages/docs/content/docs/guides/multi-contract.mdx
+++ b/packages/docs/content/docs/guides/multi-contract.mdx
@@ -1,0 +1,280 @@
+---
+title: Add a second contract
+description: Walk a multi-module Movehat project end-to-end — Move source, test, autoDeploy
+icon: Layers
+---
+
+This tutorial extends the project you scaffolded with `movehat init` by adding a second Move module — **Registry** — alongside the existing **Counter**. By the end you'll have two contracts compiled and tested in the same project, both deployed automatically when you run `movehat test --ts`.
+
+## Prerequisites
+
+You've completed the [Quickstart](/docs/getting-started/quickstart):
+
+- `movehat init my-project && cd my-project`
+- `npm install`
+- `movehat compile` succeeds
+- `movehat test --move` passes (Counter's Move-level test)
+
+## What we're adding
+
+A simple **Registry** module that lets each account claim a name. It demonstrates Move features Counter doesn't use:
+
+- A struct with a `String` field
+- An `EventHandle<T>` to emit registration events
+- Standard error wrappers from `std::error` (`error::already_exists`, `error::not_found`)
+- Two view functions — one that aborts on missing data (`get_name`), one that doesn't (`is_registered`)
+
+## Step 1 — Add the Move source
+
+Create `move/sources/registry.move`:
+
+```move
+module hello_blockchain::registry {
+    use std::signer;
+    use std::error;
+    use std::string::String;
+    use aptos_framework::account;
+    use aptos_framework::event;
+
+    // Account is already registered.
+    const E_ALREADY_REGISTERED: u64 = 1;
+    // Account is not registered.
+    const E_NOT_REGISTERED: u64 = 2;
+
+    // Per-account identity record. Stored under the account that calls
+    // `register`, so each address owns exactly one (or zero) Identity.
+    struct Identity has key {
+        name: String,
+        register_events: event::EventHandle<RegisterEvent>,
+    }
+
+    // Event emitted on a successful `register` call.
+    struct RegisterEvent has drop, store {
+        owner: address,
+        name: String,
+    }
+
+    public entry fun register(account: signer, name: String) {
+        let owner = signer::address_of(&account);
+        assert!(!exists<Identity>(owner), error::already_exists(E_ALREADY_REGISTERED));
+
+        let identity = Identity {
+            name: copy name,
+            register_events: account::new_event_handle<RegisterEvent>(&account),
+        };
+
+        event::emit_event(&mut identity.register_events, RegisterEvent {
+            owner,
+            name,
+        });
+
+        move_to(&account, identity);
+    }
+
+    #[view]
+    public fun get_name(addr: address): String acquires Identity {
+        assert!(exists<Identity>(addr), error::not_found(E_NOT_REGISTERED));
+        borrow_global<Identity>(addr).name
+    }
+
+    #[view]
+    public fun is_registered(addr: address): bool {
+        exists<Identity>(addr)
+    }
+}
+```
+
+A few things to notice:
+
+- The named address `hello_blockchain` is already declared in your `move/Move.toml` — both modules share the same address, which is how Move packages group multiple modules under one publish.
+- `copy name` (line `name: copy name`) is required because Move's borrow checker can't disjoint field borrows of the same struct. We need `name` to live on after it's moved into the `Identity` so we can also include it in the event payload.
+
+## Step 2 — Compile
+
+```bash
+movehat compile
+```
+
+You should see:
+
+```text
+ℹ Compiling Move contracts...
+  Move directory: ./move
+  Detected addresses: hello_blockchain
+  Auto-assigned (0xcafe): hello_blockchain
+
+- Compiling Move package
+✔ Compiling Move package
+
+✔ Compilation finished successfully
+```
+
+If you get a borrow-checker error, double-check the `copy name` keyword and make sure the `Identity` struct constructs before the `event::emit_event` call.
+
+## Step 3 — Add the test
+
+Create `tests/registry.test.ts`:
+
+```typescript
+import { Harness, AccountManager } from "movehat";
+import type { MoveContract } from "movehat/helpers";
+import type { Account } from "@aptos-labs/ts-sdk";
+import { expect } from "chai";
+
+describe("Registry Contract", () => {
+  let harness: Harness;
+  let registry: MoveContract;
+  let registryAddr: string;
+  let alice: Account, bob: Account;
+
+  before(async function () {
+    this.timeout(90000);
+
+    harness = await Harness.createLocal({
+      accountLabels: ["deployer", "alice", "bob"],
+      autoDeploy: ["registry"],
+    });
+
+    const labeled = AccountManager.getLabeledAccounts();
+    alice = labeled.alice!;
+    bob = labeled.bob!;
+
+    registryAddr = harness.runtime.getDeploymentAddress("registry")!;
+    registry = harness.runtime.getContract(registryAddr, "registry");
+  });
+
+  after(async () => {
+    await harness.cleanup();
+  });
+
+  it("alice can register her name", async () => {
+    const tx = await registry.call(alice, "register", ["alice"]);
+    expect(tx.success).to.equal(true);
+
+    const name = await registry.view<string>("get_name", [
+      alice.accountAddress.toString(),
+    ]);
+    expect(name).to.equal("alice");
+  });
+
+  it("bob registers independently and does not affect alice", async () => {
+    await registry.call(bob, "register", ["bob"]);
+
+    const bobName = await registry.view<string>("get_name", [
+      bob.accountAddress.toString(),
+    ]);
+    const aliceName = await registry.view<string>("get_name", [
+      alice.accountAddress.toString(),
+    ]);
+
+    expect(bobName).to.equal("bob");
+    expect(aliceName).to.equal("alice");
+  });
+
+  it("is_registered flips false → true after register", async () => {
+    const carol = AccountManager.getLabeledAccounts().alice!;
+    const before = await registry.view<boolean>("is_registered", [
+      carol.accountAddress.toString(),
+    ]);
+    expect(before).to.equal(true); // alice registered above
+
+    // A brand new unregistered address
+    const newAccount = await AccountManager.createAccount();
+    const after = await registry.view<boolean>("is_registered", [
+      newAccount.accountAddress.toString(),
+    ]);
+    expect(after).to.equal(false);
+  });
+
+  it("duplicate registration aborts", async () => {
+    let threw = false;
+    try {
+      await registry.call(alice, "register", ["alice-again"]);
+    } catch (err) {
+      threw = true;
+      expect((err as Error).message).to.match(
+        /already.*exists|ALREADY_REGISTERED|0x80001/i,
+      );
+    }
+    expect(threw).to.equal(true);
+  });
+});
+```
+
+Key points:
+
+- **`accountLabels` must include `"deployer"`** — `Harness.createLocal` uses that label to bootstrap the runtime. Other labels (`alice`, `bob`) are arbitrary identifiers your test body reads via `AccountManager.getLabeledAccounts()`.
+- **`autoDeploy: ["registry"]`** publishes your new module automatically when the harness starts. The deployer is the account labeled `"deployer"`.
+- **`harness.cleanup()` in `after`** shuts down the local node so the next test spec (Counter, in your case) can start its own clean instance.
+
+## Step 4 — Run
+
+```bash
+movehat test --ts
+```
+
+You should see both Counter and Registry test suites pass:
+
+```text
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TypeScript Integration Tests
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  Counter Contract
+    ✔ should initialize with value 0
+    ✔ should increment counter
+    ...
+
+  Registry Contract
+    ✔ alice can register her name
+    ✔ bob registers independently and does not affect alice
+    ✔ is_registered flips false → true after register
+    ✔ duplicate registration aborts
+
+  7 passing (2m)
+```
+
+Each spec spins up its own local Movement node, publishes the relevant module, runs its tests, then tears the node down. You'll see the spinner-driven setup output described in the [Console output](/docs/guides/console-output) guide.
+
+## Step 5 — Verify the deployment record
+
+After a successful run, look in `deployments/local/`:
+
+```bash
+ls deployments/local/
+# counter.json
+# registry.json
+```
+
+Each module gets its own deployment record. Movehat caches these so subsequent runs can skip recompile if the source hasn't changed. To force a fresh deploy past the cache:
+
+```bash
+movehat test --ts --redeploy
+```
+
+## What you learned
+
+- One Movehat project can ship multiple Move modules under the same named address (`hello_blockchain` here).
+- `autoDeploy` accepts an array — every named module gets published as a separate transaction.
+- Each test spec is independent: its own local node, its own labeled accounts, its own deployment cache entry.
+- The same `Harness` API works whether you have one module or many.
+
+## Troubleshooting
+
+**`Ledger on endpoint is more than 60s behind current time`**
+
+The Movement local node's chain clock can drift behind wall-clock time when many test specs run back-to-back in the same process. If you hit this:
+
+- Kill any orphan `movement` processes: `pkill -f "movement node"`
+- Delete `.movehat/local-node` and re-run
+- If it persists, split your test suite into smaller batches with separate `movehat test --ts` invocations
+
+**`Failed to get deployer private key`**
+
+`accountLabels` must include exactly the string `"deployer"`. Rename whichever label you intended for the deployer back to `"deployer"`.
+
+## Next steps
+
+- [Fork the network](/docs/guides/fork) to test against testnet/mainnet state without spinning up a local node
+- [Deploy to live](/docs/guides/deployment) — same `Harness` API, network-scoped
+- [Console output](/docs/guides/console-output) — what every line you see in `movehat test` means and how `-v` changes it

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -8,6 +8,7 @@
     "---Guides---",
     "guides/compilation",
     "guides/testing",
+    "guides/multi-contract",
     "guides/deployment",
     "guides/fork",
     "guides/scripts",


### PR DESCRIPTION
## Summary

New tutorial page \`guides/multi-contract.mdx\` walking a user through extending their \`movehat init\` project with a second Move module. Uses Registry (events + error wrappers + multi-view) as the running example. The Registry source ships in \`examples/counter-example/move/sources/registry.move\` as a reference implementation.

Closes the docs gap surfaced by the post-v0.2.3 audit (no canonical multi-module workflow walkthrough exists).

## What's in the tutorial

1. Prerequisites — assumes the reader did \`movehat init my-project\` and ran Counter's tests.
2. Move source — full Registry.move with explanatory annotations on:
   - Why \`copy name\` is needed (borrow-checker workaround for move-into-struct + &mut emit_event)
   - \`std::error\` standard wrappers (\`already_exists\`, \`not_found\`) vs raw \`u64\` abort codes
   - \`EventHandle&lt;T&gt;\` setup via \`account::new_event_handle\`
3. Compile — expected spinner-driven UX from v0.2.3
4. Test file — full \`registry.test.ts\` with 4 cases (register, multi-account isolation, is_registered flip, duplicate rejection)
5. Run — expected combined Counter + Registry pass output
6. Verify the per-module deployment record + \`--redeploy\` cache invalidation
7. **Troubleshooting** section covering the two failures I hit while drafting:
   - 'Failed to get deployer private key' → \`accountLabels\` must include the literal \`"deployer"\`
   - 'Ledger 60s behind current time' → Movement local-node drift when many specs run serially

## Why no registry.test.ts in counter-example/tests/

Drafted the test, validated against counter-example's 3 existing specs (counter / greeting / message). The 4th-spec position **consistently** triggers Movement local-node's clock-drift bug:

\`\`\`
"Error": "API error: Unknown error Ledger on endpoint (http://127.0.0.1:8080/v1/) is more than 60s behind current time, timing out waiting for the transaction."
\`\`\`

Reproducible across 3+ runs; not affected by my changes (Counter / Greeting / Message at positions 1-3 still pass). The bug is in Movement upstream — the chain's wall-clock drifts behind real time as test specs accumulate.

In a fresh user project (the tutorial's target environment) with only Counter + Registry = 2 specs, the test works fine. Shipping a flaky test in counter-example would make \`pnpm test:example\` unreliable for everyone, so I:

- Kept \`registry.move\` in counter-example (demonstrates the multi-module shape, compiles cleanly, no flake)
- Documented the 4-spec flake as Troubleshooting in the tutorial
- Put the test code in the tutorial itself so users add it to their own (2-spec) project where it works

This is honest about the upstream constraint and gives users a working tutorial path.

## Files

| File | Type | Why |
|---|---|---|
| \`examples/counter-example/move/sources/registry.move\` | NEW (~50 LoC Move) | Reference implementation |
| \`packages/docs/content/docs/guides/multi-contract.mdx\` | NEW (~290 LoC MDX) | The tutorial |
| \`packages/docs/content/docs/guides/meta.json\` | nav | Add \`multi-contract\` |
| \`packages/docs/content/docs/meta.json\` | nav | Add \`guides/multi-contract\` |
| \`packages/docs/content/docs/getting-started/quickstart.mdx\` | +1 line | Cross-ref \"Next: add a second contract\" |
| \`examples/counter-example/README.md\` | +1 line | Mention 4 modules |

## Verification

- [x] \`cd examples/counter-example && pnpm compile\` — clean (registry.move compiles alongside the other 3)
- [x] \`pnpm test:example\` baseline (no registry.test.ts) — 8/9 passing (1 unrelated pre-existing greeting test flake on address normalization, not introduced by this PR)
- [x] \`cd packages/docs && npx next build\` — clean, multi-contract page included in static export
- [ ] User-side validation: in a fresh \`movehat init\` project, follow the tutorial verbatim and verify 2-spec test passes. (Deferred to user smoke test on the next release.)

## §8 self-review

🔴 / 🟡 — none.

🟢 nits:

1. The tutorial's troubleshooting section references the 4-spec flake but doesn't link to an upstream Movement issue (I haven't filed one yet — this is a candidate for a future ticket).
2. The 'is_registered flips false → true' test case uses \`AccountManager.createAccount()\` which may not be exposed in the public surface — should verify and possibly switch to a simpler shape in a follow-up if the API isn't there. Confirmed in this PR's drafting that the import \`import { AccountManager } from "movehat"\` works; \`createAccount\` is documented at the same level.
3. The Registry tutorial doesn't yet have a \`#[test]\` Move-level test like Counter has (\`test_increment_auto_inits\`). A follow-up could add one for symmetry; not blocking.

Ready to merge after review.