### PR TITLE
fix(security): prefer movehat-bundled tsx over cwd resolution (#52)

### DIFF
--- a/packages/movehat/src/commands/__tests__/run.test.ts
+++ b/packages/movehat/src/commands/__tests__/run.test.ts
@@ -13,7 +13,7 @@ vi.mock("../../utils/runCli.js", () => ({
 }));
 
 // Static import after mock declaration — vi hoists vi.mock.
-const { default: runCommand } = await import("../run.js");
+const { default: runCommand, resolveTsxCliPath } = await import("../run.js");
 
 /**
  * Direct coverage for the signal-forwarding branch added to fix the
@@ -188,5 +188,112 @@ describe("runCommand — orchestrator", () => {
     const path = join(tmpCwd, "script.ts");
     writeFileSync(path, "");
     await expect(runCommand("script.ts")).rejects.toThrow("__test_exit_1__");
+  });
+});
+
+// Regression coverage for #52 — tsx resolution priority. Previously cwd
+// was tried first, allowing a malicious node_modules/tsx in an untrusted
+// project dir to take over the runner. Now bundled tsx is preferred by
+// default; cwd resolution is opt-in via MOVEHAT_TSX_FROM_CWD=1.
+describe("resolveTsxCliPath (#52)", () => {
+  it("returns a path ending in dist/cli.mjs when tsx is resolvable", () => {
+    const path = resolveTsxCliPath();
+    expect(path).not.toBeNull();
+    expect(path).toMatch(/[\\/]dist[\\/]cli\.mjs$/);
+  });
+
+  it("returns the same valid path when preferCwd is explicitly false (default)", () => {
+    expect(resolveTsxCliPath({ preferCwd: false })).toMatch(
+      /[\\/]dist[\\/]cli\.mjs$/
+    );
+  });
+
+  it("with preferCwd:true still returns a valid path when cwd has tsx too", () => {
+    // At test time, cwd (packages/movehat) has tsx hoisted via the
+    // workspace, so a strict cwd-first lookup also succeeds. The key
+    // assertion: we always get a valid path. Filesystem-controlled
+    // order assertions are out of scope (see the 'tsx not found' note
+    // earlier in this file).
+    expect(resolveTsxCliPath({ preferCwd: true })).toMatch(
+      /[\\/]dist[\\/]cli\.mjs$/
+    );
+  });
+
+  it("respects MOVEHAT_TSX_FROM_CWD=1 env var when no explicit opts", () => {
+    const before = process.env.MOVEHAT_TSX_FROM_CWD;
+    process.env.MOVEHAT_TSX_FROM_CWD = "1";
+    try {
+      expect(resolveTsxCliPath()).toMatch(/[\\/]dist[\\/]cli\.mjs$/);
+    } finally {
+      if (before === undefined) delete process.env.MOVEHAT_TSX_FROM_CWD;
+      else process.env.MOVEHAT_TSX_FROM_CWD = before;
+    }
+  });
+});
+
+describe("runCommand — MOVEHAT_TSX_FROM_CWD warning (#52)", () => {
+  let tmpCwd: string;
+  let cwdBefore: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-run-cwdwarn-"));
+    cwdBefore = process.cwd();
+    process.chdir(tmpCwd);
+    runCliMock.mockReset();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.chdir(cwdBefore);
+    rmSync(tmpCwd, { recursive: true, force: true });
+    warnSpy.mockRestore();
+  });
+
+  it("emits a warning when MOVEHAT_TSX_FROM_CWD=1 is set", async () => {
+    const before = process.env.MOVEHAT_TSX_FROM_CWD;
+    process.env.MOVEHAT_TSX_FROM_CWD = "1";
+    runCliMock.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+    const script = join(tmpCwd, "script.ts");
+    writeFileSync(script, "");
+
+    try {
+      await runCommand("script.ts");
+    } catch {
+      // process.exit propagation may throw; the warning fires first
+    }
+
+    const messages = warnSpy.mock.calls.map((c) => c.join(" "));
+    expect(messages.some((m) => /MOVEHAT_TSX_FROM_CWD=1/.test(m))).toBe(true);
+
+    if (before === undefined) delete process.env.MOVEHAT_TSX_FROM_CWD;
+    else process.env.MOVEHAT_TSX_FROM_CWD = before;
+  });
+
+  it("does NOT emit the warning under default behavior", async () => {
+    const before = process.env.MOVEHAT_TSX_FROM_CWD;
+    delete process.env.MOVEHAT_TSX_FROM_CWD;
+    runCliMock.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+    const script = join(tmpCwd, "script.ts");
+    writeFileSync(script, "");
+
+    try {
+      await runCommand("script.ts");
+    } catch {
+      // ignore
+    }
+
+    const messages = warnSpy.mock.calls.map((c) => c.join(" "));
+    expect(messages.some((m) => /MOVEHAT_TSX_FROM_CWD/.test(m))).toBe(false);
+
+    if (before !== undefined) process.env.MOVEHAT_TSX_FROM_CWD = before;
   });
 });

--- a/packages/movehat/src/commands/run.ts
+++ b/packages/movehat/src/commands/run.ts
@@ -6,6 +6,47 @@ import { runCli } from "../utils/runCli.js";
 import { logger } from "../ui/index.js";
 import type { RunResult } from "../utils/childProcessAdapter.js";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const requireFromHere = createRequire(import.meta.url);
+
+/**
+ * Resolve the tsx CLI entrypoint (`<tsx-pkg>/dist/cli.mjs`) used by
+ * `movehat run` to execute user scripts. Prefers movehat's bundled tsx
+ * by default; falls back to the cwd's tsx only if bundled is missing
+ * (defensive — should not happen for normal installs). Set
+ * `MOVEHAT_TSX_FROM_CWD=1` or pass `preferCwd: true` to flip the
+ * order — power-users who pinned a different tsx in their project.
+ *
+ * Security: the default order closes #52 (untrusted cwd could ship a
+ * malicious `node_modules/tsx/dist/cli.mjs`).
+ *
+ * Exported so the resolution logic can be unit-tested without
+ * spawning a real process.
+ */
+export function resolveTsxCliPath(opts?: { preferCwd?: boolean }): string | null {
+  const preferCwd =
+    opts?.preferCwd ?? process.env.MOVEHAT_TSX_FROM_CWD === "1";
+  const bundledRoot = __dirname;
+  const cwdRoot = process.cwd();
+  const lookupOrder = preferCwd
+    ? [cwdRoot, bundledRoot]
+    : [bundledRoot, cwdRoot];
+
+  for (const root of lookupOrder) {
+    try {
+      const tsxEntry = requireFromHere.resolve("tsx", { paths: [root] });
+      // require.resolve("tsx") returns .../tsx/dist/loader.mjs; walk up
+      // to the package root and into dist/cli.mjs.
+      const packageRoot = dirname(dirname(tsxEntry));
+      const cliPath = join(packageRoot, "dist", "cli.mjs");
+      if (existsSync(cliPath)) return cliPath;
+    } catch {
+      // Lookup failed at this root; try the next one.
+    }
+  }
+  return null;
+}
+
 /**
  * Apply the exit policy for a child whose output was inherited by the
  * parent. When the child dies via signal, re-raise it on the parent so
@@ -58,41 +99,16 @@ export default async function runCommand(scriptPath: string) {
   }
   logger.newline();
 
-  // Find tsx binary - try multiple locations for compatibility
-  // Uses require.resolve for cross-platform compatibility (works on Windows, macOS, Linux)
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = dirname(__filename);
-
-  // Create require function for ESM (needed to use require.resolve in ESM modules)
-  const require = createRequire(import.meta.url);
-
-  let tsxPath: string;
-  try {
-    // Try to resolve tsx package from user's project first
-    const tsxPackagePath = require.resolve("tsx", { paths: [process.cwd()] });
-    // require.resolve("tsx") returns .../tsx/dist/loader.mjs
-    // We need to go up to the tsx package root, then into dist/cli.mjs
-    const tsxPackageRoot = dirname(dirname(tsxPackagePath));
-    tsxPath = join(tsxPackageRoot, "dist", "cli.mjs");
-
-    // Verify the file exists
-    if (!existsSync(tsxPath)) {
-      throw new Error("cli.mjs not found");
-    }
-  } catch {
-    try {
-      // Fallback to movehat's own tsx
-      const tsxPackagePath = require.resolve("tsx", { paths: [__dirname] });
-      const tsxPackageRoot = dirname(dirname(tsxPackagePath));
-      tsxPath = join(tsxPackageRoot, "dist", "cli.mjs");
-
-      if (!existsSync(tsxPath)) {
-        throw new Error("cli.mjs not found");
-      }
-    } catch {
-      tsxPath = "";
-    }
+  // Find tsx binary — bundled-first per #52 (supply-chain hardening).
+  // Cwd resolution stays available behind an opt-in env var for users
+  // who pinned a different tsx in their project.
+  if (process.env.MOVEHAT_TSX_FROM_CWD === "1") {
+    logger.warning(
+      "MOVEHAT_TSX_FROM_CWD=1: resolving tsx from cwd first. " +
+        "Only use this in trusted project directories."
+    );
   }
+  const tsxPath = resolveTsxCliPath();
 
   if (!tsxPath) {
     logger.error("tsx binary not found");


### PR DESCRIPTION
## Closes #52

`movehat run <script>` previously resolved tsx from `process.cwd()` FIRST and fell back to movehat's bundled tsx only on failure. A malicious `node_modules/tsx/dist/cli.mjs` in an untrusted project directory would silently execute. Supply-chain class of attack.

### Fix

Bundled-first by default, cwd as opt-in:

1. Extracted resolution into exported `resolveTsxCliPath(opts?: { preferCwd?: boolean })` helper (now unit-testable)
2. Default lookup order: `[__dirname, process.cwd()]` (bundled first)
3. With `MOVEHAT_TSX_FROM_CWD=1` env var or `preferCwd: true`: `[process.cwd(), __dirname]` (cwd first)
4. When the env var is set, `logger.warning` fires so the choice is visible in the output

### Failure mode shift

| Before | After |
|---|---|
| Cwd's tsx loaded silently (malicious or not) | Bundled tsx loaded silently; cwd opt-in is loud |

### Backward-compat (non-regression check)

- `packages/movehat/package.json` declares `"tsx": "^4.7.0"` → bundled tsx is **always present** in a normal install
- For the 99% case (movehat installed via npm/pnpm, no custom tsx pinning), bundled-first succeeds → cwd lookup never reached → **identical observable behavior**
- Users who pinned a different tsx and need it: set `MOVEHAT_TSX_FROM_CWD=1` (and accept the security warning)
- `tsx` is a CLI runner (not a library) — different versions are interface-compatible for `tsx <file>` invocation

### New tests (6 cases)

In `run.test.ts`:

1. `resolveTsxCliPath()` returns a path ending in `dist/cli.mjs` under default
2. `resolveTsxCliPath({ preferCwd: false })` (explicit default) returns valid path
3. `resolveTsxCliPath({ preferCwd: true })` returns valid path (workspace has tsx via both routes)
4. Env var `MOVEHAT_TSX_FROM_CWD=1` is respected by the orchestrator
5. `runCommand` emits warning when env var set
6. `runCommand` does NOT emit warning under default behavior

Filesystem-controlled order assertions (proving bundled is loaded vs cwd version) are out of scope — see the pre-existing `tsx not found` test comment in the same file. The observable behavior (path returned, env var honored, warning fired) is the testable surface.

### Verification

- [x] Pre-flight: `pnpm --filter movehat exec vitest run src/commands/__tests__/run.test.ts` → **17/17 pass** (was 11; +6)
- [x] Full suite: `pnpm --filter movehat test` → **535 pass** (was 529; +6)
- [x] Pre-push hook green
- [ ] CI on this PR

## Test plan

- [x] Unit suite (535)
- [x] Backward-compat audit
- [ ] CI third-party gates
