### PR TITLE
develop → main: post-0.2.6 polish batch (6 audit-pass items)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -164,7 +164,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -273,7 +273,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -309,7 +309,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 

--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,6 @@ pnpm-debug.log*
 !MAINTENANCE.md
 !MOVEMENT_CLI_COMPAT.md
 !NOTICE.md
+!CODE_OF_CONDUCT.md
 !.github/**/*.md
 *.pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-05-21
+
+7 audit-pass items closed across two layers — test coverage hardening and
+security gate tightening. No public API changes; all behavior shifts are
+strictly safer (silent → loud failure modes).
+
+### Security
+
+- `loadUserConfig` deduplicates concurrent cold-cache loads of the same
+  config file via an in-flight Promise map. Previously two parallel
+  callers raced on tsx's `register()` / `unregister()` cycle and the
+  second's `await import()` could lose the loader mid-flight. Closes #47.
+- Test-key auto-injection for `testnet` / `local` networks now requires
+  BOTH the network NAME and the URL hostname to be in an allowlist
+  (`testnet.movementnetwork.xyz`, `localhost`, `127.0.0.1`, `::1`).
+  A user-named `testnet` pointing at a production URL no longer inherits
+  the deterministic test key silently — instead a warning fires and the
+  standard "no accounts configured" error gives actionable guidance.
+  URL is sanitized in the log output (drops userinfo + query strings)
+  to avoid leaking embedded credentials. Closes #40.
+- `movehat run` resolves the `tsx` CLI from the bundled movehat copy
+  first instead of the project cwd. Closes the supply-chain risk where
+  a malicious `node_modules/tsx/dist/cli.mjs` in an untrusted project
+  directory would silently execute. Opt-in env var
+  `MOVEHAT_TSX_FROM_CWD=1` preserves the old behavior for power users
+  who pin a different tsx version. Closes #52.
+- All third-party GitHub Actions in `.github/workflows/*` pinned to
+  40-char commit SHAs (not floating major tags) to close supply-chain
+  drift from a maintainer-compromised tag re-point. Closes #214.
+- `actions/checkout` in `docs-deploy.yml` now uses
+  `persist-credentials: false` to avoid GITHUB_TOKEN persistence on
+  the OIDC-based Pages deploy path.
+
+### Fixed
+
+- `parseTxHash` no longer falls back to "any 64-hex literal in stdout"
+  when the contextual `transaction|txn|hash:` pattern misses. The
+  fallback was fragile — a padded module address or state root printed
+  before the actual transaction hash would silently return the wrong
+  hash. Now returns `undefined` + logs a warning; the 3 callers
+  (`Publisher`, `codeObject`, `script`) handle the missing value
+  appropriately. Closes #51.
+
+### Tests
+
+- New integration test in `childProcessAdapter.test.ts` proves the
+  spawn adapter passes args un-mangled (`./path`, embedded spaces,
+  shell metacharacters, empty strings, unicode). Catches a regression
+  class that PR #97 hit and unit tests with fake adapters missed.
+  Closes #98.
+- New consistency tests for `ForkServer.GET /v1/accounts/:address`
+  prove short (`0x1`), padded (`0x000…01`), and mixed-case (`0xABC`)
+  inputs all collapse to the same canonical key. The permissive regex
+  is intentional (Movement uses short framework addresses); the
+  consistency test locks in the existing normalization behavior.
+  Closes #48.
+
+### Internal
+
+- Unit suite: 507 → 539 tests (+32 across the audit-pass batch).
+- Removed public `SECURITY_AUDIT_2026-05-20.md` from the repo tree
+  (history retained). `SECURITY.md` remains the public reporting
+  channel. CHANGELOG entry for the M8 release updated to reflect the
+  removal.
+
 ## [0.2.5] - 2026-05-21
 
 ### Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at gilbertsahumada@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,29 @@ The templates in `packages/movehat/src/templates/` are what users get when they 
 
 **Important:** Templates use `"movehat": "workspace:*"` during development. This is automatically replaced with the actual version when publishing via GitHub Actions.
 
+## Git Hooks
+
+This project uses [Husky](https://typicode.github.io/husky/) to install three local git hooks in `.husky/`. They are installed automatically by `pnpm install` (via the `prepare` script).
+
+| Hook | What it runs |
+|---|---|
+| `pre-commit` | Lightweight checks placeholder (currently empty — reserved for future `lint-staged` or similar). |
+| `commit-msg` | `pnpm exec commitlint --edit "$1"` — enforces the conventional commit format (`type(scope): subject`, allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`). |
+| `pre-push` | `pnpm --filter movehat test` (unit suite) + `pnpm typecheck:example` (Tier 1 example typecheck). Optionally runs E2E + can skip the example typecheck — see env flags below. |
+
+### Skip flags (use sparingly)
+
+Set on the push command for the run only:
+
+- `MOVEHAT_E2E=1 git push` — also run E2E tests in the pre-push hook (slow; usually reserved for release verification).
+- `MOVEHAT_SKIP_EXAMPLE_CHECK=1 git push` — skip the example typecheck (for intentional WIP pushes where the public surface temporarily breaks the example). The unit-test gate remains mandatory regardless.
+
+### Bypassing hooks
+
+**Never use `--no-verify`** to skip hook execution without a documented reason. If a hook fails, the right response is to fix the underlying issue, not bypass the check. This matches the policy in `CLAUDE.md` §8 (self-review gate) and ensures CI never sees broken state that local hooks would have caught.
+
+For one-off legitimate bypasses (e.g., recovering from a corrupted state mid-rebase), document the reason in the commit message and post a follow-up PR to address whatever the hook would have caught.
+
 ## Project Architecture
 
 ### Workspace Structure

--- a/examples/counter-example/.github/workflows/ci.yml
+++ b/examples/counter-example/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/packages/docs/content/docs/contributing/index.mdx
+++ b/packages/docs/content/docs/contributing/index.mdx
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to Movehat!
 
 ## Prerequisites
 
-- **Node.js** >= 18
+- **Node.js** >= 20
 - **pnpm** >= 9.0.0
 - **Movement CLI** installed and configured
 

--- a/packages/docs/content/docs/getting-started/installation.mdx
+++ b/packages/docs/content/docs/getting-started/installation.mdx
@@ -8,7 +8,7 @@ icon: Download
 
 Before installing Movehat, make sure you have:
 
-- **Node.js** (v18 or later) — [Download](https://nodejs.org/)
+- **Node.js** (v20 or later) — [Download](https://nodejs.org/)
 - **Movement CLI** — **REQUIRED** for compiling and deploying Move contracts
 
 ### Install Movement CLI
@@ -39,7 +39,7 @@ pnpm install -g movehat
 ## System Requirements
 
 **Required:**
-- Node.js v18+
+- Node.js v20+
 - Movement CLI ([install from Movement docs](https://docs.movementnetwork.xyz/devs/movementcli))
 - npm or pnpm
 

--- a/packages/docs/content/docs/guides/tutorial-ci.mdx
+++ b/packages/docs/content/docs/guides/tutorial-ci.mdx
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -115,7 +115,7 @@ jobs:
 
 ## Step 2 — What each block does
 
-- **`actions/setup-node@v4` with `node-version: '20'`** — Movehat targets Node 20 / 22. Use 20 for the broadest LTS coverage; bump to 22 once you've validated.
+- **`actions/setup-node@v4` with `node-version: '22'`** — Movehat targets Node 20 / 22. Use 22 (current LTS) as the primary; Node 20 reaches end-of-support April 2026 and GitHub Actions removes the Node 20 runner on Sept 16, 2026.
 - **`npm ci`** — assumes you committed `package-lock.json`. Faster + reproducible than `npm install`. Swap for `pnpm install --frozen-lockfile` or `yarn install --immutable` if you use a different package manager (and update the `cache: 'npm'` field to match).
 - **`actions/cache@v4` for `${{ runner.temp }}/movement`** — caches the Movement CLI binary across runs in a user-writable path. Cold install is ~15 seconds; cache hits are ~1 second.
 - **SHA256 pins** — Movement Labs re-uses the `bypass-homebrew` tag, so the URL alone is not a stable version pin. `MOVEMENT_CLI_SHA256` verifies the downloaded tarball before `chmod`/`mv`; `MOVEMENT_CLI_BINARY_SHA256` verifies the cached/installed binary on both cache hits and fresh installs. When you adopt a new CLI build, update both SHA256 values and the cache key prefix.

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {

--- a/packages/movehat/src/__tests__/deployContract.test.ts
+++ b/packages/movehat/src/__tests__/deployContract.test.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import { spawn } from "node:child_process";
 import * as yaml from "js-yaml";
-import { CliExecutionError } from "../errors.js";
+import { CliExecutionError, ModuleAlreadyDeployedError } from "../errors.js";
 import { initRuntime } from "../runtime.js";
 import { Publisher } from "../core/Publisher.js";
 import type { ChildProcessAdapter, RunInput, RunResult } from "../utils/childProcessAdapter.js";
@@ -434,5 +434,142 @@ greeting = "0xcafe"
       errSpy.mockRestore();
       logSpy.mockRestore();
     }
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Lifecycle tests — happy path + idempotency guards. Added for #61.
+  // ──────────────────────────────────────────────────────────────────
+
+  it("happy path — writes deployment record with correct shape after successful publish", async () => {
+    const txHash = "0x" + "f".repeat(64);
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 0, stdout: "build ok", stderr: "" },
+      publish: { exitCode: 0, stdout: `Transaction hash: ${txHash}`, stderr: "" },
+    });
+
+    const runtime = await initRuntime();
+    const deployment = await runtime.deployContract("mymodule", { adapter });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.args.slice(0, 2)).toEqual(["move", "build"]);
+    expect(calls[1]?.args.slice(0, 2)).toEqual(["move", "publish"]);
+
+    const deploymentFile = join(tmpCwd, "deployments", "testnet", "mymodule.json");
+    expect(existsSync(deploymentFile)).toBe(true);
+    const persisted = JSON.parse(readFileSync(deploymentFile, "utf8")) as Record<string, unknown>;
+    expect(persisted.moduleName).toBe("mymodule");
+    expect(persisted.network).toBe("testnet");
+    expect(persisted.txHash).toBe(txHash);
+    expect(persisted.address).toBe(deployment.address);
+    expect(persisted.deployer).toBe(deployment.address);
+    expect(typeof persisted.timestamp).toBe("number");
+  });
+
+  it("throws ModuleAlreadyDeployedError when a prior deployment exists and MH_CLI_REDEPLOY is unset", async () => {
+    const networkDir = join(tmpCwd, "deployments", "testnet");
+    mkdirSync(networkDir, { recursive: true });
+    const existing = {
+      address: "0x" + "1".repeat(64),
+      moduleName: "mymodule",
+      network: "testnet",
+      deployer: "0x" + "2".repeat(64),
+      timestamp: 1700000000000,
+      txHash: "0x" + "3".repeat(64),
+    };
+    writeFileSync(join(networkDir, "mymodule.json"), JSON.stringify(existing));
+
+    const origRedeploy = process.env.MH_CLI_REDEPLOY;
+    delete process.env.MH_CLI_REDEPLOY;
+
+    try {
+      const { adapter, calls } = makeAdapter({
+        build: { exitCode: 0, stdout: "", stderr: "" },
+        publish: { exitCode: 0, stdout: "", stderr: "" },
+      });
+      const runtime = await initRuntime();
+
+      let captured: unknown;
+      try {
+        await runtime.deployContract("mymodule", { adapter });
+      } catch (err) {
+        captured = err;
+      }
+
+      expect(captured).toBeInstanceOf(ModuleAlreadyDeployedError);
+      const err = captured as ModuleAlreadyDeployedError;
+      expect(err.moduleName).toBe("mymodule");
+      expect(err.network).toBe("testnet");
+      expect(err.address).toBe(existing.address);
+      expect(err.txHash).toBe(existing.txHash);
+
+      // Early-exit fired: the CLI was never invoked.
+      expect(calls).toHaveLength(0);
+    } finally {
+      if (origRedeploy === undefined) delete process.env.MH_CLI_REDEPLOY;
+      else process.env.MH_CLI_REDEPLOY = origRedeploy;
+    }
+  });
+
+  it("MH_CLI_REDEPLOY=true proceeds and overwrites the stale deployment record", async () => {
+    const networkDir = join(tmpCwd, "deployments", "testnet");
+    mkdirSync(networkDir, { recursive: true });
+    const stale = {
+      address: "0x" + "1".repeat(64),
+      moduleName: "mymodule",
+      network: "testnet",
+      deployer: "0x" + "2".repeat(64),
+      timestamp: 1700000000000,
+      txHash: "0x" + "3".repeat(64),
+    };
+    writeFileSync(join(networkDir, "mymodule.json"), JSON.stringify(stale));
+
+    const origRedeploy = process.env.MH_CLI_REDEPLOY;
+    process.env.MH_CLI_REDEPLOY = "true";
+
+    try {
+      const newHash = "0x" + "e".repeat(64);
+      const { adapter, calls } = makeAdapter({
+        build: { exitCode: 0, stdout: "build ok", stderr: "" },
+        publish: { exitCode: 0, stdout: `Transaction hash: ${newHash}`, stderr: "" },
+      });
+      const runtime = await initRuntime();
+      await runtime.deployContract("mymodule", { adapter });
+
+      expect(calls).toHaveLength(2);
+
+      const persisted = JSON.parse(
+        readFileSync(join(networkDir, "mymodule.json"), "utf8")
+      ) as Record<string, unknown>;
+      expect(persisted.txHash).toBe(newHash);
+      expect(persisted.txHash).not.toBe(stale.txHash);
+    } finally {
+      if (origRedeploy === undefined) delete process.env.MH_CLI_REDEPLOY;
+      else process.env.MH_CLI_REDEPLOY = origRedeploy;
+    }
+  });
+
+  it("build failure prevents publish and leaves no deployment record on disk", async () => {
+    const { adapter, calls } = makeAdapter({
+      build: { exitCode: 1, stdout: "", stderr: "compile error: unresolved reference" },
+      publish: { exitCode: 0, stdout: "", stderr: "" },
+    });
+
+    const runtime = await initRuntime();
+
+    let captured: unknown;
+    try {
+      await runtime.deployContract("mymodule", { adapter });
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(CliExecutionError);
+
+    // Only build was attempted; publish never invoked.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args.slice(0, 2)).toEqual(["move", "build"]);
+
+    // No deployment file was written.
+    expect(existsSync(join(tmpCwd, "deployments", "testnet", "mymodule.json"))).toBe(false);
   });
 });

--- a/packages/movehat/src/index.ts
+++ b/packages/movehat/src/index.ts
@@ -1,12 +1,21 @@
 // Export all helpers for end users
 export * from "./helpers/index.js";
-export type { MovehatConfig } from "./types/config.js";
+export type {
+  MovehatConfig,
+  NetworkConfig,
+  LocalTestingMode,
+} from "./types/config.js";
 
 // Movehat Runtime Environment. `initRuntime` is a public utility but
 // external callers should prefer Harness; it's the construction primitive
 // `Harness.createLive` uses.
 export { initRuntime } from "./runtime.js";
+export type { InitRuntimeOptions } from "./runtime.js";
 export type { MovehatRuntime, NetworkInfo } from "./types/runtime.js";
+
+// Re-export the ChildProcessAdapter interface so end-users can supply
+// a custom adapter (e.g. sandboxed CLI execution in tests).
+export type { ChildProcessAdapter } from "./utils/childProcessAdapter.js";
 
 // Export Fork system
 export { ForkManager } from "./fork/manager.js";


### PR DESCRIPTION
## Summary

Post-0.2.6 cleanup batch. **Zero new product features, zero breaking changes, zero runtime behavior changes** — this is audit-pass polish + test coverage + docs alignment. Lands 5 merged sub-PRs (11 commits, 14 files, +336 / -16) that have been queued on `develop` since the 0.2.6 release on 2026-05-21.

## Sub-PRs in this batch

| Sub-PR | Title | Scope | Issues closed |
|---|---|---|---|
| #268 | chore: sync release 0.2.6 to develop | Pure cherry-pick of release commit `f6ff361` (version bump + CHANGELOG entry). Mirrors PR #254 precedent. | — |
| #269 | chore: re-export missing public types | Adds 4 missing re-exports to `packages/movehat/src/index.ts` (`InitRuntimeOptions`, `NetworkConfig`, `LocalTestingMode`, `ChildProcessAdapter`) per the TypeDoc warnings. Type-only — zero runtime change. | Closes #159 |
| #271 | chore: tier-1 quick wins (CODE_OF_CONDUCT + pre-commit docs + Node 22) | Three small backlog items batched: `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `## Git Hooks` section in CONTRIBUTING.md, and primary `node-version: '20'` → `'22'` across 9 workflow + tutorial locations. CI matrix stays `['20', '22']`. | Closes #202, #201, #251 |
| #272 | docs: align Node.js floor to v20+ | Bumps `installation.mdx` and `contributing/index.mdx` from v18 → v20, matching the CI matrix and PR #271's primary bump. Audit-confirmed CLEAN on all other MDX pages. | Closes #85 |
| #273 | test(deployContract): add lifecycle + idempotency unit tests | 4 new unit tests covering happy path, ModuleAlreadyDeployedError, MH_CLI_REDEPLOY bypass, build failure. Lifts `Publisher.ts` coverage 66% → 84% lines, 63% → 80% statements. | Closes #61 |

## Issues that auto-close on merge

Per §10 issue lifecycle (auto-close fires on main merge for every `Closes #N` referenced in the batch's commits):

- **#61** — `[testing] Add unit tests for runtime.deployContract`
- **#85** — `[docs] Audit README + packages/docs/ against the counter-example scaffold`
- **#159** — TypeDoc warnings re: unexported public types
- **#201** — Document pre-commit hook policy in CONTRIBUTING.md
- **#202** — Add CODE_OF_CONDUCT.md
- **#251** — Migrate primary node-version to 22 across workflows

Already-closed adjacent issues (no auto-close needed, recorded for the milestone audit trail):
- **#54** — Replace dynamic `await import()` in deployContract — closed in-session 2026-05-21 (already shipped in commit `930442d` extracting Publisher.ts)
- **#59** — closed as obsolete (GRANT files gitignored, not in repo)
- **#64** — closed manually after `sendMethodNotAllowed` shipped in `c910a12`

**Open issues after this batch lands: 13 → ~10** (some manual ones already counted).

## Coverage delta

| File | Metric | Before | After |
|---|---|---|---|
| `src/core/Publisher.ts` | Lines | 66.17% | **83.82%** |
| `src/core/Publisher.ts` | Statements | 63.38% | **80.28%** |
| `src/core/Publisher.ts` | Branches | 44.18% | 58.13% |
| `src/runtime.ts` | All | 100% | 100% (unchanged) |
| **Total tests** | — | **539** | **543** (+4) |

Global thresholds: lines 79.67% (floor 70), branches 68.77% (floor 55), functions 75.97% (floor 65), statements 77.87% (floor 70) — all pass.

## Non-regression statement

This batch contains **zero runtime behavior changes** in shipped code:

- **#268** — version bump only (no logic).
- **#269** — `export type` re-exports only. The 4 added symbols are pure type-level; verified by `exports.test.ts` (10/10 pass) + tsc.
- **#271** — `.github/workflows/*.yml` node-version flips (CI matrix already runs both 20 + 22, so no behavior change at runtime). `CONTRIBUTING.md` + `CODE_OF_CONDUCT.md` are docs.
- **#272** — pure docs (`installation.mdx` + `contributing/index.mdx`).
- **#273** — additive unit tests; no `src/` non-test code touched.

The `examples/counter-example/` scaffold remains byte-identical for all workflow steps that PRs touched (§6.4 sync maintained for the tutorial code fence ↔ example workflow YAML).

## Tier reporting (per CLAUDE.md §6)

- **Tier 1** (mandatory, auto): pre-push hook ran green on each sub-PR (`pnpm build:movehat` + `pnpm typecheck:example`).
- **Tier 2** (`test:example` + `test:smoke`): **N/A for this batch** — no `src/` non-test runtime code changed. The published tarball surface is byte-identical to what shipped in 0.2.6 (the type-only re-exports in #269 don't change `dist/` content beyond the `.d.ts` re-export lines).
- **Tier 3** (`test:e2e`): **PASS via CI on this PR** — the `E2E Tests` workflow ran green against the cumulative batch diff (downloads Movement CLI tarball with pinned SHA256, runs `movehat init` + `movehat test --move` + `movehat fork create/list` against a fresh install). Equivalent to a local `pnpm test:e2e` run on the batch tip.

## Verification

- [x] `pnpm test:coverage` on develop tip — 543/543 pass, Publisher.ts coverage gates met
- [x] Pre-push hook green on every sub-PR
- [x] `git log --oneline origin/main..origin/develop` — 11 commits ahead, clean linear history (5 merge commits + 6 squash/feature commits)
- [x] `git diff origin/main..origin/develop --stat` — 14 files / +336 / -16 (includes the #268 cherry-pick: `package.json` + `CHANGELOG.md`)
- [x] GitHub Actions CI on this PR — **all 7 checks green**: Build & Type Check ✓, Code Quality ✓, Security Audit ✓, Unit Tests ✓, Test (Node 20) ✓, Test (Node 22) ✓, E2E Tests ✓
- [x] Third-party gates: GitGuardian ✓, Socket Project Report ✓, Socket PR Alerts ✓
- [ ] CodeRabbit review on this batch (will triage real vs false-positive vs stale per repo policy before merge)
- [ ] §8 self-review on this PR

## Test plan (for the reviewer)

- [ ] Sanity-read each sub-PR description above
- [ ] Confirm the issue-closures list matches the actual `Closes #N` lines in the squashed commits
- [ ] Confirm Tier 2/3 N/A is acceptable for a polish batch (no published-surface change)
- [ ] Verify CodeRabbit findings are triaged (real → fix on develop and let the batch refresh; false-positive → resolution comment; stale → cite the commit that addressed it)

## ROADMAP impact

None. This batch closes audit-pass + cleanup items; no milestone bullets flipped. The next ROADMAP-tracked work is M9 (issue #270, 0.3.0 breaking change for #213) which lives in its own session.

## Why this is one batch (not five separate merges to main)

Per CLAUDE.md §7 + the established `develop → main` workflow: sub-PRs land on `develop`, then a single batch PR carries them to `main` as one atomic change-set. This keeps `main`'s history clean (one commit per milestone or polish cycle) and gives the CodeRabbit + install-experience gates one cumulative diff to review rather than five small ones. Mirrors the precedent of PR #250 (M8 batch) and PR #265 (0.2.6 audit-pass batch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded public API exports for runtime configuration types and child process adapter
  * Added Contributor Code of Conduct

* **Documentation**
  * Updated minimum Node.js requirement from v18 to v20
  * Added Git Hooks documentation in contributing guide
  * Updated CI tutorial with Node.js 22 guidance

* **Tests**
  * Added deployment lifecycle test coverage

* **Chores**
  * Upgraded Node.js to version 22 across CI workflows
  * Bumped package version to 0.2.6

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
