### PR TITLE
chore: tier-1 quick wins (CODE_OF_CONDUCT + pre-commit docs + Node 22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -164,7 +164,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -273,7 +273,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -309,7 +309,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 

--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,6 @@ pnpm-debug.log*
 !MAINTENANCE.md
 !MOVEMENT_CLI_COMPAT.md
 !NOTICE.md
+!CODE_OF_CONDUCT.md
 !.github/**/*.md
 *.pdf

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at gilbertsahumada@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,29 @@ The templates in `packages/movehat/src/templates/` are what users get when they 
 
 **Important:** Templates use `"movehat": "workspace:*"` during development. This is automatically replaced with the actual version when publishing via GitHub Actions.
 
+## Git Hooks
+
+This project uses [Husky](https://typicode.github.io/husky/) to install three local git hooks in `.husky/`. They are installed automatically by `pnpm install` (via the `prepare` script).
+
+| Hook | What it runs |
+|---|---|
+| `pre-commit` | Lightweight checks placeholder (currently empty — reserved for future `lint-staged` or similar). |
+| `commit-msg` | `pnpm exec commitlint --edit "$1"` — enforces the conventional commit format (`type(scope): subject`, allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`). |
+| `pre-push` | `pnpm --filter movehat test` (unit suite) + `pnpm typecheck:example` (Tier 1 example typecheck). Optionally runs E2E + can skip the example typecheck — see env flags below. |
+
+### Skip flags (use sparingly)
+
+Set on the push command for the run only:
+
+- `MOVEHAT_E2E=1 git push` — also run E2E tests in the pre-push hook (slow; usually reserved for release verification).
+- `MOVEHAT_SKIP_EXAMPLE_CHECK=1 git push` — skip the example typecheck (for intentional WIP pushes where the public surface temporarily breaks the example). The unit-test gate remains mandatory regardless.
+
+### Bypassing hooks
+
+**Never use `--no-verify`** to skip hook execution without a documented reason. If a hook fails, the right response is to fix the underlying issue, not bypass the check. This matches the policy in `CLAUDE.md` §8 (self-review gate) and ensures CI never sees broken state that local hooks would have caught.
+
+For one-off legitimate bypasses (e.g., recovering from a corrupted state mid-rebase), document the reason in the commit message and post a follow-up PR to address whatever the hook would have caught.
+
 ## Project Architecture
 
 ### Workspace Structure

--- a/examples/counter-example/.github/workflows/ci.yml
+++ b/examples/counter-example/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/packages/docs/content/docs/guides/tutorial-ci.mdx
+++ b/packages/docs/content/docs/guides/tutorial-ci.mdx
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -115,7 +115,7 @@ jobs:
 
 ## Step 2 — What each block does
 
-- **`actions/setup-node@v4` with `node-version: '20'`** — Movehat targets Node 20 / 22. Use 20 for the broadest LTS coverage; bump to 22 once you've validated.
+- **`actions/setup-node@v4` with `node-version: '22'`** — Movehat targets Node 20 / 22. Use 22 (current LTS) as the primary; Node 20 reaches end-of-support April 2026 and GitHub Actions removes the Node 20 runner on Sept 16, 2026.
 - **`npm ci`** — assumes you committed `package-lock.json`. Faster + reproducible than `npm install`. Swap for `pnpm install --frozen-lockfile` or `yarn install --immutable` if you use a different package manager (and update the `cache: 'npm'` field to match).
 - **`actions/cache@v4` for `${{ runner.temp }}/movement`** — caches the Movement CLI binary across runs in a user-writable path. Cold install is ~15 seconds; cache hits are ~1 second.
 - **SHA256 pins** — Movement Labs re-uses the `bypass-homebrew` tag, so the URL alone is not a stable version pin. `MOVEMENT_CLI_SHA256` verifies the downloaded tarball before `chmod`/`mv`; `MOVEMENT_CLI_BINARY_SHA256` verifies the cached/installed binary on both cache hits and fresh installs. When you adopt a new CLI build, update both SHA256 values and the cache key prefix.


### PR DESCRIPTION
## Three small backlog items batched into one PR

Closes #202, #201, #251.

### #202 — CODE_OF_CONDUCT.md

Adds [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) verbatim at repo root, with the contact placeholder substituted with `gilbertsahumada@gmail.com` (already in SECURITY.md).

`.gitignore` allow-list updated so the new file isn't filtered by the default `*.md` deny rule (line 69).

### #201 — Git Hooks policy in CONTRIBUTING.md

New `## Git Hooks` section documents the 3 husky hooks:

| Hook | Runs |
|---|---|
| `pre-commit` | empty placeholder (reserved for future lint-staged) |
| `commit-msg` | commitlint conventional-commits enforcement |
| `pre-push` | `pnpm --filter movehat test` + `pnpm typecheck:example` |

Plus skip flags (`MOVEHAT_E2E=1`, `MOVEHAT_SKIP_EXAMPLE_CHECK=1`) and a no-bypass policy: **NEVER use `--no-verify` without a documented reason** (matches CLAUDE.md §8).

### #251 — Node 20 → 22 primary

Flips `node-version: '20'` → `'22'` in 9 places:

- `.github/workflows/ci.yml` (5 steps)
- `.github/workflows/publish.yml` (1 step)
- `.github/workflows/docs-deploy.yml` (1 step)
- `examples/counter-example/.github/workflows/ci.yml` (1 step)
- `packages/docs/content/docs/guides/tutorial-ci.mdx` (1 code fence + 1 prose update)

CI matrix stays unchanged (`['20', '22']`) — coverage on both during the transition window. Node 20 reaches end-of-support April 2026 and GitHub Actions removes the Node 20 runner on Sept 16, 2026. Demoting 20 from the matrix is a separate decision for ~July 2026.

§6.4 byte-identity between example workflow and tutorial code fence: maintained.

### Verification

- [x] `pnpm --filter movehat test` → **539/539 pass** (no change from baseline)
- [x] Pre-push hook green
- [x] `grep -rn "node-version: '20'" .github/workflows/ examples/counter-example/.github/workflows/ packages/docs/content/docs/guides/tutorial-ci.mdx` → no matches outside the matrix line
- [ ] CI on this PR — proves Node 22 works in our workflows (matrix already covered, this just promotes 22 to primary)

### Non-regression

Zero runtime code change. All edits in workflows / docs / new top-level file. The CI matrix has been running Node 22 alongside Node 20 since at least M3 — promoting 22 to primary is risk-free.

## Test plan

- [x] Unit suite stays at 539
- [x] No `'20'` primary refs remain
- [ ] CI gates (third-party + own pipeline)
