### PR TITLE
ci: pin third-party actions to commit SHAs (#214)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3.0.0
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -46,7 +46,7 @@ jobs:
         run: pnpm --filter movehat run check-pack-contents
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: build-artifacts
           path: packages/movehat/dist/
@@ -60,15 +60,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3.0.0
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -80,7 +80,7 @@ jobs:
         run: pnpm test:coverage
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-report
           path: packages/movehat/coverage/
@@ -115,15 +115,15 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3.0.0
         with:
           version: 9
 
       - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
@@ -132,7 +132,7 @@ jobs:
         run: pnpm install
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: build-artifacts
           path: packages/movehat/dist/
@@ -154,15 +154,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3.0.0
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -171,14 +171,14 @@ jobs:
         run: pnpm install
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: build-artifacts
           path: packages/movehat/dist/
 
       - name: Cache Movement CLI binary
         id: cache-movement-cli
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ${{ runner.temp }}/movement
           # SHA256 prefixes tie cache hits to the pinned tarball and binary.
@@ -263,15 +263,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3.0.0
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -299,15 +299,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3.0.0
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,15 +23,15 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3.0.0
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -51,10 +51,10 @@ jobs:
           NEXT_PUBLIC_MOVEHAT_DOCS_SITE_URL: https://movehat.org
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5.0.0
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: packages/docs/out
 
@@ -75,4 +75,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3.0.0
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Closes #214

Pins 6 distinct action+version pairs across 3 internal workflows to 40-char commit SHAs. Supply-chain hardening — closes the risk of a maintainer compromise re-pointing `@v4` to a malicious commit between runs.

### Pinned mappings

```
actions/checkout@v4              → 34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
actions/setup-node@v4            → 49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
actions/cache@v4                 → 0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
actions/upload-artifact@v4       → ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
actions/download-artifact@v4     → d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
actions/configure-pages@v5       → 983d7736d9b0ae728b81ab479565c72886d7745b  # v5.0.0
actions/deploy-pages@v4          → d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5
actions/upload-pages-artifact@v3 → 56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
pnpm/action-setup@v3             → a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3.0.0
```

The trailing `# vN.N.N` comment lets Renovate/Dependabot suggest bumps without breaking the SHA pin guarantee.

### Scope deliberately excludes

- `examples/counter-example/.github/workflows/ci.yml` — user-facing reference workflow, kept approachable with `@v4` tags. Users who want supply-chain hardening can opt-in.
- `packages/docs/content/docs/guides/tutorial-ci.mdx` — same reason; tutorial code fence stays byte-identical with the example workflow per CLAUDE.md §6.4.

### Files changed

| File | LoC delta |
|---|---|
| `.github/workflows/ci.yml` | 46± |
| `.github/workflows/docs-deploy.yml` | 12± |
| `.github/workflows/publish.yml` | 6± |
| **Total** | **32 / 32** |

### Verification

- [x] `grep -nE "uses: actions/\|uses: pnpm/" .github/workflows/*.yml | grep -vE "@[a-f0-9]{40}"` → empty (no floating tags remain)
- [x] All SHAs verified via `gh api repos/<org>/<repo>/commits/<tag>` at time of pinning
- [ ] CI on this PR — green = SHAs resolve to valid actions

### Non-regression

Zero risk per the user priority:
- No `src/` change
- No application code change
- If any SHA is wrong, the GitHub Actions runner fails with "action not found" before the workflow can do anything. Caught immediately, no production impact.

## Test plan

- [x] No-floating-tags grep
- [ ] CI on this PR (build, tests, e2e — all must still find actions)
