### PR TITLE
refactor: migrate internal callers + add harness.accounts (M9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,22 @@ convention was adopted (see CLAUDE.md §11).
   process-wide singleton whose `poolPath` is eagerly captured at module
   import (the legacy behavior). Removal of the static facade ships in
   0.3.0 (#270). Closes #277.
+- Per-Harness account isolation. Each `Harness` now owns its own
+  `AccountManager` instance reachable at `harness.runtime.accountManager`.
+  New `Harness.accounts: Record<string, Account>` field exposes labeled
+  accounts created at construction time (`accountLabels` in
+  `createLocal` / `createFork` options) as a snapshot — late additions
+  via `harness.runtime.accountManager.createAccount(...)` are not
+  reflected. `Harness.createLive` produces an empty `accounts` Record
+  (live mode does not create labeled accounts). New optional
+  `InitRuntimeOptions.accountManager?` lets callers (`setupLocalTesting`,
+  `setupTestFixture`) construct accounts before runtime init and thread
+  the same instance through. Two `Harness.createLocal({ accountLabels:
+  ["alice"] })` calls in the same process now produce DIFFERENT alice
+  accounts — fixes the long-standing F8(a) label collision quirk that
+  silently shadowed accounts across test files. Legacy `AccountManager.X()`
+  static API still works unchanged via the singleton facade from M9.1
+  (deprecation warning in 0.2.7, removal in 0.3.0). Closes #279.
 
 ### Changed
 

--- a/packages/movehat/src/__tests__/harness/Harness.accounts.test.ts
+++ b/packages/movehat/src/__tests__/harness/Harness.accounts.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { Harness } from "../../harness/index.js";
+import { initRuntime } from "../../runtime.js";
+import { AccountManager } from "../../core/AccountManager.js";
+import { setupHarnessTestFixture, type HarnessTestFixture } from "./_fixture.js";
+
+/**
+ * M9.2 — Harness.accounts + runtime.accountManager wiring.
+ *
+ * Verifies the user-facing F8(a) fix that M9.2 unlocks: each Harness
+ * owns a per-instance AccountManager, and `harness.accounts` is a
+ * snapshot of that manager's labeled accounts. Two runtimes built with
+ * separate `AccountManager` instances do NOT share label state (the
+ * static facade's process-wide collision is bypassed).
+ *
+ * Live-mode coverage only — `Harness.createLocal` / `createFork` spin
+ * up real infrastructure (movement node / fork server) and live in the
+ * integration tier. The wiring being tested here (snapshot from
+ * runtime.accountManager.getLabeledAccounts()) is identical across all
+ * three modes, so live-mode is a sufficient unit-level proof.
+ */
+describe("Harness.accounts + runtime.accountManager (M9.2, #279)", () => {
+  let fixture: HarnessTestFixture;
+
+  beforeEach(() => {
+    fixture = setupHarnessTestFixture();
+  });
+
+  afterEach(() => {
+    fixture.teardown();
+  });
+
+  it("exposes the constructed AccountManager via runtime.accountManager", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      expect(harness.runtime.accountManager).toBeInstanceOf(AccountManager);
+      // The runtime constructed its own AccountManager (no caller-supplied
+      // option threaded in via createLive).
+      expect(typeof harness.runtime.accountManager.getLabeledAccounts).toBe(
+        "function",
+      );
+      expect(typeof harness.runtime.accountManager.createAccount).toBe(
+        "function",
+      );
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("harness.accounts is empty {} for createLive (no labels in config-driven account loading)", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      expect(harness.accounts).toEqual({});
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("InitRuntimeOptions.accountManager threads a pre-seeded manager onto the runtime", async () => {
+    // Caller pre-creates the manager, seeds it, then passes to initRuntime.
+    // The returned runtime.accountManager === the passed instance, so the
+    // pre-existing labels survive.
+    const mgr = new AccountManager();
+    mgr.createAccount("alice");
+    mgr.createAccount("bob");
+    const seededSize = mgr.getPoolSize(); // 2
+
+    const runtime = await initRuntime({
+      network: "testnet",
+      accountManager: mgr,
+    });
+
+    // Identity check: the runtime's manager IS the caller's instance.
+    expect(runtime.accountManager).toBe(mgr);
+
+    // The pre-seeded labels survive.
+    expect(runtime.accountManager.hasLabel("alice")).toBe(true);
+    expect(runtime.accountManager.hasLabel("bob")).toBe(true);
+
+    // initRuntime additionally calls loadAccountsFromConfig(config), which
+    // loads the testnet config's accounts (1 auto-generated deterministic
+    // test key when no `accounts` array is configured) and adds them to
+    // the same manager. Pool size = seeded + config-loaded.
+    expect(runtime.accountManager.getPoolSize()).toBe(seededSize + 1);
+  });
+
+  it("two runtimes with separate AccountManager instances have isolated label maps", async () => {
+    // The user-facing F8(a) fix: two harnesses no longer silently shadow
+    // each other's account labels. Verified at the runtime layer here
+    // (the cheap path); the Harness layer just snapshots whatever
+    // runtime.accountManager.getLabeledAccounts() returns.
+    const mgr1 = new AccountManager();
+    const mgr2 = new AccountManager();
+
+    const alice1 = mgr1.createAccount("alice");
+    const alice2 = mgr2.createAccount("alice");
+
+    const r1 = await initRuntime({ network: "testnet", accountManager: mgr1 });
+    const r2 = await initRuntime({ network: "testnet", accountManager: mgr2 });
+
+    // The two runtimes resolve "alice" to DIFFERENT accounts.
+    const a1 = r1.accountManager.getAccountByLabel("alice");
+    const a2 = r2.accountManager.getAccountByLabel("alice");
+
+    expect(a1!.accountAddress.toString()).toBe(alice1.accountAddress.toString());
+    expect(a2!.accountAddress.toString()).toBe(alice2.accountAddress.toString());
+    expect(a1!.accountAddress.toString()).not.toBe(
+      a2!.accountAddress.toString(),
+    );
+
+    // Pool sizes are independent. Each manager has its 1 pre-seeded
+    // "alice" + 1 config-loaded auto-generated test key (from
+    // initRuntime → loadAccountsFromConfig on a testnet config with no
+    // explicit accounts).
+    expect(r1.accountManager.getPoolSize()).toBe(2);
+    expect(r2.accountManager.getPoolSize()).toBe(2);
+  });
+
+  it("runtime.createAccount() adds to runtime.accountManager (per-instance, not the static singleton)", async () => {
+    const harness = await Harness.createLive("testnet");
+    try {
+      const before = harness.runtime.accountManager.getPoolSize();
+      const a = harness.runtime.createAccount();
+      const b = harness.runtime.createAccount();
+
+      expect(harness.runtime.accountManager.getPoolSize()).toBe(before + 2);
+      expect(a.accountAddress.toString()).not.toBe(
+        b.accountAddress.toString(),
+      );
+
+      // The new accounts are in THIS runtime's pool — getAllAccounts()
+      // returns them.
+      const all = harness.runtime.accountManager.getAllAccounts();
+      const addresses = all.map((acc) => acc.accountAddress.toString());
+      expect(addresses).toContain(a.accountAddress.toString());
+      expect(addresses).toContain(b.accountAddress.toString());
+
+      // harness.accounts is a SNAPSHOT — late additions do NOT appear.
+      // (Documented as Hardhat-style ergonomics in the Harness JSDoc.)
+      expect(Object.values(harness.accounts)).toHaveLength(0);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/packages/movehat/src/__tests__/runtime.test.ts
+++ b/packages/movehat/src/__tests__/runtime.test.ts
@@ -134,11 +134,15 @@ describe("initRuntime", () => {
 
   it("createAccount returns a fresh account each call (pool grows)", async () => {
     const runtime = await initRuntime();
-    const before = AccountManager.getPoolSize();
+    // Pool size is measured on the runtime's OWN AccountManager — not on
+    // the static facade's singleton. M9.2 made each runtime own its
+    // per-instance manager; `runtime.createAccount()` adds to that
+    // instance's pool, not the shared singleton.
+    const before = runtime.accountManager.getPoolSize();
     const a = runtime.createAccount();
     const b = runtime.createAccount();
     expect(a.accountAddress.toString()).not.toBe(b.accountAddress.toString());
-    expect(AccountManager.getPoolSize()).toBe(before + 2);
+    expect(runtime.accountManager.getPoolSize()).toBe(before + 2);
   });
 
   it("getAccount loads from a private key hex", async () => {

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -1,3 +1,4 @@
+import type { Account } from "@aptos-labs/ts-sdk";
 import type { MovehatRuntime } from "../types/runtime.js";
 import type { LocalNodeManager } from "../node/LocalNodeManager.js";
 import type { ForkServer } from "../fork/server.js";
@@ -36,14 +37,38 @@ interface HarnessInit {
  * a Proxy that synchronously throws {@link HarnessDisposedError} on any
  * post-`cleanup()` call to one of the deployment / script / view methods.
  *
- * AccountManager note: the underlying account pool is a process-wide
- * static (see `core/AccountManager.ts`). Two Harness instances in the
- * same process share account labels; this is the same constraint that
- * already governs `setupTestFixture`.
+ * Account isolation: each Harness owns a per-instance `AccountManager`
+ * (see `core/AccountManager.ts`) reachable at `harness.runtime.accountManager`.
+ * Two Harness instances in the same process have independent account
+ * pools and label maps — `Harness.createLocal({ accountLabels: ["alice"] })`
+ * twice produces two DIFFERENT alice accounts.
+ *
+ * Labeled accounts created during construction (via `accountLabels` in
+ * `createLocal`) are snapshotted onto `harness.accounts` at construction
+ * time. Late additions via `harness.runtime.accountManager.createAccount(...)`
+ * are NOT reflected in the `accounts` Record — that's a snapshot, not a
+ * live view. For live mode (`Harness.createLive`), `accounts` is `{}`
+ * because the live factory does not create labeled accounts; reach into
+ * `harness.runtime.accountManager.*` for advanced operations.
+ *
+ * The `AccountManager` class-static methods remain available in 0.2.x
+ * for backward compatibility (deprecation warning lands in 0.2.7,
+ * removal in 0.3.0 — see #270). New code should prefer
+ * `harness.accounts.<label>` for the common read path.
  */
 export class Harness {
   public readonly mode: HarnessMode;
   public readonly runtime: MovehatRuntime;
+
+  /**
+   * Labeled accounts snapshotted from `runtime.accountManager` at
+   * construction time. For `createLocal`, this is populated from the
+   * `accountLabels` option. For `createFork`, populated the same way.
+   * For `createLive`, empty (live mode does not create labeled accounts;
+   * use `harness.runtime.accountManager.loadAccountFromPrivateKey(...)`
+   * for direct key loading).
+   */
+  public readonly accounts: Record<string, Account>;
 
   /** @internal */
   public readonly localNode?: LocalNodeManager;
@@ -57,6 +82,7 @@ export class Harness {
   private constructor(init: HarnessInit) {
     this.mode = init.mode;
     this.runtime = init.runtime;
+    this.accounts = init.runtime.accountManager.getLabeledAccounts();
     if (init.localNode) this.localNode = init.localNode;
     if (init.forkServer) this.forkServer = init.forkServer;
     if (init.forkManager) this.forkManager = init.forkManager;

--- a/packages/movehat/src/helpers/__tests__/setupLocalTesting.fork-network.test.ts
+++ b/packages/movehat/src/helpers/__tests__/setupLocalTesting.fork-network.test.ts
@@ -73,22 +73,26 @@ vi.mock("../../runtime.js", () => ({
 
 vi.mock("../../core/AccountManager.js", () => {
   let _seq = 0;
-  return {
-    AccountManager: {
-      createBatch(labels: readonly string[]) {
-        const out: Record<string, { accountAddress: { toString(): string } }> = {};
-        for (const l of labels) {
-          _seq++;
-          const addr = "0x" + _seq.toString(16).padStart(64, "0");
-          out[l] = { accountAddress: { toString: () => addr } };
-        }
-        return out;
-      },
-      exportPrivateKeys(_labels: readonly string[]) {
-        return { deployer: "0x" + "1".repeat(64) };
-      },
-    },
-  };
+  // Mock the AccountManager AS A CLASS so `new AccountManager()` works
+  // (M9.2 introduced the instance API; setupLocalTesting now constructs
+  // a per-context instance and calls createBatch / exportPrivateKeys
+  // on it). The mocked instance only needs to satisfy the two methods
+  // setupLocalTesting actually invokes here.
+  class AccountManager {
+    createBatch(labels: readonly string[]) {
+      const out: Record<string, { accountAddress: { toString(): string } }> = {};
+      for (const l of labels) {
+        _seq++;
+        const addr = "0x" + _seq.toString(16).padStart(64, "0");
+        out[l] = { accountAddress: { toString: () => addr } };
+      }
+      return out;
+    }
+    exportPrivateKeys(_labels: readonly string[]) {
+      return { deployer: "0x" + "1".repeat(64) };
+    }
+  }
+  return { AccountManager };
 });
 
 // Imported after mocks so vi.hoisted ordering applies.

--- a/packages/movehat/src/helpers/setup.ts
+++ b/packages/movehat/src/helpers/setup.ts
@@ -31,8 +31,10 @@ export async function setupTestEnvironment(networkName?: string): Promise<TestEn
 
   const aptos = new Aptos(aptosConfig);
 
-  // Load account using AccountManager
-  const account = AccountManager.loadAccountFromPrivateKey(config.privateKey);
+  // Load account using a throwaway AccountManager instance. This helper
+  // returns Aptos+Account directly (no runtime exposure), so a local
+  // instance suffices — no shared pool needed.
+  const account = new AccountManager().loadAccountFromPrivateKey(config.privateKey);
 
   logger.success("Test environment ready");
   logger.plain(`   Account: ${account.accountAddress.toString()}`);
@@ -48,7 +50,8 @@ export async function setupTestEnvironment(networkName?: string): Promise<TestEn
 }
 
 export function createTestAccount(): Account {
-    return AccountManager.createAccount();
+    // Throwaway instance — see setupTestEnvironment for rationale.
+    return new AccountManager().createAccount();
 }
 
 

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -165,8 +165,13 @@ async function setupWithLocalNode(
   // leaks and port 8080 stays bound until the OS reaps it (manifests as
   // "Movement command failed" on the next test:example run).
   try {
+    // Per-context AccountManager. Threaded into initRuntime below so
+    // the runtime exposes the SAME instance — the labels created by
+    // createBatch here are visible on `runtime.accountManager`.
+    const accountManager = new AccountManager();
+
     logger.step(`Generating ${accountLabels.length} test accounts...`);
-    const accounts = AccountManager.createBatch(accountLabels);
+    const accounts = accountManager.createBatch(accountLabels);
 
     for (const [label, account] of Object.entries(accounts)) {
       logger.plain(`   ${label}: ${account.accountAddress.toString()}`);
@@ -180,7 +185,7 @@ async function setupWithLocalNode(
 
     logger.step("Initializing runtime for local network...");
 
-    const deployerPrivateKey = AccountManager.exportPrivateKeys(["deployer"]).deployer;
+    const deployerPrivateKey = accountManager.exportPrivateKeys(["deployer"]).deployer;
 
     if (!deployerPrivateKey) {
       throw new Error("Failed to get deployer private key");
@@ -188,6 +193,7 @@ async function setupWithLocalNode(
 
     const runtime = await initRuntime({
       network: "local",
+      accountManager,
       configOverride: {
         networks: {
           local: {
@@ -331,8 +337,11 @@ async function setupWithFork(
   try {
     await new Promise((resolve) => setTimeout(resolve, 500));
 
+    // Per-context AccountManager (mirror of setupWithLocalNode pattern).
+    const accountManager = new AccountManager();
+
     logger.step(`Generating ${accountLabels.length} test accounts...`);
-    const accounts = AccountManager.createBatch(accountLabels);
+    const accounts = accountManager.createBatch(accountLabels);
 
     for (const [label, account] of Object.entries(accounts)) {
       logger.plain(`   ${label}: ${account.accountAddress.toString()}`);
@@ -348,7 +357,7 @@ async function setupWithFork(
 
     logger.step("Initializing runtime for local network...");
 
-    const deployerPrivateKey = AccountManager.exportPrivateKeys(["deployer"]).deployer;
+    const deployerPrivateKey = accountManager.exportPrivateKeys(["deployer"]).deployer;
 
     if (!deployerPrivateKey) {
       throw new Error("Failed to get deployer private key");
@@ -356,6 +365,7 @@ async function setupWithFork(
 
     const runtime = await initRuntime({
       network: "local",
+      accountManager,
       configOverride: {
         networks: {
           local: {

--- a/packages/movehat/src/helpers/testFixtures.ts
+++ b/packages/movehat/src/helpers/testFixtures.ts
@@ -1,7 +1,6 @@
 import type { Account } from "@aptos-labs/ts-sdk";
 import type { MovehatRuntime } from "../types/runtime.js";
 import type { MoveContract } from "../core/contract.js";
-import { AccountManager } from "../core/AccountManager.js";
 import { setupLocalTesting } from "./setupLocalTesting.js";
 import { logger } from "../ui/index.js";
 import type { LocalTestOptions } from "../types/config.js";
@@ -29,10 +28,11 @@ export interface TestFixture<TModules extends string = string> {
   /**
    * Stop the local node / fork server this fixture started.
    *
-   * Does **not** clear the shared `AccountManager` pool — clearing it
-   * would break parallel `setupTestFixture` invocations that share the
-   * pool. The pool grows for the lifetime of the process; the process
-   * exit reclaims it.
+   * Each fixture owns its own `AccountManager` instance (via
+   * `setupLocalTesting` → `initRuntime`), so there is no shared pool
+   * to clear — accounts are garbage-collected when the fixture goes
+   * out of scope. Parallel `setupTestFixture` invocations have fully
+   * isolated label maps and pools (M9.2, #270).
    */
   teardown: () => Promise<void>;
 }
@@ -104,7 +104,7 @@ export async function setupTestFixture<TModules extends readonly string[]>(
   try {
     const mh = ctx.runtime;
 
-    const labeledAccounts = AccountManager.getLabeledAccounts();
+    const labeledAccounts = mh.accountManager.getLabeledAccounts();
 
     // any: TestFixture.accounts has a structural shape with required
     // `deployer/alice/bob` plus a `[key: string]: Account` index. The
@@ -119,7 +119,7 @@ export async function setupTestFixture<TModules extends readonly string[]>(
     };
 
     for (const label of accountLabels) {
-      accounts[label] = labeledAccounts[label] || AccountManager.getOrCreateLabeled(label);
+      accounts[label] = labeledAccounts[label] || mh.accountManager.getOrCreateLabeled(label);
     }
 
     const contracts = {} as Record<TModules[number], MoveContract>;
@@ -182,7 +182,7 @@ export async function setupMinimalFixture(
   try {
     const mh = ctx.runtime;
 
-    const labeledAccounts = AccountManager.getLabeledAccounts();
+    const labeledAccounts = mh.accountManager.getLabeledAccounts();
 
     // any: see setupTestFixture above — same dynamic-key builder pattern.
     const accounts: any = {
@@ -191,7 +191,7 @@ export async function setupMinimalFixture(
     };
 
     for (const label of accountLabels) {
-      accounts[label] = labeledAccounts[label] || AccountManager.getOrCreateLabeled(label);
+      accounts[label] = labeledAccounts[label] || mh.accountManager.getOrCreateLabeled(label);
     }
 
     logger.newline();

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -23,6 +23,18 @@ export interface InitRuntimeOptions {
   network?: string;
   accountIndex?: number;
   configOverride?: Partial<MovehatUserConfig>;
+  /**
+   * Optional pre-constructed `AccountManager` instance. When supplied,
+   * the returned runtime's `accountManager` field is THIS instance —
+   * so labeled accounts created BEFORE `initRuntime` are visible on
+   * the runtime. When omitted, `initRuntime` constructs a fresh
+   * `new AccountManager()` per call.
+   *
+   * `setupLocalTesting` uses this option to thread one manager through
+   * `createBatch` → `exportPrivateKeys` → `initRuntime` so the deployer
+   * key it extracts ends up on the same manager the runtime exposes.
+   */
+  accountManager?: AccountManager;
 }
 
 /**
@@ -62,9 +74,12 @@ export async function initRuntime(
   });
   const aptos = new Aptos(aptosConfig);
 
-  // Setup accounts using AccountManager
+  // Setup accounts using AccountManager. Use the caller-supplied
+  // instance when threaded in (preserves labels created before
+  // initRuntime); otherwise construct a fresh one.
+  const accountManager = options.accountManager ?? new AccountManager();
   const accountIndex = options.accountIndex || 0;
-  const accounts: Account[] = AccountManager.loadAccountsFromConfig(config);
+  const accounts: Account[] = accountManager.loadAccountsFromConfig(config);
 
   // Primary account (accounts[0] or selected index)
   const account = accounts[accountIndex];
@@ -115,11 +130,11 @@ export async function initRuntime(
   };
 
   const createAccount = (): Account => {
-    return AccountManager.createAccount();
+    return accountManager.createAccount();
   };
 
   const getAccountHelper = (privateKeyHex: string): Account => {
-    return AccountManager.loadAccountFromPrivateKey(privateKeyHex);
+    return accountManager.loadAccountFromPrivateKey(privateKeyHex);
   };
 
   const getAccountByIndex = (index: number): Account => {
@@ -141,6 +156,7 @@ export async function initRuntime(
     aptos,
     account,
     accounts,
+    accountManager,
     getContract: getContractHelper,
     deployContract,
     getDeployment,

--- a/packages/movehat/src/types/runtime.ts
+++ b/packages/movehat/src/types/runtime.ts
@@ -2,6 +2,7 @@ import { Aptos, Account } from "@aptos-labs/ts-sdk";
 import { MovehatConfig } from "./config.js";
 import { MoveContract } from "../core/contract.js";
 import { DeploymentInfo } from "../core/deployments.js";
+import type { AccountManager } from "../core/AccountManager.js";
 import type { ChildProcessAdapter } from "../utils/childProcessAdapter.js";
 
 export interface NetworkInfo {
@@ -25,6 +26,13 @@ export interface MovehatRuntime {
 
   // All accounts for this network
   accounts: Account[];
+
+  // Per-runtime AccountManager instance. Holds the account pool +
+  // label map scoped to this runtime — two `initRuntime()` calls
+  // produce independent managers. Use `harness.accounts.<label>` for
+  // the common read path; reach into this manager for advanced ops
+  // (createBatch, exportPrivateKeys, saveAccountPool, etc.).
+  accountManager: AccountManager;
 
   // Helper functions
   getContract: (address: string, moduleName: string) => MoveContract;


### PR DESCRIPTION
## Summary

Second sub-PR of **M9** ([meta #270](https://github.com/gilbertsahumada/movehat/issues/270)). Migrates every internal `AccountManager.X()` static call site (13 across 4 files) to the per-instance API shipped in [M9.1 (PR #278)](https://github.com/gilbertsahumada/movehat/pull/278). Adds the user-facing `Harness.accounts` Record accessor — the Hardhat-style ergonomic that M9.4 will canonicalize across docs.

## What this PR ships

| Layer | Change |
|---|---|
| `MovehatRuntime` interface | NEW `accountManager: AccountManager` field |
| `InitRuntimeOptions` | NEW `accountManager?: AccountManager` option — caller-supplied instance threads through; otherwise default-constructed |
| `Harness` class | NEW `accounts: Record<string, Account>` field, snapshotted at construction from `runtime.accountManager.getLabeledAccounts()` |
| `runtime.ts` | 3 static calls → instance; constructs/accepts manager; exposes on returned runtime |
| `helpers/setupLocalTesting.ts` | 4 static calls → instance; constructs per-context AccountManager, threads through `initRuntime` |
| `helpers/testFixtures.ts` | 4 static calls → `ctx.runtime.accountManager.*`; teardown docstring updated to reflect per-instance reality |
| `helpers/setup.ts` | 2 static calls → throwaway local instances (per the M9.2 plan — these legacy helpers don't expose runtime) |
| `harness/Harness.ts:39-42` docstring | Old "process-wide static" caveat rewritten to describe per-instance isolation + snapshot semantics |
| Test fixes | `runtime.test.ts:135` assertion updated; `setupLocalTesting.fork-network.test.ts` mock now exposes `AccountManager` AS A CLASS |
| NEW test file | `src/__tests__/harness/Harness.accounts.test.ts` (5 tests) — asserts the wiring + F8(a) fix at runtime layer |
| CHANGELOG | New `[Unreleased] ### Added` bullet per CLAUDE.md §11 |

## The hard goal — verified

```bash
grep -rnE "AccountManager\.[a-z]\w+\(" packages/movehat/src/ \
  --include="*.ts" | grep -v __tests__ | grep -v core/AccountManager.ts
```

Returns ONLY:
```
packages/movehat/src/templates/tests/Counter.test.ts:26
```

The template is intentionally kept on the static facade — it migrates in **M9.3** alongside the example, when the deprecation warnings are added and 0.2.7 ships.

## The user-facing F8(a) fix

```typescript
const h1 = await Harness.createLocal({ accountLabels: ["alice"] });
const h2 = await Harness.createLocal({ accountLabels: ["alice"] });
// Pre-M9.2: h1.accounts.alice === h2.accounts.alice (silent shadow)
// Post-M9.2: h1.accounts.alice !== h2.accounts.alice (proper isolation)
```

Tested at the runtime layer (cheap) in the new `Harness.accounts.test.ts` because `createLocal` spawns a real Movement node (integration tier). The wiring is identical across all 3 modes — runtime-layer proof is sufficient for unit coverage.

## Snapshot semantics (documented in Harness JSDoc)

`harness.accounts` is a snapshot at construction time. Late additions via `harness.runtime.accountManager.createAccount("late")` are NOT reflected in the snapshot — matches Hardhat ergonomics (`ethers.getSigners()` returns a fixed array). Advanced operations route through `harness.runtime.accountManager.*` for full mutability.

## Live mode caveat

`Harness.createLive` produces `harness.accounts === {}` because `createLive` does not create labeled accounts (it loads bare private keys from config). Documented in JSDoc + tested explicitly. Users on live mode reach into `harness.runtime.accountManager.loadAccountFromPrivateKey(...)` for direct key access.

## Coverage

| File | Before | After |
|---|---|---|
| `src/core/AccountManager.ts` | 97.4% / 100% / 83% | **97.4% / 100% / 83%** (unchanged from M9.1) |
| `src/runtime.ts` | 100% / 100% / 100% | **100% / 100% / 100%** (per-file gate ≥80% met) |
| `src/harness/Harness.ts` | 51.16% / 68.75% / 34.48% | **51.16%** (unchanged — Harness.ts not in per-file ratchet; createLocal/createFork live in integration tier) |

Total tests: **548 → 553** (+5 new harness-isolation tests).

## Verification

- [x] `pnpm test` — 553/553 pass
- [x] `pnpm test:coverage` — AccountManager.ts stays ≥97%; runtime.ts at 100%; global gates pass
- [x] `pnpm build:movehat` — green (pre-push hook)
- [x] `pnpm typecheck:example` — green (template still uses static facade — singleton preserves behavior)
- [x] Hard goal grep verified (only `templates/tests/Counter.test.ts` remains, as expected — M9.3 target)
- [x] F8 pinning tests in `global-state.test.ts` still pass (singleton facade still preserves legacy)
- [x] New isolation tests in `Harness.accounts.test.ts` pass (5/5)

## Tier reporting (per CLAUDE.md §6)

- **Tier 1** (auto): pre-push hook green
- **Tier 2** (`test:example`): partially verified via `typecheck:example`. Full `pnpm test:example` deferred to M9.3 PR (template + example will be migrated together; running this PR's example today exercises the static facade path which is already verified by AccountManager.test.ts + the F8 pinning tests at unit tier)
- **Tier 3** (`test:e2e`): N/A — no template/published-surface change at this stage. Will run before M9.3 ships 0.2.7

## Out of scope (deferred to remaining M9 sub-PRs)

- Deprecation `console.warn` on static API → **M9.3**
- Template (`src/templates/tests/Counter.test.ts`) migration to `harness.accounts.X` → **M9.3**
- Example (`examples/counter-example/tests/Counter.test.ts`) migration → **M9.3**
- 5 docs MDX files rewrite → **M9.4**
- Delete static facade + remove F8 pinning assertions → **M9.4 (0.3.0 BREAKING)**
- Migration guide (`docs/upgrading/0.3.0.mdx`) → **M9.4**

## §10 issue lifecycle

Closes #279 (M9.2 sub-issue)
Tracks #270 (M9 meta — closes when M9.4 lands)

## CodeRabbit

Skipped per develop-target policy. Will be re-reviewed in the develop→main batch.