### PR TITLE
chore(release): 0.2.6 — audit-pass batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-05-21
+
+7 audit-pass items closed across two layers — test coverage hardening and
+security gate tightening. No public API changes; all behavior shifts are
+strictly safer (silent → loud failure modes).
+
+### Security
+
+- `loadUserConfig` deduplicates concurrent cold-cache loads of the same
+  config file via an in-flight Promise map. Previously two parallel
+  callers raced on tsx's `register()` / `unregister()` cycle and the
+  second's `await import()` could lose the loader mid-flight. Closes #47.
+- Test-key auto-injection for `testnet` / `local` networks now requires
+  BOTH the network NAME and the URL hostname to be in an allowlist
+  (`testnet.movementnetwork.xyz`, `localhost`, `127.0.0.1`, `::1`).
+  A user-named `testnet` pointing at a production URL no longer inherits
+  the deterministic test key silently — instead a warning fires and the
+  standard "no accounts configured" error gives actionable guidance.
+  URL is sanitized in the log output (drops userinfo + query strings)
+  to avoid leaking embedded credentials. Closes #40.
+- `movehat run` resolves the `tsx` CLI from the bundled movehat copy
+  first instead of the project cwd. Closes the supply-chain risk where
+  a malicious `node_modules/tsx/dist/cli.mjs` in an untrusted project
+  directory would silently execute. Opt-in env var
+  `MOVEHAT_TSX_FROM_CWD=1` preserves the old behavior for power users
+  who pin a different tsx version. Closes #52.
+- All third-party GitHub Actions in `.github/workflows/*` pinned to
+  40-char commit SHAs (not floating major tags) to close supply-chain
+  drift from a maintainer-compromised tag re-point. Closes #214.
+- `actions/checkout` in `docs-deploy.yml` now uses
+  `persist-credentials: false` to avoid GITHUB_TOKEN persistence on
+  the OIDC-based Pages deploy path.
+
+### Fixed
+
+- `parseTxHash` no longer falls back to "any 64-hex literal in stdout"
+  when the contextual `transaction|txn|hash:` pattern misses. The
+  fallback was fragile — a padded module address or state root printed
+  before the actual transaction hash would silently return the wrong
+  hash. Now returns `undefined` + logs a warning; the 3 callers
+  (`Publisher`, `codeObject`, `script`) handle the missing value
+  appropriately. Closes #51.
+
+### Tests
+
+- New integration test in `childProcessAdapter.test.ts` proves the
+  spawn adapter passes args un-mangled (`./path`, embedded spaces,
+  shell metacharacters, empty strings, unicode). Catches a regression
+  class that PR #97 hit and unit tests with fake adapters missed.
+  Closes #98.
+- New consistency tests for `ForkServer.GET /v1/accounts/:address`
+  prove short (`0x1`), padded (`0x000…01`), and mixed-case (`0xABC`)
+  inputs all collapse to the same canonical key. The permissive regex
+  is intentional (Movement uses short framework addresses); the
+  consistency test locks in the existing normalization behavior.
+  Closes #48.
+
+### Internal
+
+- Unit suite: 507 → 539 tests (+32 across the audit-pass batch).
+- Removed public `SECURITY_AUDIT_2026-05-20.md` from the repo tree
+  (history retained). `SECURITY.md` remains the public reporting
+  channel. CHANGELOG entry for the M8 release updated to reflect the
+  removal.
+
 ## [0.2.5] - 2026-05-21
 
 ### Added

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {


### PR DESCRIPTION
Bumps movehat from 0.2.5 to 0.2.6 + CHANGELOG entry.

Contents reflect the 7 audit-pass items shipped via PR #265 (batch) and #266 (CR follow-up):

- #98 arg-shape integration test
- #214 pin GHA to commit SHAs (+ persist-credentials: false on docs-deploy)
- #48 fork address normalization consistency tests
- #51 fragile tx-hash fallback dropped
- #40 test-key URL allowlist gate (+ URL sanitization in warning)
- #52 prefer movehat-bundled tsx (cwd opt-in)
- #47 dedupe concurrent loadUserConfig calls

507 → 539 unit tests (+32 regression coverage).

On merge: GitHub release v0.2.6 → publish.yml triggers → npm publish with SLSA v1 provenance via OIDC Trusted Publishers.