### PR TITLE
test: arg-shape pass-through integration coverage (#98)

### DIFF
--- a/packages/movehat/src/utils/__tests__/childProcessAdapter.test.ts
+++ b/packages/movehat/src/utils/__tests__/childProcessAdapter.test.ts
@@ -288,4 +288,58 @@ describe('defaultChildProcessAdapter.run with inheritStdio', () => {
       setTimeoutSpy.mockRestore();
     }
   });
+
+  // Regression coverage for the arg-shape pass-through that fake-adapter unit
+  // tests cannot exercise. The original bug was './move' being eaten somewhere
+  // between Movehat and the Movement CLI; spawn(cmd, args) is the contract we
+  // need to keep honoring forever.
+  describe('arg-shape pass-through', () => {
+    async function spawnAndCaptureArgv(extraArgs: string[]): Promise<string[]> {
+      // `--` after the script tells Node to treat following args as positional
+      // (not Node flags), so '--package-dir' etc. survive intact in argv.
+      const result = await defaultChildProcessAdapter.run({
+        command: NODE,
+        args: [
+          '-e',
+          'process.stdout.write(JSON.stringify(process.argv.slice(1)))',
+          '--',
+          ...extraArgs,
+        ],
+      });
+      expect(result.exitCode).toBe(0);
+      return JSON.parse(result.stdout);
+    }
+
+    it('passes path-with-slash literally (the ./move regression)', async () => {
+      expect(await spawnAndCaptureArgv(['./move'])).toEqual(['./move']);
+    });
+
+    it('passes args with embedded spaces as single argv entries', async () => {
+      expect(await spawnAndCaptureArgv(['hello world', 'foo'])).toEqual(['hello world', 'foo']);
+    });
+
+    it('passes flag-style args with equals signs', async () => {
+      expect(
+        await spawnAndCaptureArgv(['--package-dir', '.', '--named-addresses', 'counter=0x1'])
+      ).toEqual(['--package-dir', '.', '--named-addresses', 'counter=0x1']);
+    });
+
+    it('passes shell metacharacters literally (no shell interpretation)', async () => {
+      expect(
+        await spawnAndCaptureArgv(['$HOME', '`whoami`', '$(ls)', '|', '&&'])
+      ).toEqual(['$HOME', '`whoami`', '$(ls)', '|', '&&']);
+    });
+
+    it('passes empty-string args as empty entries (not dropped)', async () => {
+      expect(await spawnAndCaptureArgv(['first', '', 'third'])).toEqual(['first', '', 'third']);
+    });
+
+    it('passes unicode args correctly', async () => {
+      expect(await spawnAndCaptureArgv(['español', '日本語', '🚀'])).toEqual([
+        'español',
+        '日本語',
+        '🚀',
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Closes #98

Adds integration coverage for arg-shape pass-through via the real `defaultChildProcessAdapter`. The original bug (PR #97 / `./move` regression) survived the unit suite because injected fake adapters don't actually spawn a process.

### What the 6 new tests cover

Each uses Node binary as a deterministic spawn target. Helper asks the child to JSON-stringify its `argv.slice(1)`, then asserts the parsed array equals the input.

1. **path-with-slash literally** (`./move`) — the original regression
2. **embedded spaces** (`'hello world'`) — classic shell-split failure mode
3. **flag-style with `=`** (`--named-addresses counter=0x1`) — Movement CLI's actual usage
4. **shell metacharacters** (`$HOME`, `` `whoami` ``, `$(ls)`, `|`, `&&`) — proves we're using `spawn(cmd, args)` not `exec(cmdString)`
5. **empty-string** (`['first', '', 'third']`) — edge case
6. **unicode** (`español`, `日本語`, `🚀`) — encoding sanity

Note: helper inserts `--` after the inline `-e` script. Without it, Node consumes `--package-dir`-style args as Node flags and exits with code 9 (Invalid argument).

### Verification

- [x] Pre-flight: `pnpm --filter movehat exec vitest run src/utils/__tests__/childProcessAdapter.test.ts` → **25/25 pass**
- [x] Full suite: `pnpm --filter movehat test` → **513 pass** (was 507; +6)
- [x] Pre-push hook green (typecheck + build)
- [ ] CI on this PR
- [ ] §8 self-review before merge

### Why no Tier 2/3

Zero production code change. Test file only. Tier 2 (smoke) and Tier 3 (e2e) verify packaging/install which are unaffected. Marked N/A per CLAUDE.md §6.2/§6.3 rationale: change cannot affect the published artifact.

### Non-regression

Per user priority — verified the change introduces zero risk:
- No `src/**` files touched
- No exports changed
- Existing 507 tests all still pass

## Test plan

- [x] Unit tests (513 pass)
- [ ] CI matrix (Node 20/22)
- [ ] E2E (should pass — unrelated to test additions)
