### PR TITLE
docs: adopt per-PR CHANGELOG convention (CLAUDE.md §11 + MAINTENANCE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,28 @@ How to apply:
 
 Why this matters: the issue tracker is the durable record of decisions. PRs are the change-set; issues are the *why* + the linked-discussion thread. An open issue that's actually resolved is friction for everyone — new contributors think there's open work, maintainers re-investigate already-decided questions, the auto-generated "open issues" badge on the README misleads users about the project's health.
 
+## 11. CHANGELOG.md — every sub-PR that closes an issue updates `[Unreleased]`
+
+**Every sub-PR that closes an issue (per §10) MUST update `CHANGELOG.md`'s `[Unreleased]` section in the same PR.** The release PR (`release/X.Y.Z`) then moves `[Unreleased]` content into a new `[X.Y.Z] - DATE` section — it does not write entries from scratch.
+
+The rule:
+
+- Categorize each entry under one of: `### Added`, `### Changed`, `### Fixed`, `### Security`, `### Tests`, `### Internal`, `### Deprecated`, `### Removed`, `### Breaking` (the last is pre-1.0 only — see [MAINTENANCE.md](./MAINTENANCE.md) for the SemVer policy).
+- Mirror the prose density of existing 0.2.x entries: 2-4 sentences per bullet, with the *why* / context, not just *what*. A reader scanning `npm view movehat` or the file should understand the change without opening the diff.
+- Reference the closing issue at the end of the bullet (`Closes #N`).
+- Sub-PRs that are pure refactors, internal-test-only, or have zero user-visible effect MAY skip the entry. Document the skip in the PR body so the release PR knows not to look for one.
+
+Why this matters: the prior model (release-PR dredges through commits since the last tag) is fragile — the release author has to recover context they may not have, and entries get lost. The per-PR model keeps the running record accurate so the release PR is a mechanical `[Unreleased]` → `[X.Y.Z] - DATE` rename + `package.json` version bump.
+
+How to apply:
+
+1. When writing a sub-PR that closes an issue, also edit `CHANGELOG.md`: add a bullet under the appropriate `### Section` inside `[Unreleased]`. Create the section header if it doesn't exist yet for this release window.
+2. The release PR (`release/X.Y.Z`) opens with a focused diff: the `[Unreleased]` header line becomes `[X.Y.Z] - YYYY-MM-DD` and the `package.json` version bumps. No prose writing — only curation if entries need re-ordering for narrative flow.
+
+Audit cadence: when opening a release PR, grep `[Unreleased]` against the commit log since the last tag (`git log v<prev>..HEAD --oneline`). Discrepancies mean a sub-PR forgot its entry — file a follow-up `docs(changelog):` commit before tagging the release.
+
+This rule was adopted on 2026-05-22 after the post-0.2.6 polish batch (PR #274) shipped without CHANGELOG entries; the backfill PR #275 populated `[Unreleased]` retroactively. `MAINTENANCE.md` was updated in the same change to reflect the new model.
+
 ---
 
 ## Project-Specific Context

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -12,7 +12,7 @@ Movehat follows three release rhythms:
 - **Minor releases** (`0.2.x → 0.3.0`) — ship when the public surface gains new exports, when behavior changes in a backwards-compatible way, or when pre-1.0 breaking changes accumulate. Typical cadence: every 4–8 weeks. Each minor release has a `CHANGELOG.md` entry listing what changed and any deprecation announcements.
 - **Major releases** (`0.x → 1.0.0`) — single planned event when the API stabilizes. Pre-1.0 breaking changes ship in minor bumps; once 1.0 lands, breaking changes ship in majors only.
 
-**Per-milestone batch merges**: feature work lands on the `develop` branch via sub-PRs. When a milestone closes, a single `develop → main` batch PR ships everything together, followed by a release PR that bumps the version and updates the changelog. This pattern is documented in [`CLAUDE.md` §7](./CLAUDE.md). The `publish.yml` workflow gates the npm push on a matching `CHANGELOG.md` section.
+**Per-milestone batch merges**: feature work lands on the `develop` branch via sub-PRs. Each sub-PR that closes an issue updates `CHANGELOG.md` `[Unreleased]` in the same PR (see [`CLAUDE.md` §11](./CLAUDE.md)). When a milestone closes, a single `develop → main` batch PR ships everything together, followed by a release PR that bumps the version and renames `[Unreleased]` → `[X.Y.Z] - DATE` (mechanical, no prose writing). This pattern is documented in [`CLAUDE.md` §7](./CLAUDE.md) (batch flow) + §11 (CHANGELOG ownership). The `publish.yml` workflow gates the npm push on a matching `CHANGELOG.md` section.
 
 ## Issue triage SLA
 


### PR DESCRIPTION
## Context

The post-0.2.6 polish batch (PR #274) shipped 6 issue closures to `main` on 2026-05-21 without updating `CHANGELOG.md`. That was consistent with the convention in `MAINTENANCE.md:15` at the time (release PR writes the CHANGELOG via `git log v<prev>..HEAD` dredging), but the convention is fragile — release-PR author has to recover context they may not have, and entries get lost.

Follow-up to PR #275 (which backfilled `[Unreleased]`). This PR codifies the new convention so future sub-PRs don't skip the CHANGELOG step.

## What this PR changes

### `CLAUDE.md` — new §11 (+22 LoC)

Inserted between §10 (issue lifecycle) and the `## Project-Specific Context` divider. Documents:

- **The rule**: every sub-PR that closes an issue MUST update `[Unreleased]` in the same PR
- **The allowed categories**: `### Added` / `### Changed` / `### Fixed` / `### Security` / `### Tests` / `### Internal` / `### Deprecated` / `### Removed` / `### Breaking` (matches existing 0.2.x usage + adds M9-relevant categories)
- **Why this matters**: release-PR-dredges is fragile; per-PR keeps the running record accurate
- **How to apply**: edit `CHANGELOG.md` alongside the code change; release PR becomes mechanical
- **Audit cadence**: `git log v<prev>..HEAD` vs `[Unreleased]` when opening a release PR
- **Origin note**: references PR #274 (the gap) + PR #275 (the backfill)

Section style mirrors §7 + §10 (rule → why → how to apply → audit cadence).

### `MAINTENANCE.md:15` — one-paragraph rewrite

**Before:** "*…followed by a release PR that bumps the version and updates the changelog.*"

**After:** "*Each sub-PR that closes an issue updates `CHANGELOG.md` `[Unreleased]` in the same PR (see `CLAUDE.md §11`). …followed by a release PR that bumps the version and renames `[Unreleased]` → `[X.Y.Z] - DATE` (mechanical, no prose writing).*"

Resolves the doc inconsistency: CLAUDE.md and MAINTENANCE.md now point at the same model.

## Verification

- [x] `git diff --stat` — `CLAUDE.md` +22, `MAINTENANCE.md` 1 line changed (2 files, 23 insertions, 1 deletion)
- [x] §11 placed correctly: `grep -n "^## " CLAUDE.md` shows §1-§10 → §11 → "Project-Specific Context"
- [x] Cross-link integrity: MAINTENANCE.md:15 now cites both §7 and §11 explicitly
- [x] §11 cites PR #274 (the gap) + PR #275 (the backfill) as durable origin record
- [x] Pre-push hook green

## Tier reporting (per CLAUDE.md §6)

- **Tier 1**: pre-push hook ran (no-op for docs)
- **Tier 2**: N/A — no `src/` change
- **Tier 3**: N/A — no published-surface change

## §10 + §11 issue lifecycle

This PR does **not** close any GitHub issue. The convention switch is the PR itself; the durable record is the merged commit + the §11 prose. The CHANGELOG entry under `[Unreleased] ### Internal` could be added but felt redundant given §11 itself is the artifact — happy to add if you'd prefer.

## Why two PRs (this + #275)

User requested sequential. PR #275 carried the backfill (CHANGELOG data). This PR codifies the rule that produced the backfill (process). Independent revertability: if §11 turns out to be wrong wording, this PR can revert without disturbing the [Unreleased] entries from #275.

## CodeRabbit

Skipped per develop-target policy. Will be re-reviewed in the next develop→main batch.