### PR TITLE
refactor: 3 console.warn → logger.warning + CHANGELOG type fix (CR followup to #285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ convention was adopted (see CLAUDE.md §11).
   0.3.0 (#270). Closes #277.
 - Per-Harness account isolation. Each `Harness` now owns its own
   `AccountManager` instance reachable at `harness.runtime.accountManager`.
-  New `Harness.accounts: Record<string, Account>` field exposes labeled
+  New `Harness.accounts: Readonly<Record<string, Account>>` field exposes labeled
   accounts created at construction time (`accountLabels` in
   `createLocal` / `createFork` options) as a snapshot — late additions
   via `harness.runtime.accountManager.createAccount(...)` are not

--- a/packages/movehat/src/core/AccountManager.ts
+++ b/packages/movehat/src/core/AccountManager.ts
@@ -193,7 +193,7 @@ export class AccountManager {
         accounts.push(account);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        console.warn(`Warning: Failed to load account from config: ${msg}`);
+        logger.warning(`Failed to load account from config: ${msg}`);
       }
     }
     return accounts;
@@ -263,7 +263,7 @@ export class AccountManager {
 
       const privateKey = this.privateKeys.get(address);
       if (!privateKey) {
-        console.warn(`Warning: No private key found for account ${address}, skipping`);
+        logger.warning(`No private key found for account ${address}, skipping`);
         continue;
       }
 
@@ -330,7 +330,7 @@ export class AccountManager {
       return true;
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      console.warn(`Warning: Failed to load account pool: ${msg}`);
+      logger.warning(`Failed to load account pool: ${msg}`);
       return false;
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to CodeRabbit findings on batch PR #285. Two real CR findings, both quick wins per CLAUDE.md §8 defer threshold (≤5 LoC + non-zero cost-of-being-wrong → fix in originating cycle).

## What this PR ships

### Finding 1 — §9 console UX violation (🟠 Major)

3 raw `console.warn` calls in `packages/movehat/src/core/AccountManager.ts:196, 266, 333` violate §9:

> No raw console.log / console.error / console.warn in packages/movehat/src/ outside src/ui/. Every system message must route through logger.* methods.

These predate M9 (carried through M9.1 unchanged), but the §9 sweep in [#223](https://github.com/gilbertsahumada/movehat/issues/223) didn't reach them. CR caught them when the batch PR exposed the full AccountManager.ts diff.

Replaced with `logger.warning(...)` and dropped the redundant `Warning:` prefix (logger.warning renders ⚠ already).

### Finding 2 — CHANGELOG type drift (🟡 Minor)

`CHANGELOG.md:38` documented the M9.2 `Harness.accounts` field as `Record<string, Account>` (mutable). PR #282 (M9.2 polish) tightened the actual type to `Readonly<Record<string, Account>>` but didn't update the CHANGELOG bullet. Fixed.

## Verification

- [x] 560/560 unit tests pass
- [x] `pnpm typecheck:example` green
- [x] §9 grep returns 0:
  ```bash
  grep -rnE "console\.(log|warn|error)" packages/movehat/src/ --include="*.ts" \
    | grep -v __tests__ | grep -v "src/ui/" | grep -v "src/templates/"
  # 0 lines
  ```
- [x] CHANGELOG line 38 now matches actual `Harness.accounts` type

## Tier reporting

- **Tier 1**: pre-push hook green
- **Tier 2**: N/A — pure refactor, no public surface change beyond logger consistency
- **Tier 3**: N/A — no template/published change

## CHANGELOG skip (per §11)

No new `[Unreleased]` entry. The §11 *"MAY skip"* clause applies — pure refactor + doc typo correction. Both fixes are documented in this PR + the linked CR thread.

## §10 issue lifecycle

Closes #286

## Why a sub-PR vs direct commit to develop

Per §5 + §10 — every PR ships with a sub-issue and structured review. Pushing directly to develop would skip §10 lineage. The ceremony is small (7 LoC + 1 issue) but maintains the convention.

## After this merges

- Batch PR #285 auto-refreshes with this commit included
- CR threads on #285 can be resolved (will reference this PR)
- Batch ready for §8 self-review + merge to main → release/0.2.7 cycle continues