### PR TITLE
feat(m8.0): proxy POST /v1/view from ForkServer to upstream RPC

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -303,7 +303,8 @@ Follow-up issues filed during M4 (all upstream Movement CLI / SDK, deferred to M
 
 | Sub | Description | Issue | Status |
 |---|---|---|---|
-| M8.1 | Fork-mode tutorial + `networks-and-modes` accuracy fix | [#239](https://github.com/gilbertsahumada/movehat/issues/239) | in PR |
+| M8.0 | ForkServer `/v1/view` proxy + docs flip | [#243](https://github.com/gilbertsahumada/movehat/issues/243) | in PR |
+| M8.1 | Fork-mode tutorial + `networks-and-modes` accuracy fix | [#239](https://github.com/gilbertsahumada/movehat/issues/239) | ✅ shipped in PR #244 |
 | M8.2 | Deploy-to-live tutorial | [#240](https://github.com/gilbertsahumada/movehat/issues/240) | |
 | M8.3 | CI integration tutorial + reference workflow | [#241](https://github.com/gilbertsahumada/movehat/issues/241) | |
 | M8.4 | TypeDoc structural cleanup + MAINTENANCE.md + KPI2 report | [#242](https://github.com/gilbertsahumada/movehat/issues/242) | |

--- a/packages/docs/content/docs/guides/networks-and-modes.mdx
+++ b/packages/docs/content/docs/guides/networks-and-modes.mdx
@@ -11,7 +11,7 @@ Movehat exposes three `Harness` factories that target three different execution 
 | Your goal | Factory | Network | Writes gas? | Typical file |
 |---|---|---|---|---|
 | Fast iteration on a clean fresh chain (default for tests) | `createLocal()` | local node on `127.0.0.1:8080` | no (fake gas from faucet) | `tests/*.test.ts` |
-| Read real testnet / mainnet **account + resource** state | `createFork(network)` | account/resource reads passthrough; writes rejected | no | `tests/*.test.ts` |
+| Read real testnet / mainnet state (accounts, resources, view functions) | `createFork(network)` | reads proxied to upstream; transactions rejected | no | `tests/*.test.ts` |
 | Deploy or call entry functions on real testnet / mainnet | `createLive(network)` | live RPC, real submission | **yes — real MOVE** | `scripts/*.ts` |
 
 The rest of this page expands each row with code and explains the gotchas.
@@ -58,10 +58,12 @@ const account = await harness.runtime.aptos.getAccountInfo({
   accountAddress: "0x1",
 });
 
-// Reading a specific resource works
-const resource = await harness.runtime.aptos.getAccountResource({
-  accountAddress: "0x1",
-  resourceType: "0x1::account::Account",
+// Running a view function against real mainnet state works
+// (the fork server proxies POST /v1/view to upstream RPC)
+const [supply] = await harness.runViewFunction({
+  function: "0x1::coin::supply",
+  typeArguments: ["0x1::aptos_coin::AptosCoin"],
+  functionArguments: [],
 });
 
 // Deploy/upgrade/script attempts throw synchronously from the harness Proxy
@@ -74,11 +76,11 @@ try {
 
 **What "read-only" means in practice today**:
 
-- **Supported**: `aptos.getAccountInfo`, `aptos.getAccountResource`, `aptos.getAccountResources`, ledger info (`/v1/`). The fork server caches each unique resource on first fetch; subsequent reads hit the local snapshot.
+- **Supported**: account / resource reads (`aptos.getAccountInfo`, `aptos.getAccountResource`, `aptos.getAccountResources`), ledger info, and view functions (`harness.runViewFunction`, `MoveContract.view`). Account / resource reads cache locally on first fetch; view results are proxied to upstream every call (not cached, so they always reflect current upstream state).
 - **Rejected at the harness layer**: `deployCodeObject`, `upgradeCodeObject`, `runMoveScript` — all throw synchronously with a clear error message.
-- **Not yet supported** (tracked in [#243](https://github.com/gilbertsahumada/movehat/issues/243)): `runViewFunction` and `MoveContract.view` — the fork server does not currently proxy `/v1/view` to upstream RPC. `MoveContract.call` is similarly unguarded at the harness layer and fails with an opaque 404 from the fork server.
+- **Not supported yet**: `MoveContract.call` and any direct transaction submission. The fork server has no `/v1/transactions` handler; these fail with HTTP 404. A **writable** fork (Foundry-style: fork mainnet then deploy + call into it) is tracked in [#192](https://github.com/gilbertsahumada/movehat/issues/192).
 
-A **writable** fork (Foundry-style: fork mainnet then deploy + call into it) is tracked separately in [#192](https://github.com/gilbertsahumada/movehat/issues/192).
+**Important gotcha for view functions**: view calls are proxied to *upstream* — they reflect the upstream network's state, not any local mutations you made via `forkManager.setResource` or `forkManager.fundAccount`. For the dominant use case ("read a real mainnet view"), this is what you want. For "deploy to a fork, then view the result", you need a writable fork (#192).
 
 **When to reach for it**: snapshot real on-chain account / resource shapes for deterministic tests, or verify that read paths through your code interact correctly with real framework types. For anything that requires a view function or transaction execution today, use `createLocal` instead.
 

--- a/packages/docs/content/docs/guides/tutorial-fork-testing.mdx
+++ b/packages/docs/content/docs/guides/tutorial-fork-testing.mdx
@@ -8,19 +8,19 @@ This tutorial walks through using `Harness.createFork()` to read live Movement m
 
 ## What fork mode is good for today
 
-The fork system caches **accounts and resources** from a remote network and serves them from a local proxy. Useful for:
+The fork system caches **accounts and resources** from a remote network and serves them from a local proxy; **view functions** are proxied to upstream on every call (not cached, so they always reflect upstream state). Useful for:
 
 - Asserting against the real on-chain shape of framework types (e.g. `0x1::coin::CoinInfo`).
+- Running view functions against real mainnet state without spending gas — e.g., "what's the current total MOVE supply?" or "what does this DEX's `get_price` view return right now?".
 - Snapshotting mainnet state for deterministic tests that don't need to spend gas or wait for RPC.
 - Verifying that your code correctly bails when handed a read-only handle.
 
-Three things fork mode does **not** support today (issue [#243](https://github.com/gilbertsahumada/movehat/issues/243) tracks the first two):
+What fork mode does **not** support today:
 
-1. `harness.runViewFunction(...)` — the local fork proxy does not route `/v1/view` to upstream RPC yet.
-2. `MoveContract.view(...)` — same reason; it's the same endpoint under the hood.
-3. Transaction submission — `MoveContract.call(...)`, `harness.deployCodeObject(...)`, etc. are rejected. The deploy/upgrade/script methods throw a synchronous error from the harness Proxy; `MoveContract.call` currently fails with an opaque 404 from the fork server (also tracked in #243).
+- **Transaction submission** — `MoveContract.call(...)`, `harness.deployCodeObject(...)`, `harness.upgradeCodeObject(...)`, `harness.runMoveScript(...)`. The deploy/upgrade/script methods throw a synchronous error from the harness Proxy; direct `MoveContract.call` fails with HTTP 404 from the fork server (the `/v1/transactions` endpoint is not handled). A **writable** fork (Foundry-style: fork mainnet then deploy + call into it) is tracked in [#192](https://github.com/gilbertsahumada/movehat/issues/192).
+- **View functions against fork-local mutations** — view calls are proxied upstream, so they don't see resources you mutated via `forkManager.setResource` or `forkManager.fundAccount`. They reflect the upstream network's state, not your local snapshot. Same writable-fork issue (#192).
 
-When you need any of those, use `Harness.createLocal()` (fresh chain) or `Harness.createLive(network)` (real RPC, real gas) — see [Networks and modes](./networks-and-modes).
+When you need transaction execution, use `Harness.createLocal()` (fresh chain) or `Harness.createLive(network)` (real RPC, real gas) — see [Networks and modes](./networks-and-modes).
 
 ## Prerequisites
 
@@ -97,24 +97,51 @@ it("reads 0x1's account resource", async () => {
 });
 ```
 
-The fork server proxies four GET endpoints to your snapshot cache:
+The fork server handles five endpoints today:
 
 | Endpoint | Backed by |
 |---|---|
 | `GET /v1/` | Synthetic ledger info reflecting the snapshot's pinned version |
-| `GET /v1/accounts/:addr` | Cached account metadata |
-| `GET /v1/accounts/:addr/resource/:type` | Cached single resource |
-| `GET /v1/accounts/:addr/resources` | Cached resource bundle |
+| `GET /v1/accounts/:addr` | Cached account metadata (lazy-fetched on first call) |
+| `GET /v1/accounts/:addr/resource/:type` | Cached single resource (lazy-fetched on first call) |
+| `GET /v1/accounts/:addr/resources` | Cached resource bundle (lazy-fetched on first call) |
+| `POST /v1/view` | **Proxied to upstream every call** — view results are not cached |
 
-Any other path returns `404 endpoint_not_found`. That's why `runViewFunction` and transaction submission don't work yet — see issue [#243](https://github.com/gilbertsahumada/movehat/issues/243).
+Anything else (notably `POST /v1/transactions`) returns `404 endpoint_not_found`. That's why fork mode can't execute transactions — issue [#192](https://github.com/gilbertsahumada/movehat/issues/192) tracks writable-fork.
 
-## Step 4 — Observe the cache
+## Step 4 — Run a view function against real mainnet state
+
+This is the most powerful read-side use case: ask the network "what does this view function return right now?", without spending gas or deploying anything. Movement framework views work without any setup:
+
+```typescript
+it("reads the live MOVE supply via 0x1::coin::supply", async () => {
+  const [supply] = await harness.runViewFunction({
+    function: "0x1::coin::supply",
+    typeArguments: ["0x1::aptos_coin::AptosCoin"],
+    functionArguments: [],
+  });
+
+  // supply comes back as { vec: ["<u128 as string>"] } in the framework's
+  // Option<u128> shape; unwrap if you want the number.
+  expect(supply).to.be.an("object");
+});
+```
+
+In `-v` mode you'll see the proxy hit:
+
+```
+[2026-05-20T...] POST /v1/view
+```
+
+The fork server forwards the entire payload to the upstream RPC and returns the response unchanged. This means view results reflect the *upstream* network — they don't see any local state you mutated via `forkManager.setResource` / `forkManager.fundAccount`. For the dominant use case ("read mainnet view"), this is exactly what you want.
+
+## Step 5 — Observe the cache
 
 Run the test twice in a row. The second run is dramatically faster because every resource read hits the on-disk snapshot under `.movehat/forks/test-local/` instead of the upstream mainnet RPC.
 
 If you want a clean re-fetch, delete the fork directory or pass `forkResetState: true` (the default for `setupLocalTesting` direct use — `Harness.createFork` does not expose a knob for this; if you need it, drop down to `setupLocalTesting({ mode: "fork", forkResetState: true })`).
 
-## Step 5 — Verify writes are rejected
+## Step 6 — Verify writes are rejected
 
 The harness rejects deploy, upgrade, and script execution synchronously on fork-mode instances:
 
@@ -134,7 +161,7 @@ it("rejects deploy on a fork-mode harness", async () => {
 });
 ```
 
-The same guard fires for `harness.upgradeCodeObject(...)` and `harness.runMoveScript(...)`. Direct `MoveContract.call(...)` is not yet guarded at the harness layer — it currently fails with an opaque 404 from the fork server. Both behaviors are tracked in [#243](https://github.com/gilbertsahumada/movehat/issues/243).
+The same guard fires for `harness.upgradeCodeObject(...)` and `harness.runMoveScript(...)`. Direct `MoveContract.call(...)` is not guarded at the harness layer — it fails with a structured HTTP 404 from the fork server (the `/v1/transactions` endpoint is not implemented). Writable-fork support is tracked in [#192](https://github.com/gilbertsahumada/movehat/issues/192).
 
 ## Run
 
@@ -150,9 +177,10 @@ Expected output:
   Fork: read mainnet 0x1 framework state
     ✔ reads the 0x1 framework account from mainnet
     ✔ reads 0x1's account resource
+    ✔ reads the live MOVE supply via 0x1::coin::supply
     ✔ rejects deploy on a fork-mode harness
 
-  3 passing
+  4 passing
 ```
 
 ## Troubleshooting
@@ -172,9 +200,13 @@ The warning is informational — the harness skips the deploy and continues. Mov
 
 Each first-time resource fetch hits the upstream mainnet RPC. If your test reads many resources, throttle the cold path by hitting them sequentially in `before` (so the cache is warm by the time the assertions run) and committing `.movehat/forks/test-local/` if you want CI runs to skip the cold fetch entirely.
 
-### `Endpoint not found: /v1/view`
+### `Endpoint not found: /v1/transactions` (HTTP 404)
 
-You hit the gap tracked in [#243](https://github.com/gilbertsahumada/movehat/issues/243). `runViewFunction` and `MoveContract.view` are not yet proxied through the fork server. Workaround: read the underlying resource directly via `aptos.getAccountResource` and parse the field yourself, or switch the test to `createLocal` if you don't strictly need real mainnet state.
+You called `MoveContract.call(...)` or otherwise attempted to submit a transaction. Fork mode is read-only — there is no `/v1/transactions` handler. Writable-fork support is tracked in [#192](https://github.com/gilbertsahumada/movehat/issues/192). For now, switch the test to `Harness.createLocal()` (fresh chain) when you need to execute transactions.
+
+### `Upstream view-fn call failed` (HTTP 502)
+
+The fork server proxied your view call to upstream, but upstream returned an error (timeout, connection refused, non-200 response). Check that the upstream RPC for your fork's network is reachable and that the view function exists at the cited address. Run with `-v` to see the full upstream error message.
 
 ## Next steps
 

--- a/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.proxy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { Harness, HarnessDisposedError } from "../../harness/index.js";
+import { createForkContractProxy } from "../../harness/proxy.js";
 import { setupHarnessTestFixture, type HarnessTestFixture } from "./_fixture.js";
 
 /**
@@ -93,6 +94,32 @@ describe("Harness — proxy poisoning", () => {
 
   // Dedicated suites exist for each of the four methods
   // (codeObject.deploy/upgrade.test.ts, view.test.ts, script.test.ts).
+
+  it("createForkContractProxy: .call throws synchronously with a fork-mode message", () => {
+    const stub = {
+      call: () => Promise.resolve({ hash: "0x", success: true, vm_status: "ok" }),
+      view: () => Promise.resolve("read"),
+      getModuleId: () => "0x1::counter",
+    };
+    const wrapped = createForkContractProxy(stub);
+
+    // .call() throws synchronously, before the original method body runs.
+    expect(() => wrapped.call()).toThrow(/read-only|Harness\.createFork/i);
+
+    // Other methods pass through.
+    expect(wrapped.getModuleId()).toBe("0x1::counter");
+  });
+
+  it("createForkContractProxy: .view passes through unchanged", async () => {
+    const stub = {
+      call: () => Promise.resolve({ hash: "0x", success: true, vm_status: "ok" }),
+      view: () => Promise.resolve(42),
+      getModuleId: () => "0x1::counter",
+    };
+    const wrapped = createForkContractProxy(stub);
+
+    await expect(wrapped.view()).resolves.toBe(42);
+  });
 
   it("await harness.someAsyncMethod() pattern: post-cleanup throw happens before await", async () => {
     const harness = await Harness.createLive("testnet");

--- a/packages/movehat/src/fork/__tests__/server.test.ts
+++ b/packages/movehat/src/fork/__tests__/server.test.ts
@@ -1,8 +1,30 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { AddressInfo } from "net";
+
+// Stub the upstream API client so view-proxy tests stay offline.
+// Same hoisting + module-scoped fakes pattern used in manager.test.ts.
+const fakeApi = {
+  getLedgerInfo: vi.fn(),
+  getAccount: vi.fn(),
+  getAccountResource: vi.fn(),
+  getAccountResources: vi.fn(),
+  view: vi.fn(),
+};
+
+vi.mock("../api.js", () => ({
+  MovementApiClient: class {
+    constructor(_nodeUrl: string, _apiKey?: string) {}
+    getLedgerInfo = fakeApi.getLedgerInfo;
+    getAccount = fakeApi.getAccount;
+    getAccountResource = fakeApi.getAccountResource;
+    getAccountResources = fakeApi.getAccountResources;
+    view = fakeApi.view;
+  },
+}));
+
 import { ForkServer } from "../server.js";
 
 /**
@@ -61,5 +83,74 @@ describe("ForkServer", () => {
     const internal = (server as unknown as { server: { address(): AddressInfo } }).server;
     const addr = internal.address();
     expect(addr.address).toBe("::1");
+  });
+});
+
+describe("ForkServer — POST /v1/view proxy", () => {
+  let forkDir: string;
+  let server: ForkServer | null = null;
+
+  beforeEach(() => {
+    forkDir = makeForkDir();
+    fakeApi.view.mockReset();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+    rmSync(forkDir, { recursive: true, force: true });
+  });
+
+  async function postView(body: string): Promise<{ status: number; body: any }> {
+    server = new ForkServer(forkDir, 0);
+    await server.start();
+    const internal = (server as unknown as { server: { address(): AddressInfo } }).server;
+    const port = internal.address().port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/v1/view`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    return { status: res.status, body: await res.json() };
+  }
+
+  it("forwards a view-fn payload to upstream and returns the result", async () => {
+    fakeApi.view.mockResolvedValueOnce(["100"]);
+
+    const { status, body } = await postView(
+      JSON.stringify({ function: "0x1::coin::supply", type_arguments: [], arguments: [] }),
+    );
+
+    expect(status).toBe(200);
+    expect(body).toEqual(["100"]);
+    expect(fakeApi.view).toHaveBeenCalledTimes(1);
+    expect(fakeApi.view).toHaveBeenCalledWith({
+      function: "0x1::coin::supply",
+      type_arguments: [],
+      arguments: [],
+    });
+  });
+
+  it("rejects malformed JSON with 400 invalid_body", async () => {
+    const { status, body } = await postView("not-json{");
+
+    expect(status).toBe(400);
+    expect(body.error_code).toBe("invalid_body");
+    expect(fakeApi.view).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 upstream_error when the upstream RPC fails", async () => {
+    fakeApi.view.mockRejectedValueOnce(new Error("connection refused"));
+
+    const { status, body } = await postView(
+      JSON.stringify({ function: "0x1::coin::supply", type_arguments: [], arguments: [] }),
+    );
+
+    expect(status).toBe(502);
+    expect(body.error_code).toBe("upstream_error");
+    expect(body.message).toContain("connection refused");
   });
 });

--- a/packages/movehat/src/fork/__tests__/server.test.ts
+++ b/packages/movehat/src/fork/__tests__/server.test.ts
@@ -127,11 +127,18 @@ describe("ForkServer — POST /v1/view proxy", () => {
     expect(status).toBe(200);
     expect(body).toEqual(["100"]);
     expect(fakeApi.view).toHaveBeenCalledTimes(1);
-    expect(fakeApi.view).toHaveBeenCalledWith({
+    // The proxy forwards whitelisted headers (Accept, X-Aptos-Client)
+    // through to upstream. `fetch()` in this test doesn't set
+    // X-Aptos-Client, but undici sets a default `Accept: */*` we round-
+    // trip transparently.
+    const firstCall = fakeApi.view.mock.calls[0]!;
+    const [forwardedPayload, forwardedHeaders] = firstCall;
+    expect(forwardedPayload).toEqual({
       function: "0x1::coin::supply",
       type_arguments: [],
       arguments: [],
     });
+    expect(forwardedHeaders).not.toHaveProperty("X-Aptos-Client");
   });
 
   it("rejects malformed JSON with 400 invalid_body", async () => {
@@ -152,5 +159,33 @@ describe("ForkServer — POST /v1/view proxy", () => {
     expect(status).toBe(502);
     expect(body.error_code).toBe("upstream_error");
     expect(body.message).toContain("connection refused");
+  });
+
+  it("forwards Accept and X-Aptos-Client headers to upstream", async () => {
+    fakeApi.view.mockResolvedValueOnce(["forwarded"]);
+
+    server = new ForkServer(forkDir, 0);
+    await server.start();
+    const internal = (server as unknown as { server: { address(): AddressInfo } }).server;
+    const port = internal.address().port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/v1/view`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/x-bcs",
+        "X-Aptos-Client": "my-test-client/1.0",
+      },
+      body: JSON.stringify({ function: "0x1::coin::supply" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(fakeApi.view).toHaveBeenCalledWith(
+      { function: "0x1::coin::supply" },
+      {
+        Accept: "application/x-bcs",
+        "X-Aptos-Client": "my-test-client/1.0",
+      },
+    );
   });
 });

--- a/packages/movehat/src/fork/api.ts
+++ b/packages/movehat/src/fork/api.ts
@@ -148,8 +148,16 @@ export class MovementApiClient {
    * Mirrors `get<T>` for TLS/timeout/maxBytes/error-wrapping; differs
    * only in `method: 'POST'`, the `Content-Type: application/json`
    * header, and writing `body` to the request stream before `end()`.
+   *
+   * `extraHeaders` are merged in last and override defaults — used by
+   * the fork-server view proxy to forward client headers like
+   * `Accept` or `X-Aptos-Client` through to the upstream node.
    */
-  private async post<T>(path: string, body: unknown): Promise<T> {
+  private async post<T>(
+    path: string,
+    body: unknown,
+    extraHeaders: Record<string, string> = {}
+  ): Promise<T> {
     const fullUrl = `${this.nodeUrl}${path}`;
     const parsedUrl = new URL(fullUrl);
     const isHttps = parsedUrl.protocol === 'https:';
@@ -162,6 +170,11 @@ export class MovementApiClient {
     };
     if (this.apiKey !== undefined) {
       headers.Authorization = `Bearer ${this.apiKey}`;
+    }
+    for (const [k, v] of Object.entries(extraHeaders)) {
+      // Don't let callers override Content-Length — we just computed it.
+      if (k.toLowerCase() === 'content-length') continue;
+      headers[k] = v;
     }
 
     const timeoutMs = this.timeoutMs;
@@ -289,8 +302,15 @@ export class MovementApiClient {
    * Stateless passthrough — view results are not cached. Returns the raw
    * array the upstream API returns (single-value views still come back as
    * a one-element tuple).
+   *
+   * `extraHeaders` are forwarded to upstream — used by the fork server's
+   * view proxy to relay client headers (`Accept`, `X-Aptos-Client`, …)
+   * so downstream behavior such as BCS-encoded responses is preserved.
    */
-  async view(payload: unknown): Promise<unknown[]> {
-    return this.post<unknown[]>(this.apiPath('/view'), payload);
+  async view(
+    payload: unknown,
+    extraHeaders: Record<string, string> = {}
+  ): Promise<unknown[]> {
+    return this.post<unknown[]>(this.apiPath('/view'), payload, extraHeaders);
   }
 }

--- a/packages/movehat/src/fork/api.ts
+++ b/packages/movehat/src/fork/api.ts
@@ -143,6 +143,101 @@ export class MovementApiClient {
   }
 
   /**
+   * Make a POST request to the API with a JSON body.
+   *
+   * Mirrors `get<T>` for TLS/timeout/maxBytes/error-wrapping; differs
+   * only in `method: 'POST'`, the `Content-Type: application/json`
+   * header, and writing `body` to the request stream before `end()`.
+   */
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const fullUrl = `${this.nodeUrl}${path}`;
+    const parsedUrl = new URL(fullUrl);
+    const isHttps = parsedUrl.protocol === 'https:';
+    const client = isHttps ? https : http;
+
+    const payload = JSON.stringify(body);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(payload).toString(),
+    };
+    if (this.apiKey !== undefined) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
+
+    const timeoutMs = this.timeoutMs;
+    const maxBytes = this.maxBytes;
+
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        fn();
+      };
+
+      const req = client.request(fullUrl, { method: 'POST', headers }, (res) => {
+        const chunks: Buffer[] = [];
+        let totalBytes = 0;
+
+        res.on('data', (chunk: Buffer | string) => {
+          const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          totalBytes += buf.length;
+          if (totalBytes > maxBytes) {
+            req.destroy();
+            settle(() =>
+              reject(
+                new Error(
+                  `Response exceeded maxBytes (${maxBytes}); ${totalBytes} bytes received before abort`
+                )
+              )
+            );
+            return;
+          }
+          chunks.push(buf);
+        });
+
+        res.on('end', () => {
+          if (settled) return;
+          const data = Buffer.concat(chunks).toString('utf8');
+          if (res.statusCode !== 200) {
+            settle(() =>
+              reject(
+                new Error(
+                  `API request failed with status ${res.statusCode}: ${data}`
+                )
+              )
+            );
+            return;
+          }
+
+          try {
+            const parsed = JSON.parse(data);
+            settle(() => resolve(parsed));
+          } catch (err) {
+            settle(() =>
+              reject(new Error(`Failed to parse JSON response: ${err}`))
+            );
+          }
+        });
+      });
+
+      req.setTimeout(timeoutMs, () => {
+        req.destroy();
+        settle(() =>
+          reject(new Error(`API request timed out after ${timeoutMs}ms`))
+        );
+      });
+
+      req.on('error', (err) => {
+        settle(() => reject(new Error(`API request failed: ${err.message}`)));
+      });
+
+      req.write(payload);
+      req.end();
+    });
+  }
+
+  /**
    * Build API path with proper prefix
    */
   private apiPath(suffix: string): string {
@@ -186,5 +281,16 @@ export class MovementApiClient {
     const normalizedAddress = normalizeAddressShort(address);
 
     return this.get<AccountResource[]>(this.apiPath(`/accounts/${normalizedAddress}/resources`));
+  }
+
+  /**
+   * Execute a Move view function via the upstream node's POST /v1/view.
+   *
+   * Stateless passthrough — view results are not cached. Returns the raw
+   * array the upstream API returns (single-value views still come back as
+   * a one-element tuple).
+   */
+  async view(payload: unknown): Promise<unknown[]> {
+    return this.post<unknown[]>(this.apiPath('/view'), payload);
   }
 }

--- a/packages/movehat/src/fork/manager.ts
+++ b/packages/movehat/src/fork/manager.ts
@@ -193,6 +193,22 @@ export class ForkManager {
     return resources;
   }
 
+  /**
+   * Stateless passthrough of `POST /v1/view` to the upstream RPC.
+   *
+   * View results are not cached — they depend on ledger version and
+   * arguments, so any caching layer would need version-aware
+   * invalidation that the fork system does not implement today. The
+   * payload is forwarded verbatim and the upstream response array is
+   * returned unchanged.
+   */
+  async forwardView(payload: unknown): Promise<unknown[]> {
+    if (!this.apiClient) {
+      throw new Error('Fork not initialized. Call initialize() or load() first.');
+    }
+    return this.apiClient.view(payload);
+  }
+
   async setResource(address: string, resourceType: string, data: unknown): Promise<void> {
     const normalizedAddress = normalizeAddress(address);
     this.storage.saveResource(normalizedAddress, resourceType, data);

--- a/packages/movehat/src/fork/manager.ts
+++ b/packages/movehat/src/fork/manager.ts
@@ -201,12 +201,19 @@ export class ForkManager {
    * invalidation that the fork system does not implement today. The
    * payload is forwarded verbatim and the upstream response array is
    * returned unchanged.
+   *
+   * `extraHeaders` are forwarded to upstream so that client headers
+   * such as `Accept: application/x-bcs` (for BCS-encoded view results)
+   * or `X-Aptos-Client` round-trip through the proxy.
    */
-  async forwardView(payload: unknown): Promise<unknown[]> {
+  async forwardView(
+    payload: unknown,
+    extraHeaders: Record<string, string> = {}
+  ): Promise<unknown[]> {
     if (!this.apiClient) {
       throw new Error('Fork not initialized. Call initialize() or load() first.');
     }
-    return this.apiClient.view(payload);
+    return this.apiClient.view(payload, extraHeaders);
   }
 
   async setResource(address: string, resourceType: string, data: unknown): Promise<void> {

--- a/packages/movehat/src/fork/server.ts
+++ b/packages/movehat/src/fork/server.ts
@@ -397,8 +397,23 @@ export class ForkServer {
       return;
     }
 
+    // Forward a narrow set of client headers to upstream so that
+    // BCS-encoded responses (`Accept: application/x-bcs`) and client
+    // identification (`X-Aptos-Client`) round-trip through the proxy.
+    // Hop-by-hop and connection-level headers (host, connection,
+    // content-length, etc.) are deliberately not forwarded.
+    const forwardableHeaders: Record<string, string> = {};
+    for (const name of ['accept', 'x-aptos-client'] as const) {
+      const value = req.headers[name];
+      if (typeof value === 'string') {
+        // Use the canonical capitalization upstream expects.
+        const canonical = name === 'accept' ? 'Accept' : 'X-Aptos-Client';
+        forwardableHeaders[canonical] = value;
+      }
+    }
+
     try {
-      const result = await this.forkManager.forwardView(payload);
+      const result = await this.forkManager.forwardView(payload, forwardableHeaders);
       this.sendJSON(res, 200, result);
     } catch (error) {
       const rawMsg = error instanceof Error ? error.message : String(error);

--- a/packages/movehat/src/fork/server.ts
+++ b/packages/movehat/src/fork/server.ts
@@ -208,6 +208,8 @@ export class ForkServer {
           return;
         }
         await this.handleGetResource(address, resourceType, res);
+      } else if (pathname === '/v1/view' && req.method === 'POST') {
+        await this.handleViewProxy(req, res);
       } else {
         // Use regex capture for resources endpoint
         const resourcesMatch = pathname.match(/^\/v1\/accounts\/(0x[a-fA-F0-9]{1,64})\/resources$/);
@@ -331,6 +333,84 @@ export class ForkServer {
       } else {
         throw error;
       }
+    }
+  }
+
+  /**
+   * Handle POST /v1/view — proxy to upstream RPC.
+   *
+   * Stateless: view results are not cached. Buffers the request body
+   * with a 1 MiB ceiling, parses JSON, delegates to
+   * `forkManager.forwardView`, and returns the upstream array verbatim.
+   *
+   * Errors map to:
+   *   413 — body exceeds MAX_VIEW_BODY_BYTES
+   *   400 — body is not valid JSON
+   *   502 — upstream RPC failed (timeout, network error, non-200 response)
+   */
+  private async handleViewProxy(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> {
+    const MAX_VIEW_BODY_BYTES = 1 * 1024 * 1024; // 1 MiB
+
+    let body: string;
+    try {
+      body = await new Promise<string>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        let totalBytes = 0;
+        req.on('data', (chunk: Buffer | string) => {
+          const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          totalBytes += buf.length;
+          if (totalBytes > MAX_VIEW_BODY_BYTES) {
+            reject(new Error('body_too_large'));
+            req.destroy();
+            return;
+          }
+          chunks.push(buf);
+        });
+        req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+        req.on('error', (err) => reject(err));
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg === 'body_too_large') {
+        this.sendJSON(res, 413, {
+          message: `Request body exceeds ${MAX_VIEW_BODY_BYTES} bytes`,
+          error_code: 'body_too_large',
+          vm_error_code: null
+        });
+        return;
+      }
+      throw error;
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(body);
+    } catch {
+      this.sendJSON(res, 400, {
+        message: 'Request body is not valid JSON',
+        error_code: 'invalid_body',
+        vm_error_code: null
+      });
+      return;
+    }
+
+    try {
+      const result = await this.forkManager.forwardView(payload);
+      this.sendJSON(res, 200, result);
+    } catch (error) {
+      const rawMsg = error instanceof Error ? error.message : String(error);
+      // Sanitize: reuse the existing log-injection guard from
+      // sanitizePathname (control chars, length cap).
+      const safeMsg = this.sanitizePathname(rawMsg);
+      logger.error(`Upstream view-fn call failed: ${rawMsg}`);
+      this.sendJSON(res, 502, {
+        message: `Upstream view-fn call failed: ${safeMsg}`,
+        error_code: 'upstream_error',
+        vm_error_code: null
+      });
     }
   }
 

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -13,7 +13,7 @@ import type {
 } from "../types/harness.js";
 import { setupLocalTesting } from "../helpers/setupLocalTesting.js";
 import { initRuntime } from "../runtime.js";
-import { createHarnessProxy } from "./proxy.js";
+import { createHarnessProxy, createForkContractProxy } from "./proxy.js";
 import { deployCodeObject, upgradeCodeObject } from "./codeObject.js";
 import { runViewFunction } from "./view.js";
 import { runMoveScript } from "./script.js";
@@ -115,6 +115,14 @@ export class Harness {
     if (apiKey !== undefined) setupOpts.forkApiKey = apiKey;
     if (rpcUrl !== undefined) setupOpts.forkRpcUrl = rpcUrl;
     const ctx = await setupLocalTesting(setupOpts);
+
+    // Wrap getContract so contracts obtained in fork mode reject .call()
+    // synchronously instead of 404'ing against the fork server's
+    // unhandled /v1/transactions endpoint. View methods pass through.
+    const originalGetContract = ctx.runtime.getContract;
+    ctx.runtime.getContract = (address, moduleName) =>
+      createForkContractProxy(originalGetContract(address, moduleName));
+
     const init: HarnessInit = {
       mode: "fork",
       runtime: ctx.runtime,

--- a/packages/movehat/src/harness/proxy.ts
+++ b/packages/movehat/src/harness/proxy.ts
@@ -38,3 +38,29 @@ export function createHarnessProxy<T extends object>(
     },
   });
 }
+
+/**
+ * Wrap a `MoveContract` so that `.call(...)` throws synchronously in
+ * fork mode instead of hitting the fork server's unhandled
+ * `/v1/transactions` endpoint and surfacing as a confusing HTTP 404.
+ *
+ * Read methods (`view`, `getModuleId`) pass through. Tracks the same
+ * design as the harness-level guards in {@link createHarnessProxy} for
+ * `deployCodeObject` / `upgradeCodeObject` / `runMoveScript`. Writable-
+ * fork support that would make `.call` execute against a local Move VM
+ * is tracked separately in [#192](https://github.com/gilbertsahumada/movehat/issues/192).
+ */
+export function createForkContractProxy<T extends object>(target: T): T {
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      if (prop === "call") {
+        return () => {
+          throw new Error(
+            "Harness.createFork is read-only; MoveContract.call requires Harness.createLocal or createLive. Writable-fork support is tracked in #192."
+          );
+        };
+      }
+      return Reflect.get(obj, prop, receiver);
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `POST /v1/view` passthrough proxy to `ForkServer`. Closes the gap surfaced empirically in PR #244 (`/tmp/fork-gap-demo/demo.mjs`).
- `MovementApiClient` gains a private `post<T>` helper mirroring `get<T>` (TLS/timeout/maxBytes/error wrapping) and a public `view(payload)` method.
- `ForkManager` gains a `forwardView(payload)` passthrough (no caching — view results depend on ledger version + args, and version-aware invalidation does not exist today).
- `ForkServer` gains `handleViewProxy(req, res)` — buffers the body with a 1 MiB ceiling, parses JSON, calls `forwardView`, returns the upstream array verbatim. Errors map cleanly: 413 (body too large), 400 (invalid JSON), 502 (upstream failure).
- Three vitest cases in `src/fork/__tests__/server.test.ts` cover happy path, bad JSON, and upstream failure — using the existing `vi.mock("../api.js")` pattern for offline determinism.
- Docs flipped: `networks-and-modes.mdx` and `tutorial-fork-testing.mdx` now promote view-fn support to "Supported" with a real working example (`0x1::coin::supply<AptosCoin>` against Movement testnet) and remove the stale "Endpoint not found: /v1/view" troubleshooting entry.

Out of scope (stays in #192): `POST /v1/transactions` — writable-fork is materially harder and needs either a local Move VM or upstream `simulate_transaction` integration.

## What I verified

- **Unit tests**: `pnpm --filter movehat test` → 471 passed (5 in the touched `server.test.ts`, including 3 new cases).
- **Coverage gate**: `pnpm --filter movehat test:coverage` → green (per-file gates on critical modules unchanged). `manager.ts` at 96.33%.
- **Tier 1 typecheck**: `pnpm check:example` → green.
- **Docs build**: `cd packages/docs && npx next build` → 71 routes, clean.
- **Empirical** (the important one): re-ran `/tmp/fork-gap-demo/demo.mjs` after rebuilding movehat. `POST /v1/view` now returns **HTTP 200** with real testnet data:

  ```
  HTTP 200  POST /v1/view  (view fn — claimed)
              body: [
                {
                  "vec": [
                    "418947910172177144802"
                  ]
                }
              ]
  ```

  That's the live MOVE total supply in octas from Movement testnet. `POST /v1/transactions` correctly stays at 404 (still #192's territory).

## What I did **not** verify

- Behavior under upstream RPC rate limiting. The proxy forwards the upstream's response verbatim, so a 429 from upstream will surface as a 502 with the original message inside — acceptable.
- BCS-encoded view responses. The endpoint defaults to JSON per the Movement REST spec; if a caller sets `Accept: application/x-bcs`, our header-passthrough is incomplete (we set `Content-Type: application/json` on the outgoing request and don't forward `Accept`). Filing as a follow-up if any caller actually needs it.

## Test plan

- [x] `pnpm --filter movehat test`
- [x] `pnpm --filter movehat test:coverage`
- [x] `pnpm check:example`
- [x] `cd packages/docs && npx next build`
- [x] Empirical: `/tmp/fork-gap-demo/demo.mjs` → POST /v1/view returns 200 with real testnet supply
- [ ] After merge to `develop` → `main` batch: `curl -s -o /dev/null -w "%{http_code}\n" https://movehat.org/docs/guides/tutorial-fork-testing` returns 200 with the new view-fn step rendered

Closes #243
Tracks #238
