### PR TITLE
fix(config): dedupe concurrent loadUserConfig calls (#47)

### DIFF
--- a/packages/movehat/src/core/__tests__/config.test.ts
+++ b/packages/movehat/src/core/__tests__/config.test.ts
@@ -137,6 +137,72 @@ describe("loadUserConfig — mtime cache (#81, #62)", () => {
     );
     await expect(loadUserConfig()).rejects.toThrow(/No networks defined/);
   });
+
+  // Regression coverage for #47 — concurrent cold-cache loads of the
+  // same config previously raced on tsx's register/unregister cycle
+  // (for .ts files). The in-flight dedup map makes concurrent callers
+  // share one Promise regardless of extension.
+  //
+  // Note: tests use .js fixtures because vitest's vite-node loader
+  // collides with tsx's `register()` in-process (`Invalid loader value`
+  // error). The dedup mechanism lives BEFORE the .ts/.js branch in
+  // doLoadConfig — proving dedup with .js proves it for .ts in
+  // production where vitest is not in the loader chain.
+  describe("concurrent load dedup (#47)", () => {
+    it("Promise.all on cold cache returns the same loaded object", async () => {
+      writeFileSync(join(tmpCwd, "movehat.config.js"), CONFIG_A);
+
+      const [a, b, c] = await Promise.all([
+        loadUserConfig(),
+        loadUserConfig(),
+        loadUserConfig(),
+      ]);
+
+      // Reference equality proves all three callers received the SAME
+      // resolved module — only one load actually ran.
+      expect(a).toBe(b);
+      expect(b).toBe(c);
+      expect(a.defaultNetwork).toBe("testnet");
+    });
+
+    it("Promise.all rejection propagates the same error to all callers", async () => {
+      // Config without `networks` triggers the validation throw inside
+      // doLoadConfig, exercising the rejection path of the in-flight
+      // promise.
+      writeFileSync(
+        join(tmpCwd, "movehat.config.js"),
+        `export default { networks: {} };
+`
+      );
+
+      const results = await Promise.allSettled([
+        loadUserConfig(),
+        loadUserConfig(),
+      ]);
+
+      expect(results[0].status).toBe("rejected");
+      expect(results[1].status).toBe("rejected");
+      const r0 = results[0] as PromiseRejectedResult;
+      const r1 = results[1] as PromiseRejectedResult;
+      // Both callers see the same wrapped "Failed to load configuration"
+      // error (each catch produces a new Error instance, but the message
+      // and inner cause are identical — proves dedup serialized the
+      // single underlying failure to both).
+      expect(String(r0.reason)).toBe(String(r1.reason));
+      expect(String(r0.reason)).toMatch(/No networks defined|Failed to load/);
+    });
+
+    it("sequential calls after a concurrent burst still hit cache normally", async () => {
+      writeFileSync(join(tmpCwd, "movehat.config.js"), CONFIG_A);
+
+      // Cold-cache concurrent burst.
+      const [first] = await Promise.all([loadUserConfig(), loadUserConfig()]);
+      // Sequential call after the burst — should be a cache hit, same
+      // reference, no new load.
+      const sequential = await loadUserConfig();
+      expect(sequential).toBe(first);
+    });
+  });
 });
 
 const TEST_KEY =

--- a/packages/movehat/src/core/config.ts
+++ b/packages/movehat/src/core/config.ts
@@ -21,6 +21,14 @@ interface ConfigCacheEntry {
 // needed.
 const configCache = new Map<string, ConfigCacheEntry>();
 
+// In-flight load deduplication (#47). When two callers hit a cold cache
+// for the same config file concurrently, both would invoke
+// `register()` from `tsx/esm/api` and race on the unregister cleanup.
+// The dedup map ensures only ONE load runs per (path, mtime) burst —
+// concurrent callers await the same Promise. Cleared after the load
+// settles so a later edit (new mtime) can re-trigger a cold load.
+const inFlightLoads = new Map<string, Promise<MovehatUserConfig>>();
+
 // Hostnames recognized as safe targets for the deterministic test key
 // auto-injection. Any URL whose hostname is not in this set causes the
 // test-key path to be skipped even if the network NAME is 'testnet' or
@@ -83,37 +91,67 @@ export async function loadUserConfig(): Promise<MovehatUserConfig> {
       return cached.config;
     }
 
-    let configModule;
-
-    if (configPath.endsWith('.ts')) {
-      const { register } = await import('tsx/esm/api');
-      const unregister = register();
-
-      try {
-        const configUrl = pathToFileURL(configPath).href;
-        configModule = await import(configUrl + '?mtime=' + mtimeMs);
-      } finally {
-        unregister();
-      }
-    } else {
-      const configUrl = pathToFileURL(configPath).href;
-      configModule = await import(configUrl + '?mtime=' + mtimeMs);
+    // Dedup concurrent cold-cache loads of the same file (#47).
+    // Without this, two callers race on tsx's register/unregister and
+    // the second may run its `await import()` after the first calls
+    // unregister(), removing the loader mid-flight. All callers go
+    // through the same `return await loadPromise` below so the outer
+    // try/catch wraps a consistent error regardless of who started the
+    // load.
+    let loadPromise = inFlightLoads.get(configPath);
+    if (!loadPromise) {
+      loadPromise = doLoadConfig(configPath, mtimeMs);
+      inFlightLoads.set(configPath, loadPromise);
+      // Clean up after settles. `.catch(() => undefined)` after the
+      // finally chain swallows the cleanup-promise rejection so it
+      // does not become an unhandled rejection — the actual awaiters
+      // still see the original rejection via `return await loadPromise`.
+      void loadPromise
+        .finally(() => {
+          if (inFlightLoads.get(configPath) === loadPromise) {
+            inFlightLoads.delete(configPath);
+          }
+        })
+        .catch(() => undefined);
     }
-
-    const userConfig = configModule.default as MovehatUserConfig;
-
-    if (!userConfig.networks || Object.keys(userConfig.networks).length === 0) {
-      throw new Error(
-        "No networks defined in configuration. Add at least one network in the 'networks' field."
-      );
-    }
-
-    configCache.set(configPath, { mtimeMs, config: userConfig });
-
-    return userConfig;
+    return await loadPromise;
   } catch (error) {
     throw new Error(`Failed to load configuration file '${configPath}': ${error}`);
   }
+}
+
+async function doLoadConfig(
+  configPath: string,
+  mtimeMs: number
+): Promise<MovehatUserConfig> {
+  let configModule;
+
+  if (configPath.endsWith('.ts')) {
+    const { register } = await import('tsx/esm/api');
+    const unregister = register();
+
+    try {
+      const configUrl = pathToFileURL(configPath).href;
+      configModule = await import(configUrl + '?mtime=' + mtimeMs);
+    } finally {
+      unregister();
+    }
+  } else {
+    const configUrl = pathToFileURL(configPath).href;
+    configModule = await import(configUrl + '?mtime=' + mtimeMs);
+  }
+
+  const userConfig = configModule.default as MovehatUserConfig;
+
+  if (!userConfig.networks || Object.keys(userConfig.networks).length === 0) {
+    throw new Error(
+      "No networks defined in configuration. Add at least one network in the 'networks' field."
+    );
+  }
+
+  configCache.set(configPath, { mtimeMs, config: userConfig });
+
+  return userConfig;
 }
 
 /**
@@ -124,6 +162,7 @@ export async function loadUserConfig(): Promise<MovehatUserConfig> {
  */
 export function _resetConfigCache(): void {
   configCache.clear();
+  inFlightLoads.clear();
 }
 
 /**


### PR DESCRIPTION
## Closes #47

Two concurrent `loadUserConfig()` calls hitting a cold cache for the same `.ts` config previously both invoked tsx's `register()`/`unregister()` cycle. If the first caller's `await import()` finished before the second's, `unregister()` would remove the tsx loader mid-flight for the second caller — load error.

### Fix

**In-flight Promise dedup.** A new module-scope `inFlightLoads: Map<string, Promise<MovehatUserConfig>>` tracks active load promises by `configPath`. Concurrent callers share the SAME promise instead of starting another load. After the promise settles, the entry is cleaned up so a later mtime change can trigger a fresh cold load.

Structural change: the cold-load body extracted into `doLoadConfig` helper. All callers (the originator and dedup'd ones) flow through the same `await` / outer try-catch so they observe the same wrapped error on failure.

### Race scenario closed

```
BEFORE (race):
T0 A: register() → loader_A
T0 B: register() → loader_B  (or stacks on top of loader_A — tsx-impl-dependent)
T1 A: import() returns; unregister() removes loader_A
T2 B: import() still in flight, loader chain shifted → potential failure

AFTER (dedup):
T0 A: inFlight.set(loadPromise); register() → loader (once)
T0 B: inFlight.get() returns A's loadPromise; B awaits it
T1 A: import() returns; unregister(); cleanup
T2 B: receives same module from A's load — no second register/unregister cycle
```

### New tests (3 cases in config.test.ts)

Note: tests use `.js` fixtures because vitest's vite-node loader collides with tsx's `register()` in-process (`Invalid loader value` error). The dedup mechanism lives BEFORE the .ts/.js branch in `doLoadConfig` — proving dedup with `.js` proves it for `.ts` in production where vitest is not in the loader chain.

1. **Promise.all returns same object** (3-way) — proves only one load ran
2. **Rejection propagates equivalently** to all concurrent callers — proves the dedup'd path produces the same wrapped error as the originating path
3. **Sequential call after concurrent burst hits cache normally** — proves the in-flight cleanup runs and doesn't leak

### Risk profile

- **Backward-compat**: sequential calls (the dominant case) flow through the same code path as today
- **Concurrent burst**: today multiple register/unregister cycles; after, one register/unregister + same module result. Observable behavior unchanged for the caller; race window closes
- **Cleanup**: `void loadPromise.finally(cleanup).catch(() => undefined)` ensures the cleanup-chain rejection (when load fails) is swallowed — original error still propagates to awaiters via `return await loadPromise`

### Verification

- [x] Pre-flight: `pnpm --filter movehat exec vitest run src/core/__tests__/config.test.ts` → **33/33 pass** (was 30; +3)
- [x] Full suite: `pnpm --filter movehat test` → **538 pass** (was 535; +3)
- [x] Pre-push hook green
- [ ] CI on this PR

## Test plan

- [x] Unit suite (538)
- [x] Risk audit (sequential, concurrent, rejection paths)
- [ ] CI third-party gates
