### PR TITLE
docs(changelog): backfill [Unreleased] with post-0.2.6 closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Post-0.2.6 polish batch — 6 audit-pass / cleanup items closed without
+public API change. All additive or docs-only; shipped to `main` in
+PR #274 on 2026-05-21. Backfilled 2026-05-22 when the per-PR CHANGELOG
+convention was adopted (see CLAUDE.md §11).
+
+### Added
+
+- Re-export 4 public types from `movehat`: `InitRuntimeOptions`,
+  `NetworkConfig`, `LocalTestingMode`, `ChildProcessAdapter`. Addresses
+  TypeDoc warnings about unexported public-API symbols and lets users
+  reference network configuration, runtime initialization, and custom
+  child-process adapters directly from the main entry point. Closes #159.
+- `CODE_OF_CONDUCT.md` at repo root using Contributor Covenant 2.1,
+  with the contact placeholder substituted to `gilbertsahumada@gmail.com`.
+  Closes #202.
+
+### Changed
+
+- Primary Node.js version in all GitHub Actions workflows bumped from
+  `'20'` → `'22'`. CI matrix still covers both during the transition
+  window; demotion of Node 20 is a separate decision for ~Aug 2026
+  (Node 20 reaches EOL April 2026; GitHub Actions removes the Node 20
+  runner on Sept 16, 2026). Closes #251.
+- Docs Node.js floor aligned to v20+ in `installation.mdx` and
+  `contributing/index.mdx` — matches the CI matrix and the v22 primary
+  bump above. Closes #85.
+- New `## Git Hooks` section in `CONTRIBUTING.md` documenting the 3
+  husky hooks (pre-commit, commit-msg, pre-push), their skip flags
+  (`MOVEHAT_E2E=1`, `MOVEHAT_SKIP_EXAMPLE_CHECK=1`), and the no-bypass
+  policy (no `--no-verify` without a documented reason — matches
+  CLAUDE.md §8). Closes #201.
+
+### Tests
+
+- 4 new unit tests for `Publisher.deploy()` covering happy path,
+  `ModuleAlreadyDeployedError` early-exit when a prior deployment
+  exists, `MH_CLI_REDEPLOY=true` bypass behavior, and build-failure
+  idempotency (publish never invoked, no deployment record persisted).
+  Coverage on `src/core/Publisher.ts`: lines 66.17% → 83.82%,
+  statements 63.38% → 80.28%, branches 44.18% → 58.13%. Total unit
+  tests: 539 → 543. Closes #61.
+
 ## [0.2.6] - 2026-05-21
 
 7 audit-pass items closed across two layers — test coverage hardening and


### PR DESCRIPTION
## Context

PR #274 (post-0.2.6 polish batch) shipped 6 issue closures to `main` on 2026-05-21 without updating `CHANGELOG.md`. That was **consistent with** the convention documented in `MAINTENANCE.md:15` at the time (release PR writes the CHANGELOG by dredging `git log v<prev>..HEAD`), but the convention itself is fragile — relies on the release-PR author recovering context they may not have, and entries get lost.

This PR backfills `[Unreleased]` with the 6 closures. A follow-up PR codifies the new per-PR convention in CLAUDE.md §11 + updates `MAINTENANCE.md` to match.

## What this PR adds to `CHANGELOG.md [Unreleased]`

### Added
- Re-export 4 public types (`InitRuntimeOptions`, `NetworkConfig`, `LocalTestingMode`, `ChildProcessAdapter`) (#159)
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) (#202)

### Changed
- Primary Node.js in CI workflows bumped 20 → 22 (#251)
- Docs Node.js floor aligned v18 → v20 (#85)
- New Git Hooks section in CONTRIBUTING.md (#201)

### Tests
- 4 new unit tests for `Publisher.deploy()` — coverage 66% → 84% lines (#61)

All 6 issue numbers verified against PR #274's `Closes` list.

## Verification

- [x] `git diff --stat` — `CHANGELOG.md` only, 42 insertions, 0 deletions
- [x] `git diff CHANGELOG.md | grep -oE "#(61|85|159|201|202|251)" | sort -u` — all 6 present
- [x] Mirrors the prose density + section style of the existing `[0.2.6]` entry (lines 10-73)
- [x] Pre-push hook green (`pnpm build:movehat` + `pnpm typecheck:example`)

## Tier reporting (per CLAUDE.md §6)

- **Tier 1**: pre-push hook ran (no-op for docs)
- **Tier 2**: N/A — no `src/` change
- **Tier 3**: N/A — no published-surface change

## §10 issue lifecycle

This PR does **not** close any new issue. The 6 issues it documents were closed by PR #274 on 2026-05-21. This is the CHANGELOG follow-up that the prior convention left as homework for the next release PR.

## Why two sequential PRs (not one combined)

User requested sequential. Also: PR 2 (`CLAUDE.md §11` codification) can cite this PR's number in the §11 body once this one merges, instead of a `<TBD>` placeholder. Independent reverts if either needs backing out.