### PR TITLE
fix(security): require URL allowlist before auto-injecting test key (#40)

### DIFF
--- a/packages/movehat/src/core/__tests__/config.test.ts
+++ b/packages/movehat/src/core/__tests__/config.test.ts
@@ -374,4 +374,84 @@ describe("resolveNetworkConfig", () => {
     const resolved = await resolveNetworkConfig(user, "a");
     expect(resolved.profile).toBe("custom-profile");
   });
+
+  // Regression coverage for #40 — auto-injection of the deterministic test
+  // key (0x0..01) was previously gated only on the network NAME being
+  // 'testnet' / 'local'. A user-named 'testnet' pointing at a production
+  // URL silently inherited the weak key. Now name AND URL host must match.
+  describe("test-key auto-injection gate (#40)", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("injects test key for 'testnet' network with canonical Movement testnet URL", async () => {
+      const user = baseUserConfig({
+        testnet: {
+          url: "https://testnet.movementnetwork.xyz/v1",
+          chainId: "testnet",
+        },
+      });
+      const resolved = await resolveNetworkConfig(user, "testnet");
+      expect(resolved.privateKey).toBe(
+        "0x0000000000000000000000000000000000000000000000000000000000000001"
+      );
+    });
+
+    it("injects test key for 'local' network with localhost URL", async () => {
+      const user = baseUserConfig({
+        local: { url: "http://localhost:8080/v1", chainId: "local" },
+      });
+      const resolved = await resolveNetworkConfig(user, "local");
+      expect(resolved.privateKey).toBe(
+        "0x0000000000000000000000000000000000000000000000000000000000000001"
+      );
+    });
+
+    it("REFUSES to inject test key when 'testnet' name points at a non-test URL (the #40 trap)", async () => {
+      const user = baseUserConfig({
+        testnet: { url: "https://prod.example.com/v1", chainId: "testnet" },
+      });
+      await expect(resolveNetworkConfig(user, "testnet")).rejects.toThrow(
+        /has no accounts configured/
+      );
+      const warningMessages = warnSpy.mock.calls.map((c) => c.join(" "));
+      expect(
+        warningMessages.some((m) => /not a recognized test endpoint/i.test(m))
+      ).toBe(true);
+    });
+
+    it("REFUSES to inject test key when 'local' name points at a remote URL", async () => {
+      const user = baseUserConfig({
+        local: { url: "https://prod.example.com/v1", chainId: "local" },
+      });
+      await expect(resolveNetworkConfig(user, "local")).rejects.toThrow(
+        /has no accounts configured/
+      );
+    });
+
+    it("treats 127.0.0.1 as a known test endpoint", async () => {
+      const user = baseUserConfig({
+        local: { url: "http://127.0.0.1:8080/v1", chainId: "local" },
+      });
+      const resolved = await resolveNetworkConfig(user, "local");
+      expect(resolved.privateKey).toBe(
+        "0x0000000000000000000000000000000000000000000000000000000000000001"
+      );
+    });
+
+    it("rejects malformed URLs without injecting (URL parser returns false)", async () => {
+      const user = baseUserConfig({
+        testnet: { url: "not-a-url", chainId: "testnet" },
+      });
+      await expect(resolveNetworkConfig(user, "testnet")).rejects.toThrow(
+        /has no accounts configured/
+      );
+    });
+  });
 });

--- a/packages/movehat/src/core/config.ts
+++ b/packages/movehat/src/core/config.ts
@@ -21,6 +21,26 @@ interface ConfigCacheEntry {
 // needed.
 const configCache = new Map<string, ConfigCacheEntry>();
 
+// Hostnames recognized as safe targets for the deterministic test key
+// auto-injection. Any URL whose hostname is not in this set causes the
+// test-key path to be skipped even if the network NAME is 'testnet' or
+// 'local' (#40 — name-only gating was spoofable when users named a
+// production-pointing network 'testnet').
+const TEST_ENDPOINT_HOSTS = new Set([
+  "testnet.movementnetwork.xyz",
+  "localhost",
+  "127.0.0.1",
+  "::1",
+]);
+
+function isKnownTestEndpoint(url: string): boolean {
+  try {
+    return TEST_ENDPOINT_HOSTS.has(new URL(url).hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Loads the user's movehat.config.{ts,js} from the current working directory.
  *
@@ -175,15 +195,36 @@ export async function resolveNetworkConfig(
     accounts = [process.env.PRIVATE_KEY];
   }
 
-  // 4. Validate we have at least one account (unless using testnet/local)
+  // 4. Validate we have at least one account (unless using testnet/local
+  //    AND the URL is a recognized test endpoint — name alone is not enough
+  //    per #40, since a user can name a network 'testnet' but point it at
+  //    a production RPC and would otherwise inherit the deterministic test
+  //    key with a production endpoint).
   if (accounts.length === 0 || !accounts[0]) {
-    // Special case: Auto-generate test accounts for testing networks
-    // testnet = public Movement test network (recommended)
-    // local = local fork server
-    if (selectedNetwork === "testnet" || selectedNetwork === "local") {
+    const isTestNetworkName =
+      selectedNetwork === "testnet" || selectedNetwork === "local";
+    const isTestEndpoint =
+      isTestNetworkName && isKnownTestEndpoint(networkConfig.url);
+
+    if (isTestNetworkName && !isTestEndpoint) {
+      // Name matches the reserved convention but URL is not a recognized
+      // test endpoint — block the deterministic test-key injection. Falls
+      // through to the standard "no accounts" throw below so the user gets
+      // actionable guidance.
+      logger.warning(
+        `Network '${selectedNetwork}' uses a name reserved for testnet/local ` +
+          `but '${networkConfig.url}' is not a recognized test endpoint. ` +
+          `Skipping auto-injection of the deterministic test key to protect ` +
+          `against accidental production use. Set PRIVATE_KEY explicitly, ` +
+          `configure 'accounts' in movehat.config.ts, or rename this network.`
+      );
+    }
+
+    if (isTestEndpoint) {
       // Security: Using a deterministic test account (like Hardhat's default accounts)
       // This is SAFE because:
-      // 1. Only used for testnet/local (never mainnet - that throws error below)
+      // 1. Only used for testnet/local against a known test endpoint
+      //    (network NAME + URL allowlist enforced above; bypassed otherwise)
       // 2. Perfect for transaction simulation (no real funds)
       // 3. Deterministic = consistent test results
       const testPrivateKey = "0x0000000000000000000000000000000000000000000000000000000000000001";
@@ -193,8 +234,9 @@ export async function resolveNetworkConfig(
       logger.warning("[TESTNET] For mainnet, set PRIVATE_KEY in .env");
       logger.newline();
     } else {
-      // For any other network (especially mainnet), REQUIRE explicit configuration
-      // This prevents accidentally using the test key on production networks
+      // For any other network (mainnet, or testnet/local with a non-test
+      // URL), REQUIRE explicit configuration. This prevents accidentally
+      // using the test key on production networks.
       throw new Error(
         `Network '${selectedNetwork}' has no accounts configured.\n` +
         `\n` +


### PR DESCRIPTION
## Closes #40

The deterministic test key (`0x0..01`) was previously injected whenever the network NAME matched `testnet` or `local` — regardless of what URL the user pointed that network at. A user who defined:

```ts
{ networks: { testnet: { url: 'https://prod.example.com/v1', ... } } }
```

…silently got the well-known test key with a production endpoint. Critical (low-probability, high-impact) footgun, especially with `setupTestFixture` flows that don't surface the key being used.

### Fix

Gate the test-key injection on **both** network name AND URL host being in an allowlist:

```
TEST_ENDPOINT_HOSTS = { testnet.movementnetwork.xyz, localhost, 127.0.0.1, ::1 }
```

When name matches but URL doesn't:
1. Log a `logger.warning` explaining why injection was skipped
2. Fall through to the standard "no accounts configured" throw with actionable guidance (PRIVATE_KEY env, explicit `accounts` config, or rename)

### Failure mode shift

| Before | After |
|---|---|
| SILENT test-key injection with arbitrary URL | LOUD warning + explicit "no accounts" error unless URL matches allowlist |

Strictly safer. No more silent test-key on production.

### Backward-compat (non-regression check)

- Users with literal `testnet` / `local` pointing at the canonical URLs → **IDENTICAL behavior** (test key injected as before)
- Users with explicit `accounts` in their config → **unaffected** (the auto-inject branch only fires when `accounts` is empty)
- Users with `PRIVATE_KEY` env var → **unaffected** (env path takes precedence)
- Users who renamed `testnet` to point at custom URL → **now get a clear warning + error** instead of silently using the wrong key

### Phase 3 deferred to 0.3.0

This PR ships Phases 1+2 (gate + warn). Phase 3 (hard-fail with breaking error message instead of warn-and-skip) is deferred to 0.3.0 per MAINTENANCE.md deprecation policy.

### Verification

- [x] Pre-flight: `pnpm --filter movehat exec vitest run src/core/__tests__/config.test.ts` → **30/30 pass** (was 24; +6 new)
- [x] Full suite: `pnpm --filter movehat test` → **529 pass** (was 523; +6)
- [x] Pre-push hook green
- [ ] CI on this PR

### New tests (6 cases)

1. canonical Movement testnet URL → injects test key
2. localhost URL with `local` network → injects test key
3. **THE #40 TRAP**: `testnet` name + production URL → throws + warn
4. `local` name + remote URL → throws
5. `127.0.0.1` is recognized as test endpoint
6. malformed URL (no `://`) → throws (no injection)

## Test plan

- [x] Unit suite (529)
- [x] Backward-compat audit
- [ ] CI third-party gates
