### PR TITLE
fix(ci): sync coverage fix to main (unbreak unit-test gate)

### DIFF
--- a/packages/movehat/src/commands/test.ts
+++ b/packages/movehat/src/commands/test.ts
@@ -211,6 +211,9 @@ async function runTypeScriptTests(watch: boolean = false): Promise<void> {
   // terminal until the user Ctrl+Cs the parent (which kills the child via
   // inherited stdio). Attach .catch so a spawn-time failure doesn't become
   // an unhandled rejection.
+  /* c8 ignore start -- watch mode launches a long-running mocha process and
+     never returns; not testable as a unit. Behaviour is covered by the
+     integration suite and by manual smoke. */
   if (watch) {
     runCli(
       {
@@ -229,6 +232,7 @@ async function runTypeScriptTests(watch: boolean = false): Promise<void> {
     logger.newline();
     return;
   }
+  /* c8 ignore stop */
 
   // Non-watch mode: await the run, surface the exit code as a thrown error
   // so the orchestrator above can summarize the failure.
@@ -243,10 +247,14 @@ async function runTypeScriptTests(watch: boolean = false): Promise<void> {
       },
       { throwOnNonZeroExit: false }
     );
+    /* c8 ignore start -- runCli with throwOnNonZeroExit:false only throws on
+       spawn-time failure (ENOENT, etc.), which is blocked upstream by the
+       existsSync(mochaPath) check at line 192. Defense in depth. */
   } catch (error) {
     logger.error(`Failed to run TypeScript tests: ${(error as Error).message}`);
     throw error;
   }
+  /* c8 ignore stop */
 
   if (result.exitCode === 0) {
     return;


### PR DESCRIPTION
Brings PR #233 to main so CI unit-tests job goes green.

## §8 — PR #233's review applies. Pure c8-ignore annotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code coverage configuration for test execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->