### PR TITLE
refactor: tighten harness.accounts type + test switchNetwork accountManager threading

### DIFF
--- a/packages/movehat/src/__tests__/runtime.test.ts
+++ b/packages/movehat/src/__tests__/runtime.test.ts
@@ -164,6 +164,27 @@ describe("initRuntime", () => {
     expect(runtime.network.name).toBe("testnet");
   });
 
+  it("switchNetwork preserves a caller-supplied accountManager across the network switch", async () => {
+    // M9.2 wired `accountManager` through InitRuntimeOptions. The
+    // switchNetwork closure spreads `...options` into the recursive
+    // initRuntime call, so a caller-supplied manager survives the
+    // switch (labels created on it are still visible). Without this
+    // spread, the new runtime would default-construct a fresh manager
+    // and labels would silently disappear post-switch. This test pins
+    // the spread behavior — refactoring switchNetwork to drop it must
+    // fail here, not in a downstream user's test suite.
+    const mgr = new AccountManager();
+    mgr.createAccount("alice");
+
+    const runtime = await initRuntime({ accountManager: mgr });
+    expect(runtime.accountManager).toBe(mgr);
+    expect(runtime.accountManager.hasLabel("alice")).toBe(true);
+
+    const switched = await runtime.switchNetwork("custom");
+    expect(switched.accountManager).toBe(mgr);
+    expect(switched.accountManager.hasLabel("alice")).toBe(true);
+  });
+
   it("getDeployment / getDeployments / getDeploymentAddress return null/empty for an unused network", async () => {
     const runtime = await initRuntime();
     // Nothing deployed in the tmp cwd, so these all short-circuit.

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -67,8 +67,12 @@ export class Harness {
    * For `createLive`, empty (live mode does not create labeled accounts;
    * use `harness.runtime.accountManager.loadAccountFromPrivateKey(...)`
    * for direct key loading).
+   *
+   * Typed `Readonly` so the snapshot can't be mutated via
+   * `harness.accounts.alice = X`. Reach into
+   * `harness.runtime.accountManager.*` when you need mutable access.
    */
-  public readonly accounts: Record<string, Account>;
+  public readonly accounts: Readonly<Record<string, Account>>;
 
   /** @internal */
   public readonly localNode?: LocalNodeManager;


### PR DESCRIPTION
## Summary

Follow-up to [PR #280](https://github.com/gilbertsahumada/movehat/pull/280) (M9.2) addressing two real findings from the post-merge code review. Third finding was reclassified as stylistic and skipped.

## What this PR ships

### 1. `Harness.accounts` typed as `Readonly<Record<string, Account>>`

Before:
\`\`\`typescript
public readonly accounts: Record<string, Account>;  // mutable inner Record
\`\`\`

After:
\`\`\`typescript
public readonly accounts: Readonly<Record<string, Account>>;
\`\`\`

The \`readonly\` field modifier prevented \`harness.accounts = X\` but NOT \`harness.accounts.alice = X\`. Snapshot semantics documented in the JSDoc + M9.2 plan demand inner immutability too.

NOT adding \`Object.freeze\` — Hardhat doesn't freeze (their signers array is mutable too) and the cost-of-mutation is user-inflicted. Type-level enforcement is sufficient.

### 2. New test: `switchNetwork` preserves caller-supplied `accountManager`

\`runtime.ts:148-150\`:
\`\`\`typescript
const switchNetwork = async (networkName: string): Promise<MovehatRuntime> => {
  return initRuntime({ ...options, network: networkName });
};
\`\`\`

The \`...options\` spread carries \`accountManager\` through when supplied, so labels survive a network switch. Correct today, but untested — refactoring switchNetwork to drop the spread would silently lose labels. New test pins:

\`\`\`typescript
const mgr = new AccountManager();
mgr.createAccount("alice");
const runtime = await initRuntime({ accountManager: mgr });
const switched = await runtime.switchNetwork("custom");
expect(switched.accountManager).toBe(mgr);  // identity preserved
expect(switched.accountManager.hasLabel("alice")).toBe(true);  // labels survive
\`\`\`

## Out of scope (review finding reclassified)

The review's third finding (\`setup.ts\` throwaway-instance pattern) was flagged as stylistic. My own review verdict was *"Defer to M9.4 cleanup. Not worth changing now."* Cost is trivial (<1KB allocation). Closing as no-action; M9.4 will rewrite this area anyway.

## CHANGELOG skip (per CLAUDE.md §11)

No \`[Unreleased]\` entry for this PR — zero user-visible behavior change. Type tightening + internal-test addition only. The §11 *"MAY skip"* clause applies:

> Sub-PRs that are pure refactors, internal-test-only, or have zero user-visible effect MAY skip the entry. Document the skip in the PR body so the release PR knows not to look for one.

The merged PR + this commit are the durable record. The original M9.2 entry already covers \`harness.accounts\` as user-visible API.

## Verification

- [x] \`pnpm test\` — 553 → 554 (+1 switchNetwork test)
- [x] \`pnpm build:movehat\` — green
- [x] \`pnpm typecheck:example\` — green (Readonly<> typecheck passes downstream)
- [x] No new \`AccountManager.X()\` static-API regressions

## Tier reporting (per CLAUDE.md §6)

- **Tier 1**: pre-push hook green
- **Tier 2**: N/A — type tightening + test only, no runtime code change
- **Tier 3**: N/A — no published-surface change

## §10 issue lifecycle

Closes #281

## CodeRabbit

Skipped per develop-target policy.