### PR TITLE
chore: re-export missing public types (#159)

### DIFF
--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -1,12 +1,21 @@
 // Export all helpers for end users
 export * from "./helpers/index.js";
-export type { MovehatConfig } from "./types/config.js";
+export type {
+  MovehatConfig,
+  NetworkConfig,
+  LocalTestingMode,
+} from "./types/config.js";
 
 // Movehat Runtime Environment. `initRuntime` is a public utility but
 // external callers should prefer Harness; it's the construction primitive
 // `Harness.createLive` uses.
 export { initRuntime } from "./runtime.js";
+export type { InitRuntimeOptions } from "./runtime.js";
 export type { MovehatRuntime, NetworkInfo } from "./types/runtime.js";
+
+// Re-export the ChildProcessAdapter interface so end-users can supply
+// a custom adapter (e.g. sandboxed CLI execution in tests).
+export type { ChildProcessAdapter } from "./utils/childProcessAdapter.js";
 
 // Export Fork system
 export { ForkManager } from "./fork/manager.js";


### PR DESCRIPTION
Closes #159.

Adds 4 missing type re-exports to `packages/movehat/src/index.ts` per the TypeDoc warnings:

- `InitRuntimeOptions` (from `runtime.ts`)
- `NetworkConfig` (from `types/config.ts`)
- `LocalTestingMode` (from `types/config.ts`)
- `ChildProcessAdapter` (from `utils/childProcessAdapter.ts`) — the interface custom CLI adapters implement, needed for the `LocalNodeOptions.adapter` slot

The other types cited in the issue body (`DeployCodeObjectOptions`, `UpgradeCodeObjectOptions`, `RunViewFunctionOptions`, `RunMoveScriptOptions`, `MoveScriptResult`, `CodeObjectInfo`) are already exported — verified at `index.ts:23-30`.

Also relates to: #59 (closed separately as obsolete — GRANT files are gitignored, not in repo) and #64 (closed manually per §10 — `sendMethodNotAllowed` shipped in `c910a12`).

### Verification

- [x] Pre-flight: `pnpm --filter movehat exec vitest run src/__tests__/exports.test.ts` → 10/10 pass
- [x] Full suite: 539/539
- [x] Tier 1: `pnpm typecheck:example` green
- [x] Pre-push hook green
- [ ] CI on this PR

### Non-regression

Type re-exports only. Zero runtime change. `exports.test.ts` was checked against the new surface (only runtime values are probed there; type-only exports verify via tsc which is already green).