### PR TITLE
fix(parser): drop fragile fallback regex in parseTxHash (#51)

### DIFF
--- a/packages/movehat/src/utils/__tests__/parseCliOutput.test.ts
+++ b/packages/movehat/src/utils/__tests__/parseCliOutput.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseTxHash } from '../parseCliOutput.js';
+
+// Real-world-ish hashes — distinct values so the "wrong-fallback" trap
+// is visible if anyone re-introduces the loose regex.
+const REAL_TX_HASH = '0x' + 'a'.repeat(64);
+const TRAP_HASH = '0x' + 'b'.repeat(64); // padded module address, state root, etc.
+
+describe('parseTxHash (regression: #51)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Logger uses console.warn under the hood (see ui/logger.ts:139).
+    // Spy at the console level so the assertion is decoupled from logger
+    // formatting choices.
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('extracts hash from the context-bearing pattern (transaction hash: 0x…)', () => {
+    const stdout = `Some prelude line\nTransaction hash: ${REAL_TX_HASH}\nMore output`;
+    expect(parseTxHash(stdout)).toBe(REAL_TX_HASH);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('extracts hash from "txn hash:" and "hash:" variants too', () => {
+    expect(parseTxHash(`txn hash: ${REAL_TX_HASH}`)).toBe(REAL_TX_HASH);
+    expect(parseTxHash(`hash: ${REAL_TX_HASH}`)).toBe(REAL_TX_HASH);
+  });
+
+  it('does NOT match a loose 64-hex literal — returns undefined + warns (the #51 trap)', () => {
+    // Stdout printed by Movement CLI with a 64-hex token (e.g. a padded
+    // module address, state root) BEFORE the actual txhash. Pre-#51 this
+    // returned TRAP_HASH silently; post-fix it returns undefined and the
+    // caller decides whether to error.
+    const stdout = `Module address: ${TRAP_HASH}\nDeploying...\n(no Transaction hash line)`;
+    expect(parseTxHash(stdout)).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]!.join(' ')).toContain('no contextual');
+  });
+
+  it('prefers the context-bearing hash when a trap hash appears first', () => {
+    // Critical: when both forms appear, the context-bearing one wins.
+    // The loose-regex fallback (now removed) would have returned TRAP_HASH
+    // because it was the first match in the stdout buffer.
+    const stdout = `Module address: ${TRAP_HASH}\nTransaction hash: ${REAL_TX_HASH}`;
+    expect(parseTxHash(stdout)).toBe(REAL_TX_HASH);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined + warns on empty stdout', () => {
+    expect(parseTxHash('')).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is case-insensitive on the context keyword', () => {
+    expect(parseTxHash(`TRANSACTION HASH: ${REAL_TX_HASH}`)).toBe(REAL_TX_HASH);
+    expect(parseTxHash(`Hash: ${REAL_TX_HASH}`)).toBe(REAL_TX_HASH);
+  });
+});

--- a/packages/movehat/src/utils/parseCliOutput.ts
+++ b/packages/movehat/src/utils/parseCliOutput.ts
@@ -4,12 +4,17 @@
  * @internal — not exported from `src/index.ts`.
  */
 
+import { logger } from '../ui/index.js';
+
 /**
  * Extract the transaction hash from a `movement` CLI subcommand's stdout.
  *
- * Tries the context-bearing pattern first (`transaction hash: 0x…`,
- * `txn hash: 0x…`, `hash: 0x…`) and falls back to any 64-char hex
- * literal in the buffer. Returns `undefined` if no candidate matches.
+ * Only the context-bearing pattern is accepted (`transaction hash: 0x…`,
+ * `txn hash: 0x…`, `hash: 0x…`). When the context is absent we log a
+ * warning and return `undefined` so callers decide whether to throw —
+ * the previous behavior of falling back to "any 64-hex literal" was
+ * fragile: a padded module address or state root printed before the
+ * actual txhash would silently corrupt the cached deployment record.
  *
  * Shared by `core/Publisher.ts` (publish), `harness/codeObject.ts`
  * (deploy-object / upgrade-object), and `harness/script.ts`
@@ -22,6 +27,9 @@ export function parseTxHash(stdout: string): string | undefined {
     /(?:transaction\s*(?:hash)?|txn\s*(?:hash)?|hash):\s*(0x[a-fA-F0-9]{64})\b/i
   );
   if (withContext?.[1]) return withContext[1];
-  const fallback = stdout.match(/\b(0x[a-fA-F0-9]{64})\b/);
-  return fallback?.[1];
+  logger.warning(
+    `parseTxHash: no contextual 'transaction|txn|hash: 0x…' match in ${stdout.length}-byte CLI output. ` +
+      `Returning undefined; the caller decides whether to error.`
+  );
+  return undefined;
 }


### PR DESCRIPTION
## Closes #51

The previous `parseTxHash` fell back to matching the FIRST 64-char hex literal when the contextual pattern (`transaction|txn|hash: 0x…`) missed. This silently returned the WRONG hash whenever Movement CLI printed another 64-hex token before the actual transaction hash (e.g. a padded module address, a state root).

### What changes in production

`packages/movehat/src/utils/parseCliOutput.ts`:
- Removed the loose `\b(0x[a-fA-F0-9]{64})\b` fallback
- Added `logger.warning` when no contextual match is found
- Still returns `undefined` — caller behavior is unchanged

### Caller verification (no behavior regression)

All 3 callers already tolerated `undefined` from the parser:
- `core/Publisher.ts:245` — assigns to optional `deployment.txHash` field, silent acceptance
- `harness/codeObject.ts:290` — same pattern
- `harness/script.ts:154` — explicitly `if (!txHash) throw new Error(...)` with clear message

The only behavior change: when context-match fails and there's a hex blob in stdout, today's code returns a wrong-hash silently; after this fix, returns `undefined` with a logger warning. Publisher/codeObject record a deployment with no txHash (visible). Script throws (loud) — same as today.

### New regression tests

`packages/movehat/src/utils/__tests__/parseCliOutput.test.ts` (NEW, 6 cases):

1. context-bearing pattern extracts correctly
2. `txn hash:` and `hash:` variants extract correctly
3. **the #51 trap**: loose 64-hex literal returns undefined + warns (would have caught the silent wrong-hash regression)
4. when BOTH trap-hash AND context-hash appear, the context-bearing one wins (NOT the first match — this was the original bug)
5. empty stdout returns undefined + warns
6. case-insensitive on the keyword

### Verification

- [x] Pre-flight: `pnpm --filter movehat exec vitest run src/utils/__tests__/parseCliOutput.test.ts` → **6/6 pass**
- [x] Full suite: `pnpm --filter movehat test` → **523 pass** (517 → +6)
- [x] Pre-push hook green
- [ ] CI on this PR

### Non-regression (user priority)

- Caller tolerance verified (see "Caller verification" above)
- Failure mode shifts from SILENT WRONG-HASH to LOUD WARNING — strictly better
- Script-path users get a clear thrown error (same as today)
- Publisher/codeObject deployment records may have missing `txHash` in the rare case context-match fails — but the deployment IS on chain, this is a bookkeeping degradation not a deploy failure

## Test plan

- [x] Unit suite (523)
- [x] Caller tolerance audit
- [ ] CI third-party gates
