### PR TITLE
chore: sync history-comment cleanup to main (triggers docs deploy)

### DIFF
--- a/examples/counter-example/tests/Counter.test.ts
+++ b/examples/counter-example/tests/Counter.test.ts
@@ -4,11 +4,9 @@ import type { Account } from "@aptos-labs/ts-sdk";
 import { expect } from "chai";
 
 /**
- * Uses the Harness API: Harness.createLocal with autoDeploy. Same
- * Publisher-based publish path the older setupTestFixture flow used.
- * The sibling tests (greeting.test.ts, message.test.ts) stay on
- * setupTestFixture to demonstrate that the older API continues to
- * work side-by-side.
+ * Uses the Harness API: Harness.createLocal with autoDeploy. Sibling
+ * tests (greeting.test.ts, message.test.ts) use setupTestFixture to
+ * demonstrate both surfaces in the same project.
  *
  * For the code-object deploy path (`harness.deployCodeObject`), see
  * scripts/deploy-counter.ts in this directory.
@@ -36,8 +34,7 @@ describe("Counter Contract", () => {
   });
 
   it("should initialize with value 0 (via harness.runViewFunction)", async () => {
-    // Demonstrate the new SDK-backed view path. Returns the raw
-    // unknown[] tuple from aptos.view — destructure for singletons.
+    // aptos.view returns unknown[] even for single-value views
     const [value] = await harness.runViewFunction({
       function: `${counterAddr}::counter::get`,
       functionArguments: [deployer.accountAddress.toString()],

--- a/packages/docs/content/docs/guides/scripts.mdx
+++ b/packages/docs/content/docs/guides/scripts.mdx
@@ -34,7 +34,7 @@ async function main() {
     const contract = harness.runtime.getContract(deployment.address, "counter");
     await contract.call(harness.runtime.account, "init", []);
 
-    // 3. Verify via the SDK-backed view path
+    // 3. Verify
     const [value] = await harness.runViewFunction({
       function: `${deployment.address}::counter::getValue`,
     });

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -77,8 +77,7 @@ describe("Counter Contract", () => {
   });
 
   it("should initialize with value 0 (via harness.runViewFunction)", async () => {
-    // runViewFunction returns the raw unknown[] tuple from aptos.view —
-    // destructure for singletons.
+    // aptos.view returns unknown[] even for single-value views
     const [value] = await harness.runViewFunction({
       function: `${counter.moduleAddress}::counter::get`,
       functionArguments: [deployer.accountAddress.toString()],

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -31,10 +31,8 @@ function resolveForkRpcUrl(
 /**
  * Context returned by {@link setupLocalTesting}.
  *
- * Replaces the module-scoped singletons that previously tracked the
- * "current" local node / fork server / fork manager. Each invocation now
- * owns its own handles, so two parallel `setupLocalTesting` calls in the
- * same process do not trample each other.
+ * Each invocation owns its own handles, so two parallel `setupLocalTesting`
+ * calls in the same process do not trample each other.
  *
  * @public The `runtime` and `teardown` fields are the supported surface.
  *         `localNode`, `forkServer`, and `forkManager` are exposed for


### PR DESCRIPTION
Brings PR #231 to main so the GitHub Pages docs-deploy workflow fires and the live docs site reflects the comment cleanup.

`docs-deploy.yml` triggers on push to main when paths under `packages/docs/**` or `packages/movehat/src/**` change — both apply here.

## §8 — PR #231's review applies. Pure comment cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Clarified how view functions return values in testing and integration examples
* Improved documentation describing handle ownership and isolation in local testing environments
* Refined deployment verification guidance in scripts documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->