### PR TITLE
docs: align Node.js floor to v20+ across installation + contributing

### DIFF
--- a/packages/docs/content/docs/contributing/index.mdx
+++ b/packages/docs/content/docs/contributing/index.mdx
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to Movehat!
 
 ## Prerequisites
 
-- **Node.js** >= 18
+- **Node.js** >= 20
 - **pnpm** >= 9.0.0
 - **Movement CLI** installed and configured
 

--- a/packages/docs/content/docs/getting-started/installation.mdx
+++ b/packages/docs/content/docs/getting-started/installation.mdx
@@ -8,7 +8,7 @@ icon: Download
 
 Before installing Movehat, make sure you have:
 
-- **Node.js** (v18 or later) — [Download](https://nodejs.org/)
+- **Node.js** (v20 or later) — [Download](https://nodejs.org/)
 - **Movement CLI** — **REQUIRED** for compiling and deploying Move contracts
 
 ### Install Movement CLI
@@ -39,7 +39,7 @@ pnpm install -g movehat
 ## System Requirements
 
 **Required:**
-- Node.js v18+
+- Node.js v20+
 - Movement CLI ([install from Movement docs](https://docs.movementnetwork.xyz/devs/movementcli))
 - npm or pnpm
 


### PR DESCRIPTION
## Summary

Audit found only one drift across README + `packages/docs/content/docs/`: Node.js floor was inconsistent across docs (README v20+, installation v18+, contributing >= 18). This PR aligns installation + contributing to v20+, matching README and what we actually test in CI.

## Why v20+

- **CI matrix**: `['20', '22']` — we test both, not 18
- **Recent change**: `node-version: '22'` is now the primary (PR #271, closing #251)
- **Honesty**: claiming v18 support when we don't test it would mislead users; v20 is the truth

## Audit findings

Per Explore-agent recon of every MDX page in scope of issue #85:

| Surface | Verdict |
|---|---|
| `README.md` | CLEAN (already v20+) |
| `getting-started/installation.mdx` | DRIFT — v18 → v20 (this PR) |
| `getting-started/quickstart.mdx` | CLEAN |
| `getting-started/configuration.mdx` | CLEAN |
| `guides/*.mdx` (compilation, deployment, fork, scripts, testing, networks-and-modes, console-output, multi-contract, tutorial-ci, tutorial-deploy-live, tutorial-fork-testing) | CLEAN |
| `cli/*.mdx` (init, compile, run, test, fork, global-flags) | CLEAN |
| `contributing/index.mdx` | DRIFT — `>= 18` → `>= 20` (this PR) |

All `movehat` / `movehat/helpers` imports in code snippets verified against current `packages/movehat/src/index.ts` exports. `movehat.config.ts` shape in `configuration.mdx` matches `examples/counter-example/movehat.config.ts`. CLI commands and flags in `cli/*` verified against `src/cli.ts`.

## Test plan

- [x] `grep -rn "Node\.js.*v?1[68]" README.md packages/docs/content/docs/` returns 0 stragglers
- [x] Pre-push hook green (build:movehat + typecheck:example)
- [x] Diff scoped to 2 files, 3 LoC

## Tier reporting (per CLAUDE.md §6)

- **Tier 1**: N/A — pure docs, no `src/` touched. Pre-push hook ran (no-op for docs).
- **Tier 2**: N/A — `test:example` + `test:smoke` cover runtime behavior; docs PR doesn't touch the published surface.
- **Tier 3**: N/A — `test:e2e` covers install/runtime flow; docs PR doesn't change either.

## §10 issue lifecycle

Closes #85