### PR TITLE
fix(security): address CodeRabbit findings on #265 batch

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -24,6 +24,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # docs-deploy never pushes back to the repo (Pages upload uses
+          # OIDC, not git push), so persisting GITHUB_TOKEN is unnecessary
+          # token exposure. See CodeRabbit #265 + zizmor 'artipacked'.
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3.0.0

--- a/packages/movehat/src/core/__tests__/config.test.ts
+++ b/packages/movehat/src/core/__tests__/config.test.ts
@@ -501,6 +501,31 @@ describe("resolveNetworkConfig", () => {
       );
     });
 
+    it("sanitizes URL credentials and query params in the warning (CR #265)", async () => {
+      // URLs with userinfo or API keys should never leak into logs.
+      const user = baseUserConfig({
+        testnet: {
+          url: "https://alice:s3cr3t@prod.example.com/v1?apiKey=sk-private",
+          chainId: "testnet",
+        },
+      });
+      await expect(resolveNetworkConfig(user, "testnet")).rejects.toThrow(
+        /has no accounts configured/
+      );
+      const warningMessages = warnSpy.mock.calls.map((c) => c.join(" "));
+      const warnText = warningMessages.find((m) =>
+        /not a recognized test endpoint/i.test(m)
+      );
+      expect(warnText).toBeDefined();
+      // Sanitized: must drop userinfo + query string.
+      expect(warnText!).not.toContain("alice");
+      expect(warnText!).not.toContain("s3cr3t");
+      expect(warnText!).not.toContain("apiKey");
+      expect(warnText!).not.toContain("sk-private");
+      // But keep enough for the operator to identify the endpoint.
+      expect(warnText!).toContain("prod.example.com");
+    });
+
     it("treats 127.0.0.1 as a known test endpoint", async () => {
       const user = baseUserConfig({
         local: { url: "http://127.0.0.1:8080/v1", chainId: "local" },

--- a/packages/movehat/src/core/config.ts
+++ b/packages/movehat/src/core/config.ts
@@ -49,6 +49,19 @@ function isKnownTestEndpoint(url: string): boolean {
   }
 }
 
+// Render a URL for log output without exposing userinfo (`user:pass@`)
+// or query strings (`?apiKey=…`). Returns the protocol + host + pathname
+// only, which is enough for the operator to identify the endpoint
+// without leaking embedded credentials to CI logs.
+function sanitizeUrlForLog(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    return "<invalid-url>";
+  }
+}
+
 /**
  * Loads the user's movehat.config.{ts,js} from the current working directory.
  *
@@ -252,7 +265,7 @@ export async function resolveNetworkConfig(
       // actionable guidance.
       logger.warning(
         `Network '${selectedNetwork}' uses a name reserved for testnet/local ` +
-          `but '${networkConfig.url}' is not a recognized test endpoint. ` +
+          `but '${sanitizeUrlForLog(networkConfig.url)}' is not a recognized test endpoint. ` +
           `Skipping auto-injection of the deterministic test key to protect ` +
           `against accidental production use. Set PRIVATE_KEY explicitly, ` +
           `configure 'accounts' in movehat.config.ts, or rename this network.`


### PR DESCRIPTION
Two 🟡 findings from CodeRabbit's review of the 0.2.6 batch PR (#265). Both fixed here, in develop, so #265 auto-refreshes.

## Fixes

1. **docs-deploy.yml** — add `persist-credentials: false` on the checkout step. Workflow uses OIDC for Pages upload + never `git push`s, so GITHUB_TOKEN persistence is unnecessary token exposure. (zizmor 'artipacked')

2. **config.ts** — sanitize URL in the test-key-gate warning. Previously logged raw `networkConfig.url`, leaking userinfo (`user:pass@`) or query-string credentials (`?apiKey=…`) into terminal/CI logs. New `sanitizeUrlForLog` helper returns `protocol://host/pathname` only.

New test asserts a URL with userinfo + apiKey gets sanitized in the warn output (538 → 539 tests).

Pre-push hook green. Closes the 2 actionable CR comments on #265.