### PR TITLE
chore: strip history-reference comments from examples + docs

### DIFF
--- a/examples/counter-example/tests/Counter.test.ts
+++ b/examples/counter-example/tests/Counter.test.ts
@@ -4,11 +4,9 @@ import type { Account } from "@aptos-labs/ts-sdk";
 import { expect } from "chai";
 
 /**
- * Uses the Harness API: Harness.createLocal with autoDeploy. Same
- * Publisher-based publish path the older setupTestFixture flow used.
- * The sibling tests (greeting.test.ts, message.test.ts) stay on
- * setupTestFixture to demonstrate that the older API continues to
- * work side-by-side.
+ * Uses the Harness API: Harness.createLocal with autoDeploy. Sibling
+ * tests (greeting.test.ts, message.test.ts) use setupTestFixture to
+ * demonstrate both surfaces in the same project.
  *
  * For the code-object deploy path (`harness.deployCodeObject`), see
  * scripts/deploy-counter.ts in this directory.
@@ -36,8 +34,7 @@ describe("Counter Contract", () => {
   });
 
   it("should initialize with value 0 (via harness.runViewFunction)", async () => {
-    // Demonstrate the new SDK-backed view path. Returns the raw
-    // unknown[] tuple from aptos.view — destructure for singletons.
+    // aptos.view returns unknown[] even for single-value views
     const [value] = await harness.runViewFunction({
       function: `${counterAddr}::counter::get`,
       functionArguments: [deployer.accountAddress.toString()],

--- a/packages/docs/content/docs/guides/scripts.mdx
+++ b/packages/docs/content/docs/guides/scripts.mdx
@@ -34,7 +34,7 @@ async function main() {
     const contract = harness.runtime.getContract(deployment.address, "counter");
     await contract.call(harness.runtime.account, "init", []);
 
-    // 3. Verify via the SDK-backed view path
+    // 3. Verify
     const [value] = await harness.runViewFunction({
       function: `${deployment.address}::counter::getValue`,
     });

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -77,8 +77,7 @@ describe("Counter Contract", () => {
   });
 
   it("should initialize with value 0 (via harness.runViewFunction)", async () => {
-    // runViewFunction returns the raw unknown[] tuple from aptos.view —
-    // destructure for singletons.
+    // aptos.view returns unknown[] even for single-value views
     const [value] = await harness.runViewFunction({
       function: `${counter.moduleAddress}::counter::get`,
       functionArguments: [deployer.accountAddress.toString()],

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -31,10 +31,8 @@ function resolveForkRpcUrl(
 /**
  * Context returned by {@link setupLocalTesting}.
  *
- * Replaces the module-scoped singletons that previously tracked the
- * "current" local node / fork server / fork manager. Each invocation now
- * owns its own handles, so two parallel `setupLocalTesting` calls in the
- * same process do not trample each other.
+ * Each invocation owns its own handles, so two parallel `setupLocalTesting`
+ * calls in the same process do not trample each other.
  *
  * @public The `runtime` and `teardown` fields are the supported surface.
  *         `localNode`, `forkServer`, and `forkManager` are exposed for


### PR DESCRIPTION
Cleans up three pairs of code/doc comments that reference 'older' or 'new' API surfaces (history references in code — violates CLAUDE.md §1 and the project memory `feedback_no_history_refs_in_code`).

Touched:
- `examples/counter-example/tests/Counter.test.ts` — header + runViewFunction inline comment
- `packages/docs/content/docs/guides/testing.mdx` — same runViewFunction snippet
- `packages/docs/content/docs/guides/scripts.mdx` — drop 'via the SDK-backed view path' framing
- `packages/movehat/src/helpers/setupLocalTesting.ts` — `LocalTestingContext` JSDoc (propagates to TypeDoc reference pages on next docs build)

User-facing `quickstart.mdx` / `testing.mdx` lines that say 'Looking for the older API?' are deliberately KEPT — those are navigational aids for readers, not code comments.

## Verification

- `pnpm tsc --noEmit` clean
- `cd packages/docs && npx next build` clean (65+ static paths)

## §8 self-review

🔴 / 🟡 / 🟢 — none. Pure comment cleanup, no behavior change.