### PR TITLE
chore(release): 0.2.7 — M9 progress (instance API + harness.accounts + deprecation warnings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Post-0.2.6 polish batch — 6 audit-pass / cleanup items closed without
-public API change. All additive or docs-only; shipped to `main` in
-PR #274 on 2026-05-21. Backfilled 2026-05-22 when the per-PR CHANGELOG
-convention was adopted (see CLAUDE.md §11).
+## [0.2.7] - 2026-05-22
+
+M9 milestone progress (issue #270) — per-Harness `AccountManager`
+isolation foundation with backward-compatible deprecation warnings on
+the static facade. New projects on 0.2.7 get the forward-compatible
+`harness.accounts.<label>` pattern; existing projects keep working
+unchanged but see a one-time `logger.warning` per static method called.
+Closes audit finding F8(a) for instance-API users. Static API removal
+ships in 0.3.0 (M9.4) after a ≥1 month deprecation window per
+MAINTENANCE.md §6.
+
+Also lands the per-PR CHANGELOG convention (CLAUDE.md §11) and
+backfills the post-0.2.6 polish entries (PR #274 closures).
 
 ### Added
 

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {


### PR DESCRIPTION
Bumps movehat from 0.2.6 → 0.2.7 + CHANGELOG entry.

## Contents

5 substantive sub-PRs landed via the batch PR #285 + 2 CHANGELOG infrastructure PRs:

| Sub-PR | Title | Issues closed |
|---|---|---|
| #275 | docs(changelog): backfill [Unreleased] with post-0.2.6 closures | — |
| #276 | docs: adopt per-PR CHANGELOG convention (CLAUDE.md §11) | — |
| #278 | refactor(AccountManager): add instance API + singleton facade (M9.1) | #277 |
| #280 | refactor: migrate internal callers + add harness.accounts (M9.2) | #279 |
| #282 | refactor: tighten harness.accounts + switchNetwork test | #281 |
| #284 | refactor: deprecation warnings + template/example/docs migration (M9.3) | #283 |
| #287 | CR followup: console.warn → logger.warning + CHANGELOG type fix | #286 |

Total: 22 files / +927 / -266. 539 → 560 unit tests (+21).

## Public API delta

### New (additive)

- `new AccountManager(options?: AccountManagerOptions)` — per-instance pool
- `AccountManagerOptions { poolPath? }` — explicit pool path; lazy `process.cwd()` eval
- `MovehatRuntime.accountManager: AccountManager`
- `InitRuntimeOptions.accountManager?: AccountManager` — thread pre-constructed manager
- `Harness.accounts: Readonly<Record<string, Account>>` — snapshot at construction
- `_resetDeprecationWarnings()` — `@internal` test escape hatch

### Deprecated (still works, emits warning on first call per method)

- All 17 `AccountManager` class-static methods. `logger.warning` once per method per process. Points users at `harness.accounts.<label>` or `harness.runtime.accountManager.<method>`. Removal in 0.3.0 (M9.4).

### Breaking

None. M9.4 / 0.3.0 removes the static facade after the ≥1 month deprecation window per MAINTENANCE.md §6.

## Verification

- [x] 560 unit tests pass
- [x] Tier 1 (build:movehat + typecheck:example) green
- [x] Tier 2 (test:example) green — 9 mocha tests with new `harness.accounts.X` pattern (~1m)
- [x] Tier 3 (test:e2e) green via GHA workflow on batch PR #285
- [x] Hard goal: zero static `AccountManager.X()` calls in non-test src/ + examples + docs (except one descriptive JSDoc prose ref)
- [x] §9 compliance: zero raw `console.*` in `packages/movehat/src/` outside `src/ui/`
- [x] Coverage on `AccountManager.ts`: 97.4% lines / 100% functions / 83% branches

## On merge

GitHub Release `v0.2.7` triggers `publish.yml` → npm publish with SLSA v1 provenance via OIDC Trusted Publishers. Mirrors the 0.2.6 release flow ([PR #267](https://github.com/gilbertsahumada/movehat/pull/267)).

## Tier reporting (per CLAUDE.md §6 — release-PR mandatory)

- **Tier 1** (auto): pre-push hook green
- **Tier 2** (`test:example`): green on the parent batch PR #285
- **Tier 3** (`test:e2e`): green on the parent batch PR #285 — verified install-from-tarball flow works with the migrated template

## ROADMAP impact

M9 milestone progress (#270) — 3/4 sub-PRs shipped. M9.4 (BREAKING removal + migration guide + 0.3.0 release) is the next milestone item after the ≥1 month deprecation window.

## CodeRabbit

Will review on this PR (main-target). Findings triaged per repo policy before merge.