### PR TITLE
test(deployContract): add lifecycle + idempotency unit tests

### DIFF
--- a/packages/movehat/src/__tests__/deployContract.test.ts
+++ b/packages/movehat/src/__tests__/deployContract.test.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import { spawn } from "node:child_process";
 import * as yaml from "js-yaml";
-import { CliExecutionError } from "../errors.js";
+import { CliExecutionError, ModuleAlreadyDeployedError } from "../errors.js";
 import { initRuntime } from "../runtime.js";
 import { Publisher } from "../core/Publisher.js";
 import type { ChildProcessAdapter, RunInput, RunResult } from "../utils/childProcessAdapter.js";
@@ -434,5 +434,142 @@ greeting = "0xcafe"
       errSpy.mockRestore();
       logSpy.mockRestore();
     }
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Lifecycle tests — happy path + idempotency guards. Added for #61.
+  // ──────────────────────────────────────────────────────────────────
+
+  it("happy path — writes deployment record with correct shape after successful publish", async () => {
+    const txHash = "0x" + "f".repeat(64);
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      publish: { exitCode: 0, stdout: `Transaction hash: ${txHash}`, stderr: "" },
+    });
+
+    const runtime = await initRuntime();
+    const deployment = await runtime.deployContract("mymodule", { adapter });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.args.slice(0, 2)).toEqual(["move", "build"]);
+    expect(calls[1]?.args.slice(0, 2)).toEqual(["move", "publish"]);
+
+    const deploymentFile = join(tmpCwd, "deployments", "testnet", "mymodule.json");
+    expect(existsSync(deploymentFile)).toBe(true);
+    const persisted = JSON.parse(readFileSync(deploymentFile, "utf8")) as Record<string, unknown>;
+    expect(persisted.moduleName).toBe("mymodule");
+    expect(persisted.network).toBe("testnet");
+    expect(persisted.txHash).toBe(txHash);
+    expect(persisted.address).toBe(deployment.address);
+    expect(persisted.deployer).toBe(deployment.address);
+    expect(typeof persisted.timestamp).toBe("number");
+  });
+
+  it("throws ModuleAlreadyDeployedError when a prior deployment exists and MH_CLI_REDEPLOY is unset", async () => {
+    const networkDir = join(tmpCwd, "deployments", "testnet");
+    mkdirSync(networkDir, { recursive: true });
+    const existing = {
+      address: "0x" + "1".repeat(64),
+      moduleName: "mymodule",
+      network: "testnet",
+      deployer: "0x" + "2".repeat(64),
+      timestamp: 1700000000000,
+      txHash: "0x" + "3".repeat(64),
+    };
+    writeFileSync(join(networkDir, "mymodule.json"), JSON.stringify(existing));
+
+    const origRedeploy = process.env.MH_CLI_REDEPLOY;
+    delete process.env.MH_CLI_REDEPLOY;
+
+    try {
+      const { adapter, calls } = makeAdapter({
+        build: { exitCode: 0, stdout: "", stderr: "" },
+        publish: { exitCode: 0, stdout: "", stderr: "" },
+      });
+      const runtime = await initRuntime();
+
+      let captured: unknown;
+      try {
+        await runtime.deployContract("mymodule", { adapter });
+      } catch (err) {
+        captured = err;
+      }
+
+      expect(captured).toBeInstanceOf(ModuleAlreadyDeployedError);
+      const err = captured as ModuleAlreadyDeployedError;
+      expect(err.moduleName).toBe("mymodule");
+      expect(err.network).toBe("testnet");
+      expect(err.address).toBe(existing.address);
+      expect(err.txHash).toBe(existing.txHash);
+
+      // Early-exit fired: the CLI was never invoked.
+      expect(calls).toHaveLength(0);
+    } finally {
+      if (origRedeploy === undefined) delete process.env.MH_CLI_REDEPLOY;
+      else process.env.MH_CLI_REDEPLOY = origRedeploy;
+    }
+  });
+
+  it("MH_CLI_REDEPLOY=true proceeds and overwrites the stale deployment record", async () => {
+    const networkDir = join(tmpCwd, "deployments", "testnet");
+    mkdirSync(networkDir, { recursive: true });
+    const stale = {
+      address: "0x" + "1".repeat(64),
+      moduleName: "mymodule",
+      network: "testnet",
+      deployer: "0x" + "2".repeat(64),
+      timestamp: 1700000000000,
+      txHash: "0x" + "3".repeat(64),
+    };
+    writeFileSync(join(networkDir, "mymodule.json"), JSON.stringify(stale));
+
+    const origRedeploy = process.env.MH_CLI_REDEPLOY;
+    process.env.MH_CLI_REDEPLOY = "true";
+
+    try {
+      const newHash = "0x" + "e".repeat(64);
+      const { adapter, calls } = makeAdapter({
+        build: { exitCode: 0, stdout: "build ok", stderr: "" },
+        publish: { exitCode: 0, stdout: `Transaction hash: ${newHash}`, stderr: "" },
+      });
+      const runtime = await initRuntime();
+      await runtime.deployContract("mymodule", { adapter });
+
+      expect(calls).toHaveLength(2);
+
+      const persisted = JSON.parse(
+        readFileSync(join(networkDir, "mymodule.json"), "utf8")
+      ) as Record<string, unknown>;
+      expect(persisted.txHash).toBe(newHash);
+      expect(persisted.txHash).not.toBe(stale.txHash);
+    } finally {
+      if (origRedeploy === undefined) delete process.env.MH_CLI_REDEPLOY;
+      else process.env.MH_CLI_REDEPLOY = origRedeploy;
+    }
+  });
+
+  it("build failure prevents publish and leaves no deployment record on disk", async () => {
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 1, stdout: "", stderr: "compile error: unresolved reference" },
+      publish: { exitCode: 0, stdout: "", stderr: "" },
+    });
+
+    const runtime = await initRuntime();
+
+    let captured: unknown;
+    try {
+      await runtime.deployContract("mymodule", { adapter });
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(CliExecutionError);
+
+    // Only build was attempted; publish never invoked.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args.slice(0, 2)).toEqual(["move", "build"]);
+
+    // No deployment file was written.
+    expect(existsSync(join(tmpCwd, "deployments", "testnet", "mymodule.json"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds 4 unit tests to `packages/movehat/src/__tests__/deployContract.test.ts` covering the deploy lifecycle paths that lacked direct coverage after the Publisher.ts extraction (#54 / 930442d).

## Why now

#61 was filed before the Publisher.ts extraction; its acceptance asks for ≥80% coverage on "runtime.ts" but the deploy logic now lives in `src/core/Publisher.ts`. `runtime.ts` itself is at 100% (thin wrapper that delegates), but `Publisher.ts` was at **66% lines / 44% branches** — the actual gap behind the issue's intent.

## Test scenarios added

| # | Test | Why it matters |
|---|---|---|
| 1 | happy path — asserts full deployment-record shape on disk | Locks the persisted JSON shape so a refactor that breaks `saveDeployment` writes a wrong field is caught here, not in user repos |
| 2 | `ModuleAlreadyDeployedError` early-exit | Asserts the guard fires before any `runCli` call (0 adapter calls), preventing accidental redeploys |
| 3 | `MH_CLI_REDEPLOY=true` bypass | Same precondition as #2 but with the flag set; asserts deploy proceeds and overwrites the stale on-disk record |
| 4 | build failure aborts before publish | exitCode 1 from build → `CliExecutionError`, publish never invoked, no deployment file written |

## Coverage delta on `src/core/Publisher.ts`

| Metric | Before | After | Δ |
|---|---|---|---|
| Lines | 66.17% | **83.82%** | +17.65 |
| Statements | 63.38% | **80.28%** | +16.90 |
| Branches | 44.18% | 58.13% | +13.95 |
| Functions | 83.33% | 83.33% | — |

Both lines and statements now ≥80%. Branches still <70 because the PostPublishError + non-CLI catch-block branches are out of scope here (would require mocking `saveDeployment` to throw — a different test surface). No per-file branch gate is set for Publisher.ts.

`runtime.ts` already at 100% — unchanged.

## What's already covered (no duplication)

The existing 5 tests in this file cover:
- SIGINT cleanup (covers cross-issue #36)
- Concurrent isolation (covers cross-issue #37)
- Stderr redaction (leak path #2)
- Console-error redaction on successful-but-noisy publish (leak path #1)
- Move.toml non-mutation (#38)

The 4 new tests are additive and don't touch these scenarios.

## Test plan

- [x] `pnpm test -- src/__tests__/deployContract.test.ts` — 9/9 pass (was 5)
- [x] `pnpm test` — full suite 543/543 pass (was 539)
- [x] `pnpm test:coverage` — Publisher.ts at 83.82% lines (was 66.17%); global thresholds still pass
- [x] Pre-push hook green (build:movehat + typecheck:example)

## Tier reporting (per CLAUDE.md §6)

- **Tier 1** (auto): pre-push hook ran — build:movehat ✓, typecheck:example ✓
- **Tier 2**: `pnpm test:example` — N/A; new tests are unit-level on Publisher.ts, don't touch the example flow. `pnpm test:smoke` — N/A; no `src/` non-test code changed.
- **Tier 3**: `pnpm test:e2e` — N/A; no template/published-surface changes.

## §10 issue lifecycle

Closes #61

Cross-references:
- Builds on #54 (Publisher.ts extraction, commit 930442d) which moved the deploy logic out of runtime.ts
- #36 / #37 already addressed by existing tests in this file