### PR TITLE
refactor(AccountManager): add instance API + singleton facade (M9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ convention was adopted (see CLAUDE.md §11).
 - `CODE_OF_CONDUCT.md` at repo root using Contributor Covenant 2.1,
   with the contact placeholder substituted to `gilbertsahumada@gmail.com`.
   Closes #202.
+- `AccountManager` instance API alongside the existing class-static
+  surface. Construct via `new AccountManager(options?)` for a fully
+  isolated pool (independent `labelMap`, `pool`, private-key map). New
+  `AccountManagerOptions` interface exposes `{ poolPath?: string }`;
+  when omitted, `poolPath` is evaluated lazily on each call (respecting
+  `process.chdir()` between construction and pool I/O — the inverse of
+  the legacy F8(b) static-API behavior). The static facade is preserved
+  in 0.2.x for back-compat — every former static call forwards to a
+  process-wide singleton whose `poolPath` is eagerly captured at module
+  import (the legacy behavior). Removal of the static facade ships in
+  0.3.0 (#270). Closes #277.
 
 ### Changed
 

--- a/packages/movehat/src/core/AccountManager.ts
+++ b/packages/movehat/src/core/AccountManager.ts
@@ -29,62 +29,105 @@ export interface SaveAccountPoolOptions {
   includeImported?: boolean | undefined;
 }
 
+export interface AccountManagerOptions {
+  /**
+   * Filesystem location where `saveAccountPool` writes `test-pool.json`
+   * and `loadAccountPool` reads from. When omitted, the path is computed
+   * LAZILY on each call from `join(process.cwd(), ".movehat", "accounts")`
+   * — so `process.chdir()` between construction and pool I/O is respected.
+   *
+   * Pass an explicit value when per-instance isolation matters (parallel
+   * test files, harness pools that must not collide with another suite's).
+   *
+   * The process-wide static facade exposed on the `AccountManager` class
+   * itself uses a separate singleton whose `poolPath` is EAGERLY captured
+   * at module-import time. That preserves the legacy F8(b) behavior for
+   * any code still on the static API during the 0.2.7 deprecation window;
+   * the static facade is removed in 0.3.0.
+   */
+  poolPath?: string | undefined;
+}
+
 /**
  * Centralized Account Manager for movehat
  *
  * Manages all account creation, loading, and lifecycle operations.
- * Provides a pool of reusable test accounts with labels for better test readability.
+ * Provides a pool of reusable test accounts with labels for better test
+ * readability.
+ *
+ * Two API surfaces are exposed:
+ *
+ * **Instance API (recommended; M9.1+)** — `new AccountManager(options?)`
+ * gives a fully isolated pool. Two instances in the same process have
+ * independent labelMaps, private-key maps, and account pools. Each
+ * `Harness` constructed in 0.3.0+ will own one of these; user code
+ * accesses labeled accounts via `harness.accounts.<label>` (Harness
+ * snapshots them at construction time).
+ *
+ * **Static facade (deprecated; will be removed in 0.3.0)** — every
+ * former static method (`AccountManager.createAccount(...)`, etc.) still
+ * works and forwards to a single process-wide singleton. This preserves
+ * the existing label-sharing behavior across calls during the
+ * deprecation window. Migration target is the instance API; see M9 meta
+ * (#270) and migration guide at `/docs/upgrading/0.3.0` (published in
+ * M9.4).
  */
 export class AccountManager {
-  // Class-static maps: shared across every consumer in the same Node
-  // process (e.g. two Harness instances). Re-using a label across
-  // "sessions" overwrites the labelMap entry. Documented + fixed by
-  // contract in `AccountManager.global-state.test.ts` (audit F8).
-  private static pool: Map<string, Account> = new Map(); // address → Account
-  private static privateKeys: Map<string, string> = new Map(); // address → privateKey hex
-  private static labelMap: Map<string, string> = new Map(); // label → address
-  private static generatedAccountAddresses: Set<string> = new Set();
-  private static poolLoaded = false;
-  // `defaultPoolPath` is captured ONCE at module-import time. A later
-  // `process.chdir(...)` does NOT redirect the save destination — pass
-  // an explicit `poolPath` to `saveAccountPool`/`loadAccountPool` when
-  // per-test isolation matters. See audit finding F8.
-  private static defaultPoolPath = join(process.cwd(), ".movehat", "accounts");
+  // ── Instance state ──────────────────────────────────────────────
+  // All former class-static fields are now instance fields. Two
+  // `new AccountManager()` calls produce fully isolated state. The
+  // static facade below operates on a single module-level singleton,
+  // so existing callers see no behavior change.
+  private readonly pool: Map<string, Account> = new Map(); // address → Account
+  private readonly privateKeys: Map<string, string> = new Map(); // address → privateKey hex
+  private readonly labelMap: Map<string, string> = new Map(); // label → address
+  private readonly generatedAccountAddresses: Set<string> = new Set();
+  private poolLoaded = false;
+  private readonly poolPathOverride: string | undefined;
+
+  constructor(options: AccountManagerOptions = {}) {
+    this.poolPathOverride = options.poolPath;
+  }
 
   /**
-   * Get a test account from the pool. If label is provided and exists, returns that account.
-   * Otherwise creates a new account with the optional label.
-   *
-   * @param label Optional label for the account (e.g., "alice", "bob", "deployer")
-   * @returns An Account instance
-   *
-   * @example
-   * const alice = AccountManager.getTestAccount("alice");
-   * const randomAccount = AccountManager.getTestAccount();
+   * Resolved pool directory. When the caller supplied an explicit
+   * `poolPath` to the constructor, that value is returned verbatim.
+   * Otherwise the path is computed LAZILY from the current
+   * `process.cwd()` on each access — so `process.chdir()` performed
+   * between construction and pool I/O takes effect, unlike the legacy
+   * static-only API which captured cwd at module import time
+   * (audit finding F8(b)).
    */
-  static getTestAccount(label?: string): Account {
+  private get poolPath(): string {
+    return this.poolPathOverride ?? join(process.cwd(), ".movehat", "accounts");
+  }
+
+  // ── Instance methods (real implementations) ─────────────────────
+
+  /**
+   * Get a test account from the pool. If label is provided and exists,
+   * returns that account. Otherwise creates a new account with the
+   * optional label.
+   *
+   * @param label Optional label for the account (e.g., "alice", "bob")
+   * @returns An Account instance
+   */
+  getTestAccount(label?: string): Account {
     if (label) {
-      const existingAccount = this.getAccountByLabel(label);
-      if (existingAccount) {
-        return existingAccount;
+      const existing = this.getAccountByLabel(label);
+      if (existing) {
+        return existing;
       }
     }
-
     return this.createAccount(label, false);
   }
 
   /**
-   * Create a new account and optionally add it to the pool with a label
-   *
-   * @param label Optional label for the account
-   * @param fund Whether to fund the account (handled externally)
-   * @returns A new Account instance
-   *
-   * @example
-   * const deployer = AccountManager.createAccount("deployer");
-   * const bob = AccountManager.createAccount("bob", true);
+   * Create a new account and optionally add it to the pool with a
+   * label. The `fund` parameter is accepted for API symmetry; actual
+   * funding is the caller's responsibility.
    */
-  static createAccount(label?: string, fund: boolean = false): Account {
+  createAccount(label?: string, _fund: boolean = false): Account {
     const account = Account.generate();
     const address = account.accountAddress.toString();
 
@@ -100,18 +143,9 @@ export class AccountManager {
   }
 
   /**
-   * Get an account by its label
-   *
-   * @param label The label to look up
-   * @returns The Account if found, undefined otherwise
-   *
-   * @example
-   * const alice = AccountManager.getAccountByLabel("alice");
-   * if (alice) {
-   *   console.log(`Alice's address: ${alice.accountAddress.toString()}`);
-   * }
+   * Get an account by its label, or undefined if not present.
    */
-  static getAccountByLabel(label: string): Account | undefined {
+  getAccountByLabel(label: string): Account | undefined {
     const address = this.labelMap.get(label);
     if (!address) {
       return undefined;
@@ -120,136 +154,98 @@ export class AccountManager {
   }
 
   /**
-   * Load account from environment variable
+   * Load account from environment variable.
    *
-   * @param envVar The environment variable name (defaults to "PRIVATE_KEY")
-   * @returns Account instance
-   * @throws Error if environment variable is not set
-   *
-   * @example
-   * const account = AccountManager.loadAccountFromEnv("MH_PRIVATE_KEY");
+   * @throws Error if the environment variable is not set
    */
-  static loadAccountFromEnv(envVar: string = "PRIVATE_KEY"): Account {
+  loadAccountFromEnv(envVar: string = "PRIVATE_KEY"): Account {
     const privateKeyHex = process.env[envVar];
-
     if (!privateKeyHex) {
       throw new Error(
         `Environment variable ${envVar} not found. ` +
-        `Set it in your .env file or environment.`
+          `Set it in your .env file or environment.`,
       );
     }
-
     return this.loadAccountFromPrivateKey(privateKeyHex);
   }
 
   /**
-   * Load account from a private key hex string
-   *
-   * @param privateKeyHex The private key as a hex string (with or without 0x prefix)
-   * @returns Account instance
-   *
-   * @example
-   * const account = AccountManager.loadAccountFromPrivateKey("0xabc123...");
+   * Load account from a private key hex string (with or without 0x prefix).
    */
-  static loadAccountFromPrivateKey(privateKeyHex: string): Account {
+  loadAccountFromPrivateKey(privateKeyHex: string): Account {
     // Format into AIP-80 shape (`ed25519-priv-0x…`) before constructing
     // the SDK type. Without this, raw-hex inputs trigger a noisy
     // deprecation warning from `@aptos-labs/ts-sdk` on every call.
     const account = this.accountFromPrivateKey(privateKeyHex);
     this.trackAccount(account, privateKeyHex, "imported");
-
     return account;
   }
 
   /**
-   * Load all accounts from movehat config
-   *
-   * @param config The resolved MovehatConfig
-   * @returns Array of Account instances
-   *
-   * @example
-   * const config = await resolveNetworkConfig(userConfig);
-   * const accounts = AccountManager.loadAccountsFromConfig(config);
+   * Load all accounts from movehat config.
    */
-  static loadAccountsFromConfig(config: MovehatConfig): Account[] {
+  loadAccountsFromConfig(config: MovehatConfig): Account[] {
     const accounts: Account[] = [];
-
     for (const privateKeyHex of config.allAccounts) {
       try {
         const account = this.loadAccountFromPrivateKey(privateKeyHex);
         accounts.push(account);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        console.warn(
-          `Warning: Failed to load account from config: ${msg}`
-        );
+        console.warn(`Warning: Failed to load account from config: ${msg}`);
       }
     }
-
     return accounts;
   }
 
   /**
-   * Get all labeled accounts in the pool
-   *
-   * @returns Record of label to Account mappings
-   *
-   * @example
-   * const labeled = AccountManager.getLabeledAccounts();
-   * console.log(`Deployer: ${labeled.deployer?.accountAddress.toString()}`);
+   * Get all labeled accounts in the pool.
    */
-  static getLabeledAccounts(): Record<string, Account> {
+  getLabeledAccounts(): Record<string, Account> {
     const result: Record<string, Account> = {};
-
     for (const [label, address] of this.labelMap.entries()) {
       const account = this.pool.get(address);
       if (account) {
         result[label] = account;
       }
     }
-
     return result;
   }
 
   /**
-   * Save the current account pool to disk for persistence
-   *
-   * @param poolPath Optional custom path (defaults to .movehat/accounts)
-   *
-   * @example
-   * AccountManager.saveAccountPool();
+   * Save the current account pool to disk for persistence.
    */
-  static saveAccountPool(): void;
-  static saveAccountPool(poolPath: string): void;
-  static saveAccountPool(options: SaveAccountPoolOptions): void;
-  static saveAccountPool(poolPath: string, options: SaveAccountPoolOptions): void;
-  static saveAccountPool(
+  saveAccountPool(): void;
+  saveAccountPool(poolPath: string): void;
+  saveAccountPool(options: SaveAccountPoolOptions): void;
+  saveAccountPool(poolPath: string, options: SaveAccountPoolOptions): void;
+  saveAccountPool(
     poolPathOrOptions?: string | SaveAccountPoolOptions,
     options: SaveAccountPoolOptions = {},
   ): void {
-    const poolPath =
+    const explicitPath =
       typeof poolPathOrOptions === "string" ? poolPathOrOptions : undefined;
     const effectiveOptions =
       typeof poolPathOrOptions === "object" && poolPathOrOptions !== null
         ? poolPathOrOptions
         : options;
     const includeImported = effectiveOptions.includeImported ?? false;
-    const basePath = poolPath || this.defaultPoolPath;
+    const basePath = explicitPath || this.poolPath;
 
     // Ensure directory exists with restrictive perms (the pool file holds
     // plaintext private keys, so the directory must not be world-readable).
-    // Note: mkdirSync's mode is masked by the process umask, so we chmod
-    // explicitly afterwards to guarantee 0o700 regardless of umask.
+    // mkdirSync's mode is masked by the process umask; chmod explicitly
+    // afterwards to guarantee 0o700.
     if (!existsSync(basePath)) {
       mkdirSync(basePath, { recursive: true, mode: 0o700 });
     }
     chmodSync(basePath, 0o700);
 
-    // Build stored accounts array
     const storedAccounts: StoredAccount[] = [];
     const labelMapObject: Record<string, string> = {};
 
     for (const [address, account] of this.pool.entries()) {
+      void account;
       if (!includeImported && !this.generatedAccountAddresses.has(address)) {
         continue;
       }
@@ -283,10 +279,6 @@ export class AccountManager {
       labelMap: labelMapObject,
     };
 
-    // Write to file with owner-only permissions — file contains plaintext
-    // private keys for test accounts. writeFileSync's mode is masked by
-    // the process umask, so we chmod explicitly afterwards to guarantee
-    // 0o600 regardless of umask.
     const poolFilePath = join(basePath, "test-pool.json");
     writeFileSync(poolFilePath, JSON.stringify(poolData, null, 2), {
       encoding: "utf-8",
@@ -296,22 +288,15 @@ export class AccountManager {
   }
 
   /**
-   * Load account pool from disk
-   *
-   * @param poolPath Optional custom path (defaults to .movehat/accounts)
-   * @returns true if pool was loaded, false if file doesn't exist
-   *
-   * @example
-   * if (AccountManager.loadAccountPool()) {
-   *   console.log("Pool loaded successfully");
-   * }
+   * Load account pool from disk. Returns true if a pool file was found
+   * and parsed, false if the file does not exist or parsing failed.
    */
-  static loadAccountPool(poolPath?: string): boolean {
+  loadAccountPool(poolPath?: string): boolean {
     if (this.poolLoaded) {
-      return true; // Already loaded
+      return true;
     }
 
-    const basePath = poolPath || this.defaultPoolPath;
+    const basePath = poolPath || this.poolPath;
     const poolFilePath = join(basePath, "test-pool.json");
 
     if (!existsSync(poolFilePath)) {
@@ -319,15 +304,11 @@ export class AccountManager {
     }
 
     try {
-      const poolData: AccountPool = JSON.parse(
-        readFileSync(poolFilePath, "utf-8")
-      );
+      const poolData: AccountPool = JSON.parse(readFileSync(poolFilePath, "utf-8"));
 
-      // Clear existing pool
       this.pool.clear();
       this.labelMap.clear();
 
-      // Restore accounts
       for (const stored of poolData.accounts) {
         const account = this.accountFromPrivateKey(stored.privateKey);
         this.trackAccount(account, stored.privateKey, "generated");
@@ -348,23 +329,15 @@ export class AccountManager {
       return true;
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      console.warn(
-        `Warning: Failed to load account pool: ${msg}`
-      );
+      console.warn(`Warning: Failed to load account pool: ${msg}`);
       return false;
     }
   }
 
   /**
-   * Clear the entire account pool
-   * Useful for test isolation
-   *
-   * @example
-   * after(() => {
-   *   AccountManager.clearPool();
-   * });
+   * Clear the entire account pool. Useful for test isolation.
    */
-  static clearPool(): void {
+  clearPool(): void {
     this.pool.clear();
     this.privateKeys.clear();
     this.labelMap.clear();
@@ -373,46 +346,30 @@ export class AccountManager {
   }
 
   /**
-   * Get the current size of the account pool
-   *
-   * @returns Number of accounts in the pool
+   * Number of accounts in the pool.
    */
-  static getPoolSize(): number {
+  getPoolSize(): number {
     return this.pool.size;
   }
 
   /**
-   * Get all accounts in the pool
-   *
-   * @returns Array of all Account instances
+   * All accounts in the pool.
    */
-  static getAllAccounts(): Account[] {
+  getAllAccounts(): Account[] {
     return Array.from(this.pool.values());
   }
 
   /**
-   * Check if a label is already in use
-   *
-   * @param label The label to check
-   * @returns true if label exists, false otherwise
+   * Whether a label is currently bound to an account in this pool.
    */
-  static hasLabel(label: string): boolean {
+  hasLabel(label: string): boolean {
     return this.labelMap.has(label);
   }
 
   /**
-   * Get or create an account with a specific label
-   * If the label exists, returns the existing account
-   * Otherwise creates a new account with that label
-   *
-   * @param label The label for the account
-   * @returns Account instance
-   *
-   * @example
-   * const alice = AccountManager.getOrCreateLabeled("alice");
-   * const aliceAgain = AccountManager.getOrCreateLabeled("alice"); // Same account
+   * Get or create an account with a specific label.
    */
-  static getOrCreateLabeled(label: string): Account {
+  getOrCreateLabeled(label: string): Account {
     const existing = this.getAccountByLabel(label);
     if (existing) {
       return existing;
@@ -421,37 +378,24 @@ export class AccountManager {
   }
 
   /**
-   * Batch create multiple labeled accounts
-   *
-   * @param labels Array of labels to create
-   * @returns Record of label to Account mappings
-   *
-   * @example
-   * const accounts = AccountManager.createBatch(["alice", "bob", "charlie"]);
-   * console.log(accounts.alice.accountAddress.toString());
+   * Batch create multiple labeled accounts.
    */
-  static createBatch(labels: readonly string[]): Record<string, Account> {
+  createBatch(labels: readonly string[]): Record<string, Account> {
     const result: Record<string, Account> = {};
-
     for (const label of labels) {
       result[label] = this.getOrCreateLabeled(label);
     }
-
     return result;
   }
 
   /**
-   * Export account private keys for backup/sharing
-   * WARNING: Only use this for test accounts, never production keys
-   *
-   * @param labels Optional array of labels to export (exports all if not provided)
-   * @returns Record of label/address to private key hex string
+   * Export account private keys for backup/sharing.
+   * WARNING: Only use this for test accounts, never production keys.
    */
-  static exportPrivateKeys(labels?: string[]): Record<string, string> {
+  exportPrivateKeys(labels?: string[]): Record<string, string> {
     const result: Record<string, string> = {};
 
     if (labels) {
-      // Export specific labels
       for (const label of labels) {
         const address = this.labelMap.get(label);
         if (address) {
@@ -462,7 +406,6 @@ export class AccountManager {
         }
       }
     } else {
-      // Export all labeled accounts
       for (const [label, address] of this.labelMap.entries()) {
         const privateKey = this.privateKeys.get(address);
         if (privateKey) {
@@ -474,7 +417,7 @@ export class AccountManager {
     return result;
   }
 
-  private static accountFromPrivateKey(privateKeyHex: string): Account {
+  private accountFromPrivateKey(privateKeyHex: string): Account {
     const formatted = PrivateKey.formatPrivateKey(
       privateKeyHex,
       PrivateKeyVariants.Ed25519,
@@ -483,13 +426,12 @@ export class AccountManager {
     return Account.fromPrivateKey({ privateKey });
   }
 
-  private static trackAccount(
+  private trackAccount(
     account: Account,
     privateKeyHex: string,
     source: "generated" | "imported",
   ): void {
     const address = account.accountAddress.toString();
-
     this.pool.set(address, account);
     this.privateKeys.set(address, privateKeyHex);
 
@@ -499,4 +441,104 @@ export class AccountManager {
       this.generatedAccountAddresses.delete(address);
     }
   }
+
+  // ── Static facade (deprecated; removed in 0.3.0) ────────────────
+  //
+  // Every former static method below forwards to `__defaultManager`,
+  // a module-level singleton constructed once at import time. This
+  // preserves the legacy "process-wide pool shared across consumers"
+  // behavior so existing callers see no change during the 0.2.7
+  // deprecation window. The singleton is constructed with its
+  // `poolPath` eagerly captured from the import-time `process.cwd()`
+  // — preserving F8(b) for the static API specifically.
+  //
+  // Removal happens in M9.4 (0.3.0). Until then the runtime warning
+  // added in M9.3 nudges users toward `harness.accounts.<label>` or
+  // `harness.runtime.accountManager.*`.
+
+  static getTestAccount(label?: string): Account {
+    return __defaultManager.getTestAccount(label);
+  }
+
+  static createAccount(label?: string, fund: boolean = false): Account {
+    return __defaultManager.createAccount(label, fund);
+  }
+
+  static getAccountByLabel(label: string): Account | undefined {
+    return __defaultManager.getAccountByLabel(label);
+  }
+
+  static loadAccountFromEnv(envVar: string = "PRIVATE_KEY"): Account {
+    return __defaultManager.loadAccountFromEnv(envVar);
+  }
+
+  static loadAccountFromPrivateKey(privateKeyHex: string): Account {
+    return __defaultManager.loadAccountFromPrivateKey(privateKeyHex);
+  }
+
+  static loadAccountsFromConfig(config: MovehatConfig): Account[] {
+    return __defaultManager.loadAccountsFromConfig(config);
+  }
+
+  static getLabeledAccounts(): Record<string, Account> {
+    return __defaultManager.getLabeledAccounts();
+  }
+
+  static saveAccountPool(): void;
+  static saveAccountPool(poolPath: string): void;
+  static saveAccountPool(options: SaveAccountPoolOptions): void;
+  static saveAccountPool(poolPath: string, options: SaveAccountPoolOptions): void;
+  static saveAccountPool(
+    poolPathOrOptions?: string | SaveAccountPoolOptions,
+    options: SaveAccountPoolOptions = {},
+  ): void {
+    // Re-dispatch via the instance overloads, preserving caller intent.
+    if (poolPathOrOptions === undefined) {
+      __defaultManager.saveAccountPool();
+    } else if (typeof poolPathOrOptions === "string") {
+      __defaultManager.saveAccountPool(poolPathOrOptions, options);
+    } else {
+      __defaultManager.saveAccountPool(poolPathOrOptions);
+    }
+  }
+
+  static loadAccountPool(poolPath?: string): boolean {
+    return __defaultManager.loadAccountPool(poolPath);
+  }
+
+  static clearPool(): void {
+    __defaultManager.clearPool();
+  }
+
+  static getPoolSize(): number {
+    return __defaultManager.getPoolSize();
+  }
+
+  static getAllAccounts(): Account[] {
+    return __defaultManager.getAllAccounts();
+  }
+
+  static hasLabel(label: string): boolean {
+    return __defaultManager.hasLabel(label);
+  }
+
+  static getOrCreateLabeled(label: string): Account {
+    return __defaultManager.getOrCreateLabeled(label);
+  }
+
+  static createBatch(labels: readonly string[]): Record<string, Account> {
+    return __defaultManager.createBatch(labels);
+  }
+
+  static exportPrivateKeys(labels?: string[]): Record<string, string> {
+    return __defaultManager.exportPrivateKeys(labels);
+  }
 }
+
+// Module-level singleton backing the static facade. The eager poolPath
+// capture mirrors the pre-M9 behavior — `process.chdir` after import
+// does NOT redirect static-facade pool I/O. F8(b) is preserved for
+// the static API and only flips for callers using the instance API.
+const __defaultManager = new AccountManager({
+  poolPath: join(process.cwd(), ".movehat", "accounts"),
+});

--- a/packages/movehat/src/core/__tests__/AccountManager.global-state.test.ts
+++ b/packages/movehat/src/core/__tests__/AccountManager.global-state.test.ts
@@ -81,3 +81,122 @@ describe("F8 — AccountManager static state and import-time cwd capture", () =>
     expect(existsSync(join(explicit, "test-pool.json"))).toBe(true);
   });
 });
+
+/**
+ * M9.1 — per-instance API additive coverage.
+ *
+ * Validates the new `new AccountManager(options?)` shape introduced by
+ * M9.1 (#277, tracks #270). The F8 assertions above continue to pin the
+ * legacy static-facade behavior (preserved through the deprecation window
+ * via a module-level singleton). These tests pin the NEW shape:
+ *
+ *   - Two instances have fully isolated pools / labelMaps / private keys.
+ *   - An explicit `poolPath` honored on save.
+ *   - Default `poolPath` evaluated LAZILY on each call — `process.chdir`
+ *     between construction and save IS respected (the inverse of F8(b),
+ *     which only applied to the static facade and stays preserved above).
+ *
+ * When M9.4 removes the static facade in 0.3.0, the F8 block above goes
+ * away and only this block remains.
+ */
+describe("AccountManager — per-instance isolation (M9.1, #277)", () => {
+  let cwdBackup: string;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    cwdBackup = process.cwd();
+    tmpDir = mkdtempSync(join(tmpdir(), "movehat-m9.1-"));
+  });
+
+  afterEach(() => {
+    if (process.cwd() !== cwdBackup) {
+      process.chdir(cwdBackup);
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("two instances have independent label maps — re-using a label across instances does NOT collide", () => {
+    const mgr1 = new AccountManager();
+    const mgr2 = new AccountManager();
+
+    const alice1 = mgr1.createAccount("alice");
+    const alice2 = mgr2.createAccount("alice");
+
+    // Two distinct accounts — neither labelMap was touched by the other.
+    expect(alice1.accountAddress.toString()).not.toBe(
+      alice2.accountAddress.toString(),
+    );
+
+    // Each instance resolves "alice" to its own account.
+    const lookup1 = mgr1.getAccountByLabel("alice");
+    const lookup2 = mgr2.getAccountByLabel("alice");
+    expect(lookup1!.accountAddress.toString()).toBe(alice1.accountAddress.toString());
+    expect(lookup2!.accountAddress.toString()).toBe(alice2.accountAddress.toString());
+
+    // Pool sizes are independent.
+    expect(mgr1.getPoolSize()).toBe(1);
+    expect(mgr2.getPoolSize()).toBe(1);
+  });
+
+  it("two instances do not share private keys, generated-account tracking, or pool entries", () => {
+    const mgr1 = new AccountManager();
+    const mgr2 = new AccountManager();
+
+    mgr1.createAccount("shared_label");
+    mgr2.createAccount("shared_label");
+
+    const keys1 = mgr1.exportPrivateKeys();
+    const keys2 = mgr2.exportPrivateKeys();
+    expect(keys1.shared_label).toBeDefined();
+    expect(keys2.shared_label).toBeDefined();
+    expect(keys1.shared_label).not.toBe(keys2.shared_label);
+
+    // mgr2's account is NOT visible from mgr1's getAllAccounts.
+    const all1 = mgr1.getAllAccounts();
+    const all2 = mgr2.getAllAccounts();
+    expect(all1).toHaveLength(1);
+    expect(all2).toHaveLength(1);
+    expect(all1[0]!.accountAddress.toString()).not.toBe(
+      all2[0]!.accountAddress.toString(),
+    );
+  });
+
+  it("explicit poolPath option lands saveAccountPool() at the configured directory", () => {
+    const explicit = join(tmpDir, "explicit-instance-pool");
+    const mgr = new AccountManager({ poolPath: explicit });
+
+    mgr.createAccount("carol");
+    mgr.saveAccountPool();
+
+    expect(existsSync(join(explicit, "test-pool.json"))).toBe(true);
+  });
+
+  it("default poolPath is evaluated LAZILY — process.chdir between construction and save IS respected", () => {
+    // Construct with NO explicit poolPath BEFORE chdir.
+    const mgr = new AccountManager();
+    mgr.createAccount("late_chdir_account");
+
+    // Now chdir. The instance's `poolPath` getter resolves to this
+    // fresh cwd at the moment of save — the legacy F8(b) bug
+    // (cwd captured at import time) does NOT apply to instances.
+    process.chdir(tmpDir);
+    mgr.saveAccountPool();
+
+    const expectedAtNewCwd = join(tmpDir, ".movehat", "accounts", "test-pool.json");
+    expect(existsSync(expectedAtNewCwd)).toBe(true);
+  });
+
+  it("static facade still routes to a shared singleton — confirms back-compat path is wired", () => {
+    // This is a meta-assertion: the static API exists, is callable, and
+    // operates on a single shared state across calls. Without this guard,
+    // a future refactor could silently break the deprecation window.
+    AccountManager.clearPool();
+    expect(AccountManager.getPoolSize()).toBe(0);
+
+    AccountManager.createAccount("singleton_meta");
+    expect(AccountManager.getPoolSize()).toBe(1);
+    expect(AccountManager.hasLabel("singleton_meta")).toBe(true);
+
+    AccountManager.clearPool();
+  });
+});


### PR DESCRIPTION
## Summary

First sub-PR of **M9** (per [meta-issue #270](https://github.com/gilbertsahumada/movehat/issues/270)). Adds a per-instance `AccountManager` API alongside the existing class-static surface. The static API is preserved fully via a module-level singleton so existing callers see **zero behavior change** in 0.2.7.

## What this PR ships

| Layer | Change |
|---|---|
| `AccountManager` class | All 6 static fields + 13 public static methods + 2 private helpers converted to instance shape |
| Constructor | New `new AccountManager(options?: AccountManagerOptions)` — `{ poolPath?: string }` |
| `poolPath` semantics | LAZY getter for instances → respects `process.chdir()` between construction and pool I/O. The legacy F8(b) static-API behavior (cwd captured at import) is preserved on the singleton for back-compat. |
| Static facade | Every former static method forwards to `__defaultManager = new AccountManager({ poolPath: <eager-cwd> })`. Behavior identical to pre-M9. |
| Tests | F8 pinning assertions (`global-state.test.ts`) untouched — both still pass. New `describe` block adds **5 per-instance isolation tests**. |
| CHANGELOG | New `[Unreleased] ### Added` entry per CLAUDE.md §11 |

## What this PR does NOT touch (per the M9 plan)

| Out of scope | Future sub-PR |
|---|---|
| Migrate internal callers (`runtime.ts`, helpers, etc.) | **M9.2** |
| Add `harness.accounts.alice` shortcut | **M9.2** |
| Runtime `console.warn` on static API | **M9.3** |
| Migrate template + example | **M9.3** |
| Rewrite 5 docs MDX files | **M9.4** |
| Remove static facade entirely | **M9.4 / 0.3.0** |

## Coverage

`packages/movehat/src/core/AccountManager.ts`:

| Metric | Before | After |
|---|---|---|
| Lines | 97.7% | **97.4%** |
| Functions | 100% | **100%** |
| Statements | 97.7% | **97.4%** |
| Branches | 81.9% | **83.1%** |

The minor lines/statements dip is from the duplicated static-forwarder methods (each adds 1 LoC that's only exercised when the static API is called, which the existing tests cover via the F8 pinning + the new singleton-meta test).

**Test count: 543 → 548** (+5 M9.1 isolation tests).

## Verification

- [x] `pnpm test` — 548/548 pass
- [x] `pnpm test:coverage` — `AccountManager.ts` ≥ existing per-file gate (not in the per-file ratchet list; passes the global floor of 70% by a wide margin)
- [x] `pnpm build:movehat` green (pre-push hook ran)
- [x] `pnpm typecheck:example` green (template still uses static API — singleton facade keeps it compiling unchanged)
- [x] F8(a) label-collision assertion still holds (singleton's labelMap collides as before)
- [x] F8(b) cwd-capture assertion still holds (singleton's `poolPath` eagerly captured at module import — preserved deliberately)
- [x] New isolation tests prove instances do NOT share state

## Tier reporting (per CLAUDE.md §6)

- **Tier 1** (auto): pre-push hook green
- **Tier 2** (`test:example`): N/A as full run not executed in this PR — `typecheck:example` (Tier 1's stricter consumer) is green, and the template's static API still works via the facade. Will fully re-run before M9.3 ships the template migration.
- **Tier 3** (`test:e2e`): N/A — no template/published-surface change at this stage. Will run before M9.3 ships 0.2.7.

## Design notes (for reviewer)

1. **Why preserve F8(b) for the singleton?** The static facade is the back-compat contract for the 0.2.7 deprecation window. Any caller still on `AccountManager.saveAccountPool()` no-arg call expects the legacy import-time-cwd behavior. Changing it here would be a silent behavior change for the static API path. M9.4 removes the singleton entirely; until then, the two paths intentionally differ.

2. **Why `new AccountManager()` (positional `options`) instead of a factory?** Matches the SDK convention (`new AptosConfig(...)`). The `AccountManagerOptions` interface is extensible — future M9 sub-PRs may add fields like `loadOnConstruct` without breaking the call site.

3. **Why is `_fund` parameter prefixed with underscore?** TypeScript convention for documented-but-currently-unused params. The parameter was accepted in the prior static signature (callers may pass it); preserving the API shape avoids breaking anyone passing the second arg.

## §10 issue lifecycle

Closes #277 (M9.1 sub-issue)
Tracks #270 (M9 meta — closes when M9.4 lands)

## CodeRabbit

Skipped per develop-target policy.