### PR TITLE
develop → main: shared local node across test specs (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Shared local-node support via mocha root hooks. New `localNode`
+  option on `LocalTestOptions` lets `Harness.createLocal()` and
+  `setupTestFixture()` reuse a pre-started `LocalNodeManager`
+  instead of spawning a new one per test file. `movehat init` now
+  scaffolds a `tests/setup.ts` root hooks file that starts one
+  Movement node for the entire test suite and stops it at the end.
+  `Harness.cleanup()` is ownership-aware: when the node was injected
+  via `localNode`, cleanup poisons the harness but does not stop the
+  shared node. Reduces test-suite wall-clock time by ~50% for
+  multi-file projects (e.g. 3 specs: ~65s -> ~30s). Closes #235.
+
 ### Changed
 
 - M9.4 (PR #290 — AccountManager static-facade removal) reverted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Runtime validation at every fork API and storage boundary. All
+  Movement REST API responses (`getLedgerInfo`, `getAccount`,
+  `getAccountResource`, `getAccountResources`) and on-disk JSON reads
+  (`loadMetadata`, `getAccount`, `listAccounts`) are now validated
+  against their expected shapes before use. Malformed upstream
+  responses throw descriptive errors instead of silently propagating
+  corrupt data. New `CoinStore` interface formalizes the coin-store
+  resource shape; the last `any` in `src/fork/` is eliminated. New
+  `src/fork/validation.ts` with 8 assertion functions. Closes #111.
+
 ### Added
 
 - Shared local-node support via mocha root hooks. New `localNode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- Document that `movehat compile` auto-updates `Move.toml` with
+  detected named addresses. New "Move.toml Auto-Update" section in
+  `/docs/cli/compile`. CLI `--help` description updated to mention
+  the behavior. Closes #212.
+
 ### Added
 
 - Shared local-node support via mocha root hooks. New `localNode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Movement node for the entire test suite and stops it at the end.
   `Harness.cleanup()` is ownership-aware: when the node was injected
   via `localNode`, cleanup poisons the harness but does not stop the
-  shared node. Reduces test-suite wall-clock time by ~50% for
-  multi-file projects (e.g. 3 specs: ~65s -> ~30s). Closes #235.
+  shared node. Reduces test-suite wall-clock time by ~23% for 3
+  specs (~65s -> ~50s), scaling to ~50%+ at 10+ specs. Closes #235.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- Complete §9 console UX migration: 14 raw `console.log/error` calls
+  in `commands/test-move.ts`, `helpers/move-tests.ts`,
+  `commands/fork/serve.ts`, and `helpers/version-check.ts` migrated
+  to `logger.*` methods. All remaining `console.*` calls in `src/`
+  are documented §9 exceptions (CLI table output, JSON passthrough,
+  subprocess verbosity gate, banner rendering). Closes #223.
+
 ### Added
 
 - Shared local-node support via mocha root hooks. New `localNode`

--- a/examples/counter-example/.mocharc.json
+++ b/examples/counter-example/.mocharc.json
@@ -2,6 +2,7 @@
   "node-option": ["import=tsx"],
   "extensions": ["ts"],
   "spec": ["tests/**/*.test.ts"],
+  "require": ["tests/setup.ts"],
   "timeout": 60000,
   "color": true,
   "reporter": "spec"

--- a/examples/counter-example/scripts/demo-fork.ts
+++ b/examples/counter-example/scripts/demo-fork.ts
@@ -51,14 +51,14 @@ async function main() {
   console.log(`   Resource: Counter\n`);
 
   try {
-    const counterState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE);
-    
+    const counterState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE) as Record<string, unknown>;
+
     console.log("✅ Counter state retrieved!");
     console.log(`   Value: ${counterState.value}\n`);
     console.log("   Raw resource data:");
     console.log(`   ${JSON.stringify(counterState, null, 2)}\n`);
-  } catch (error: any) {
-    console.log(`❌ Could not read Counter: ${error.message}\n`);
+  } catch (error: unknown) {
+    console.log(`❌ Could not read Counter: ${(error as Error).message}\n`);
   }
 
   // Step 3: Try to read a non-existent counter (for a random account)
@@ -71,7 +71,7 @@ async function main() {
   try {
     await fork.getResource(randomAccount, COUNTER_RESOURCE);
     console.log("   ✅ Counter exists (unexpected!)\n");
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.log("   ❌ Counter not found (expected - account hasn't initialized one)\n");
   }
 
@@ -81,16 +81,16 @@ async function main() {
   console.log("   This changes the local fork WITHOUT affecting testnet!\n");
 
   // Read current state
-  const currentState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE);
+  const currentState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE) as Record<string, unknown>;
   const originalValue = currentState.value;
-  
+
   // Modify locally
   currentState.value = "999";
   await fork.setResource(COUNTER_ADDRESS, COUNTER_RESOURCE, currentState);
-  
+
   // Read back
-  const modifiedState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE);
-  
+  const modifiedState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE) as Record<string, unknown>;
+
   console.log(`   Original value: ${originalValue}`);
   console.log(`   Modified value: ${modifiedState.value}`);
   console.log("\n   💡 The real testnet contract still has value = " + originalValue);

--- a/examples/counter-example/tests/Counter.test.ts
+++ b/examples/counter-example/tests/Counter.test.ts
@@ -2,6 +2,7 @@ import { Harness } from "movehat";
 import type { MoveContract } from "movehat/helpers";
 import type { Account } from "@aptos-labs/ts-sdk";
 import { expect } from "chai";
+import { getSharedNode } from "./setup.js";
 
 /**
  * Uses the Harness API: Harness.createLocal with autoDeploy. Sibling
@@ -18,9 +19,10 @@ describe("Counter Contract", () => {
   let deployer: Account, alice: Account;
 
   before(async function () {
-    this.timeout(60000); // Allow time for local node startup + autoDeploy
+    this.timeout(60000);
 
     harness = await Harness.createLocal({
+      localNode: getSharedNode(),
       accountLabels: ["deployer", "alice", "bob"],
       autoDeploy: ["counter"],
     });

--- a/examples/counter-example/tests/greeting.test.ts
+++ b/examples/counter-example/tests/greeting.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, before, after } from "mocha";
 import { expect } from "chai";
 import { setupTestFixture, type TestFixture } from "movehat/helpers";
+import { getSharedNode } from "./setup.js";
 
 describe("Greeting Contract", () => {
   let fixture: TestFixture<'greeting'>;
 
   before(async function () {
-    this.timeout(90000); // Allow time for local node startup + deployment
+    this.timeout(60000);
 
-    // Setup local testing environment with auto-deployment
-    fixture = await setupTestFixture(['greeting'] as const, ['alice', 'bob']);
+    fixture = await setupTestFixture(['greeting'] as const, ['alice', 'bob'], {
+      localNode: getSharedNode(),
+    });
 
     console.log(`\n✅ Testing Greeting Contract on local blockchain`);
     console.log(`   Deployer: ${fixture.accounts.deployer.accountAddress.toString()}`);

--- a/examples/counter-example/tests/message.test.ts
+++ b/examples/counter-example/tests/message.test.ts
@@ -1,18 +1,17 @@
 import { describe, it, before } from "mocha";
 import { expect } from "chai";
 import { setupTestFixture, type TestFixture } from "movehat/helpers";
+import { getSharedNode } from "./setup.js";
 
 describe("Message Contract", () => {
   let fixture: TestFixture<'message'>;
 
   before(async function () {
-    this.timeout(60000); // Local node startup + auto-deploy
+    this.timeout(60000);
 
-    // Auto-deploy the `message` module (declared in
-    // move/sources/hello_blockchain.move as `module hello_blockchain::message`)
-    // against a fresh local node. Same pattern as Counter.test.ts and
-    // greeting.test.ts — no testnet, no PRIVATE_KEY required.
-    fixture = await setupTestFixture(['message'] as const, []);
+    fixture = await setupTestFixture(['message'] as const, [], {
+      localNode: getSharedNode(),
+    });
   });
 
   describe("get_message", () => {

--- a/examples/counter-example/tests/setup.ts
+++ b/examples/counter-example/tests/setup.ts
@@ -1,0 +1,33 @@
+import { LocalNodeManager } from "movehat/helpers";
+
+let sharedNode: LocalNodeManager | undefined;
+
+/**
+ * Returns the shared local Movement node started by root hooks.
+ * Pass the result as `{ localNode: getSharedNode() }` to
+ * Harness.createLocal() or setupTestFixture().
+ */
+export function getSharedNode(): LocalNodeManager {
+  if (!sharedNode || !sharedNode.isRunning()) {
+    throw new Error(
+      "Shared node not available. " +
+        'Ensure tests/setup.ts is listed in .mocharc.json under "require".'
+    );
+  }
+  return sharedNode;
+}
+
+export const mochaHooks = {
+  async beforeAll(this: Mocha.Context) {
+    this.timeout(60000);
+    sharedNode = new LocalNodeManager({ forceRestart: true });
+    await sharedNode.start();
+  },
+
+  async afterAll() {
+    if (sharedNode) {
+      await sharedNode.stop();
+      sharedNode = undefined;
+    }
+  },
+};

--- a/packages/docs/content/docs/cli/compile.mdx
+++ b/packages/docs/content/docs/cli/compile.mdx
@@ -29,7 +29,15 @@ module counter::counter {
 }
 ```
 
-Movehat detects `counter` as a named address. No manual configuration needed — just like Hardhat.
+Movehat detects `counter` as a named address. No manual configuration needed -- just like Hardhat.
+
+## Move.toml Auto-Update
+
+Movehat automatically updates your `Move.toml` when it detects named addresses that are missing from the `[addresses]` or `[dev-addresses]` sections. This ensures the Movement CLI can resolve every named address at compile time.
+
+For example, if your Move source declares `module counter::counter` but `Move.toml` has no `[addresses]` entry for `counter`, Movehat adds it with a placeholder dev address (`0xcafe`) before invoking the compiler. The mutation is idempotent -- running `movehat compile` multiple times produces the same result.
+
+This is intentional Hardhat-style UX: the framework manages build configuration so you can focus on writing Move code.
 
 ## Prerequisites
 

--- a/packages/movehat/src/__tests__/fork/api.test.ts
+++ b/packages/movehat/src/__tests__/fork/api.test.ts
@@ -87,8 +87,11 @@ function setupGetCapture(): {
       const body = JSON.stringify({
         chain_id: 250,
         ledger_version: "1",
+        oldest_ledger_version: "0",
         ledger_timestamp: "0",
+        node_role: "full_node",
         epoch: "0",
+        oldest_block_height: "0",
         block_height: "0",
       });
       callback(makeFakeResponse(body));

--- a/packages/movehat/src/cli.ts
+++ b/packages/movehat/src/cli.ts
@@ -74,7 +74,7 @@ program
 
 program
     .command('compile')
-    .description('Compile Move smart contracts using Movement CLI')
+    .description('Compile Move smart contracts (auto-detects named addresses and updates Move.toml)')
     .action(compileCommand);
 
 program

--- a/packages/movehat/src/commands/fork/fund.ts
+++ b/packages/movehat/src/commands/fork/fund.ts
@@ -49,10 +49,12 @@ export default async function forkFundCommand(options: ForkFundOptions) {
     // Verify
     const resourceType = `0x1::coin::CoinStore<${coinType}>`;
     const coinStore = await forkManager.getResource(options.account, resourceType);
+    const { assertCoinStore } = await import('../../fork/validation.js');
+    const validated = assertCoinStore(coinStore);
 
     logger.newline();
     logger.success("Account funded successfully!");
-    logger.plain(`   New balance: ${coinStore.coin.value}`);
+    logger.plain(`   New balance: ${validated.coin.value}`);
     logger.newline();
 
   } catch (error) {

--- a/packages/movehat/src/commands/fork/serve.ts
+++ b/packages/movehat/src/commands/fork/serve.ts
@@ -2,6 +2,7 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { loadUserConfig } from '../../core/config.js';
 import { ForkServer } from '../../fork/server.js';
+import { logger } from '../../ui/index.js';
 
 interface ForkServeOptions {
   fork?: string;
@@ -36,9 +37,11 @@ export default async function forkServeCommand(options: ForkServeOptions): Promi
 
     // Verify fork exists
     if (!existsSync(join(forkPath, 'metadata.json'))) {
-      console.error(`\nError: Fork not found at ${forkPath}`);
-      console.error(`\nCreate a fork first with:`);
-      console.error(`  movehat fork create --network <network> --name <name>`);
+      logger.newline();
+      logger.error(`Fork not found at ${forkPath}`);
+      logger.newline();
+      logger.error("Create a fork first with:");
+      logger.error("  movehat fork create --network <network> --name <name>");
       process.exit(1);
     }
 
@@ -51,7 +54,8 @@ export default async function forkServeCommand(options: ForkServeOptions): Promi
 
     // Handle graceful shutdown (use 'once' to prevent duplicate shutdowns)
     const shutdown = async () => {
-      console.log('\n\nShutting down...');
+      logger.newline();
+      logger.step("Shutting down...");
       await server.stop();
       process.exit(0);
     };
@@ -74,7 +78,8 @@ export default async function forkServeCommand(options: ForkServeOptions): Promi
 
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    console.error(`\nError starting fork server:`, msg);
+    logger.newline();
+    logger.error(`Error starting fork server: ${msg}`);
     process.exit(1);
   }
 }

--- a/packages/movehat/src/commands/test-move.ts
+++ b/packages/movehat/src/commands/test-move.ts
@@ -1,4 +1,5 @@
 import { runMoveTests } from "../helpers/move-tests.js";
+import { logger } from "../ui/index.js";
 
 interface TestMoveOptions {
   filter?: string;
@@ -7,7 +8,8 @@ interface TestMoveOptions {
 
 export default async function testMoveCommand(options: TestMoveOptions = {}) {
   try {
-    console.log("Running Move unit tests...\n");
+    logger.step("Running Move unit tests...");
+    logger.newline();
 
     await runMoveTests({
       filter: options.filter,
@@ -17,10 +19,11 @@ export default async function testMoveCommand(options: TestMoveOptions = {}) {
 
     process.exit(0);
   } catch (err) {
-    console.error("\n✗ Move tests failed");
+    logger.newline();
+    logger.error("Move tests failed");
     const msg = err instanceof Error ? err.message : String(err);
     if (msg) {
-      console.error(`   ${msg}`);
+      logger.error(`   ${msg}`);
     }
     process.exit(1);
   }

--- a/packages/movehat/src/fork/__tests__/storage.test.ts
+++ b/packages/movehat/src/fork/__tests__/storage.test.ts
@@ -152,9 +152,9 @@ describe('ForkStorage', () => {
     it('should list all accounts', () => {
       vol.fromJSON({
         [`${forkPath}/accounts.json`]: JSON.stringify({
-          '0x1': { sequenceNumber: '0' },
-          '0x2': { sequenceNumber: '5' },
-          '0x3': { sequenceNumber: '10' },
+          '0x1': { sequenceNumber: '0', authenticationKey: '0xaa' },
+          '0x2': { sequenceNumber: '5', authenticationKey: '0xbb' },
+          '0x3': { sequenceNumber: '10', authenticationKey: '0xcc' },
         }),
       });
 
@@ -170,7 +170,7 @@ describe('ForkStorage', () => {
     it('should clear all accounts', () => {
       vol.fromJSON({
         [`${forkPath}/accounts.json`]: JSON.stringify({
-          '0x1': { sequenceNumber: '0' },
+          '0x1': { sequenceNumber: '0', authenticationKey: '0xaa' },
         }),
       });
 

--- a/packages/movehat/src/fork/api.ts
+++ b/packages/movehat/src/fork/api.ts
@@ -3,6 +3,12 @@ import http from 'http';
 import { URL } from 'url';
 import type { LedgerInfo, AccountData, AccountResource } from '../types/fork.js';
 import { normalizeAddressShort } from '../utils/address.js';
+import {
+  assertLedgerInfo,
+  assertAccountData,
+  assertAccountResource,
+  assertAccountResourceArray,
+} from './validation.js';
 
 export interface MovementApiClientOptions {
   /** Abort the request after this many ms (default: 30_000). */
@@ -263,7 +269,8 @@ export class MovementApiClient {
    * Get ledger information
    */
   async getLedgerInfo(): Promise<LedgerInfo> {
-    return this.get<LedgerInfo>(this.apiPath('/'));
+    const raw = await this.get<unknown>(this.apiPath('/'));
+    return assertLedgerInfo(raw);
   }
 
   /**
@@ -272,19 +279,21 @@ export class MovementApiClient {
   async getAccount(address: string): Promise<AccountData> {
     const normalizedAddress = normalizeAddressShort(address);
 
-    return this.get<AccountData>(this.apiPath(`/accounts/${normalizedAddress}`));
+    const raw = await this.get<unknown>(this.apiPath(`/accounts/${normalizedAddress}`));
+    return assertAccountData(raw);
   }
 
   /**
    * Get a specific account resource
    */
-  async getAccountResource(address: string, resourceType: string): Promise<any> {
+  async getAccountResource(address: string, resourceType: string): Promise<AccountResource> {
     const normalizedAddress = normalizeAddressShort(address);
 
     // URL encode the resource type
     const encodedType = encodeURIComponent(resourceType);
 
-    return this.get<any>(this.apiPath(`/accounts/${normalizedAddress}/resource/${encodedType}`));
+    const raw = await this.get<unknown>(this.apiPath(`/accounts/${normalizedAddress}/resource/${encodedType}`));
+    return assertAccountResource(raw);
   }
 
   /**
@@ -293,7 +302,8 @@ export class MovementApiClient {
   async getAccountResources(address: string): Promise<AccountResource[]> {
     const normalizedAddress = normalizeAddressShort(address);
 
-    return this.get<AccountResource[]>(this.apiPath(`/accounts/${normalizedAddress}/resources`));
+    const raw = await this.get<unknown>(this.apiPath(`/accounts/${normalizedAddress}/resources`));
+    return assertAccountResourceArray(raw);
   }
 
   /**

--- a/packages/movehat/src/fork/manager.ts
+++ b/packages/movehat/src/fork/manager.ts
@@ -1,9 +1,10 @@
 import { createHash } from 'node:crypto';
 import { MovementApiClient } from './api.js';
 import { ForkStorage } from './storage.js';
-import type { ForkMetadata, AccountState } from '../types/fork.js';
+import type { ForkMetadata, AccountState, CoinStore } from '../types/fork.js';
 import { normalizeAddress } from '../utils/address.js';
 import { logger } from '../ui/index.js';
+import { assertCoinStore } from './validation.js';
 
 /**
  * Derive a deterministic 32-byte hex placeholder for the `authentication_key`
@@ -138,7 +139,7 @@ export class ForkManager {
     return accountState;
   }
 
-  async getResource(address: string, resourceType: string): Promise<any> {
+  async getResource(address: string, resourceType: string): Promise<unknown> {
     const normalizedAddress = normalizeAddress(address);
 
     let resource = this.storage.getResource(normalizedAddress, resourceType);
@@ -168,7 +169,7 @@ export class ForkManager {
     return resource;
   }
 
-  async getAllResources(address: string): Promise<Record<string, any>> {
+  async getAllResources(address: string): Promise<Record<string, unknown>> {
     const normalizedAddress = normalizeAddress(address);
 
     let resources = this.storage.getAllResources(normalizedAddress);
@@ -227,16 +228,11 @@ export class ForkManager {
     const normalizedAddress = normalizeAddress(address);
     const resourceType = `0x1::coin::CoinStore<${coinType}>`;
 
-    // Try to get existing coin store. The coin store is a CoinStore<T>
-    // resource whose `data` is Movement-side untyped JSON; we shape it
-    // locally as a structural object with `coin.value: string`.
-    // any: full CoinStore schema lives at the Movement REST boundary —
-    // proper validation deferred to the boundary-validation follow-up of #57.
-    let coinStore: any;
+    let coinStore: CoinStore;
     try {
-      coinStore = await this.getResource(normalizedAddress, resourceType);
+      const raw = await this.getResource(normalizedAddress, resourceType);
+      coinStore = assertCoinStore(raw);
     } catch (error) {
-      // Only catch "not found" errors, rethrow others (network, API, etc.)
       const msg = error instanceof Error ? error.message : String(error);
       if (!msg.includes('not found')) {
         throw error;
@@ -266,7 +262,7 @@ export class ForkManager {
       };
     }
 
-    const currentBalance = BigInt(coinStore.coin.value ?? '0');
+    const currentBalance = BigInt(coinStore.coin.value);
     const newBalance = currentBalance + BigInt(amount);
     coinStore.coin.value = newBalance.toString();
 

--- a/packages/movehat/src/fork/storage.ts
+++ b/packages/movehat/src/fork/storage.ts
@@ -2,6 +2,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync, readdirS
 import { join } from 'path';
 import type { ForkMetadata, AccountState } from '../types/fork.js';
 import { isHexAddress } from '../utils/address.js';
+import { assertForkMetadata, assertAccountStateRecord } from './validation.js';
 
 /**
  * Sanitize address to create a safe filename. Validates the address through
@@ -128,7 +129,7 @@ export class ForkStorage {
       throw new Error(`Fork metadata not found at ${metadataPath}`);
     }
 
-    return readJsonFile<ForkMetadata>(metadataPath, 'fork metadata');
+    return assertForkMetadata(readJsonFile<unknown>(metadataPath, 'fork metadata'));
   }
 
   /**
@@ -141,7 +142,7 @@ export class ForkStorage {
       return null;
     }
 
-    const accounts = readJsonFile<Record<string, AccountState>>(accountsPath, 'fork accounts');
+    const accounts = assertAccountStateRecord(readJsonFile<unknown>(accountsPath, 'fork accounts'));
     return accounts[address] || null;
   }
 
@@ -153,7 +154,7 @@ export class ForkStorage {
 
     let accounts: Record<string, AccountState> = {};
     if (existsSync(accountsPath)) {
-      accounts = readJsonFile<Record<string, AccountState>>(accountsPath, 'fork accounts');
+      accounts = assertAccountStateRecord(readJsonFile<unknown>(accountsPath, 'fork accounts'));
     }
 
     accounts[address] = state;
@@ -236,7 +237,7 @@ export class ForkStorage {
       return [];
     }
 
-    const accounts = readJsonFile<Record<string, AccountState>>(accountsPath, 'fork accounts');
+    const accounts = assertAccountStateRecord(readJsonFile<unknown>(accountsPath, 'fork accounts'));
     return Object.keys(accounts);
   }
 

--- a/packages/movehat/src/fork/test.ts
+++ b/packages/movehat/src/fork/test.ts
@@ -136,7 +136,7 @@ export async function viewForkResource(
   account: string,
   resourceType: string,
   options: { adapter?: ChildProcessAdapter } = {}
-): Promise<any> {
+): Promise<unknown> {
   try {
     // runCli uses spawn-with-args (no shell) to prevent command injection.
     const { stdout, stderr, exitCode } = await runCli(

--- a/packages/movehat/src/fork/validation.ts
+++ b/packages/movehat/src/fork/validation.ts
@@ -1,0 +1,132 @@
+import type {
+  LedgerInfo,
+  AccountData,
+  AccountResource,
+  ForkMetadata,
+  AccountState,
+  CoinStore,
+} from "../types/fork.js";
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function hasString(o: Record<string, unknown>, key: string): boolean {
+  return typeof o[key] === "string";
+}
+
+export function assertLedgerInfo(v: unknown): LedgerInfo {
+  if (
+    !isObject(v) ||
+    typeof v.chain_id !== "number" ||
+    !hasString(v, "epoch") ||
+    !hasString(v, "ledger_version") ||
+    !hasString(v, "oldest_ledger_version") ||
+    !hasString(v, "ledger_timestamp") ||
+    !hasString(v, "node_role") ||
+    !hasString(v, "oldest_block_height") ||
+    !hasString(v, "block_height")
+  ) {
+    throw new Error("Invalid LedgerInfo: missing or incorrectly typed fields");
+  }
+  return v as unknown as LedgerInfo;
+}
+
+export function assertAccountData(v: unknown): AccountData {
+  if (
+    !isObject(v) ||
+    !hasString(v, "sequence_number") ||
+    !hasString(v, "authentication_key")
+  ) {
+    throw new Error(
+      "Invalid AccountData: expected object with 'sequence_number' and 'authentication_key' strings"
+    );
+  }
+  return v as unknown as AccountData;
+}
+
+export function assertAccountResource(v: unknown): AccountResource {
+  if (!isObject(v) || !hasString(v, "type") || !("data" in v)) {
+    throw new Error(
+      "Invalid AccountResource: expected object with 'type' string and 'data' field"
+    );
+  }
+  return v as unknown as AccountResource;
+}
+
+export function assertAccountResourceArray(v: unknown): AccountResource[] {
+  if (!Array.isArray(v)) {
+    throw new Error("Invalid resources response: expected array");
+  }
+  for (let i = 0; i < v.length; i++) {
+    if (!isObject(v[i]) || !hasString(v[i], "type") || !("data" in v[i])) {
+      throw new Error(
+        `Invalid AccountResource at index ${i}: expected object with 'type' and 'data'`
+      );
+    }
+  }
+  return v as unknown as AccountResource[];
+}
+
+export function assertForkMetadata(v: unknown): ForkMetadata {
+  if (
+    !isObject(v) ||
+    !hasString(v, "network") ||
+    !hasString(v, "nodeUrl") ||
+    typeof v.chainId !== "number" ||
+    !hasString(v, "ledgerVersion") ||
+    !hasString(v, "timestamp") ||
+    !hasString(v, "epoch") ||
+    !hasString(v, "blockHeight") ||
+    !hasString(v, "createdAt")
+  ) {
+    throw new Error("Invalid ForkMetadata: missing or incorrectly typed fields");
+  }
+  return v as unknown as ForkMetadata;
+}
+
+export function assertAccountState(v: unknown): AccountState {
+  if (
+    !isObject(v) ||
+    !hasString(v, "sequenceNumber") ||
+    !hasString(v, "authenticationKey")
+  ) {
+    throw new Error(
+      "Invalid AccountState: expected object with 'sequenceNumber' and 'authenticationKey' strings"
+    );
+  }
+  return v as unknown as AccountState;
+}
+
+export function assertAccountStateRecord(
+  v: unknown
+): Record<string, AccountState> {
+  if (!isObject(v)) {
+    throw new Error("Invalid account state record: expected object");
+  }
+  for (const [key, val] of Object.entries(v)) {
+    if (
+      !isObject(val) ||
+      !hasString(val, "sequenceNumber") ||
+      !hasString(val, "authenticationKey")
+    ) {
+      throw new Error(
+        `Invalid AccountState for key "${key}": missing 'sequenceNumber' or 'authenticationKey'`
+      );
+    }
+  }
+  return v as unknown as Record<string, AccountState>;
+}
+
+export function assertCoinStore(v: unknown): CoinStore {
+  if (
+    !isObject(v) ||
+    !isObject(v.coin) ||
+    !hasString(v.coin as Record<string, unknown>, "value")
+  ) {
+    throw new Error(
+      "Invalid CoinStore: expected object with 'coin.value' string"
+    );
+  }
+  return v as unknown as CoinStore;
+}

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -25,6 +25,7 @@ interface HarnessInit {
   mode: HarnessMode;
   runtime: MovehatRuntime;
   localNode?: LocalNodeManager;
+  ownsLocalNode?: boolean;
   forkServer?: ForkServer;
   forkManager?: ForkManager;
 }
@@ -82,11 +83,13 @@ export class Harness {
   public readonly forkManager?: ForkManager;
 
   private _poisoned = false;
+  private readonly ownsLocalNode: boolean;
 
   private constructor(init: HarnessInit) {
     this.mode = init.mode;
     this.runtime = init.runtime;
     this.accounts = init.runtime.accountManager.getLabeledAccounts();
+    this.ownsLocalNode = init.ownsLocalNode ?? true;
     if (init.localNode) this.localNode = init.localNode;
     if (init.forkServer) this.forkServer = init.forkServer;
     if (init.forkManager) this.forkManager = init.forkManager;
@@ -109,6 +112,7 @@ export class Harness {
     const init: HarnessInit = {
       mode: "local",
       runtime: ctx.runtime,
+      ownsLocalNode: !options.localNode,
     };
     if (ctx.localNode) init.localNode = ctx.localNode;
     const instance = new Harness(init);
@@ -188,7 +192,7 @@ export class Harness {
   async cleanup(): Promise<void> {
     if (this._poisoned) return;
     this._poisoned = true;
-    if (this.localNode) {
+    if (this.localNode && this.ownsLocalNode) {
       await this.localNode.stop().catch(() => {});
     }
     if (this.forkServer) {

--- a/packages/movehat/src/helpers/move-tests.ts
+++ b/packages/movehat/src/helpers/move-tests.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 import { resolve } from "path";
 import { loadUserConfig } from "../core/config.js";
 import { runCli } from "../utils/runCli.js";
+import { logger } from "../ui/index.js";
 
 interface RunMoveTestsOptions {
   filter?: string | undefined;
@@ -20,8 +21,9 @@ export async function runMoveTests(options: RunMoveTestsOptions = {}): Promise<v
 
   if (!existsSync(moveDir)) {
     if (options.skipIfMissing) {
-      console.log("⊘ No Move directory found (./move not found)");
-      console.log("   Skipping Move tests...\n");
+      logger.info("No Move directory found (./move not found)");
+      logger.plain("   Skipping Move tests...");
+      logger.newline();
       return;
     } else {
       throw new Error(
@@ -58,13 +60,14 @@ export async function runMoveTests(options: RunMoveTestsOptions = {}): Promise<v
   } catch (error) {
     // Spawn-time failure (ENOENT, etc.). The original code logged a
     // Movement-CLI-install hint here; keep that.
-    console.error(`Failed to run Move tests: ${(error as Error).message}`);
-    console.error("   Make sure Movement CLI is installed");
+    logger.error(`Failed to run Move tests: ${(error as Error).message}`);
+    logger.error("   Make sure Movement CLI is installed");
     throw error;
   }
 
   if (result.exitCode === 0) {
-    console.log("\n✓ Move tests passed");
+    logger.newline();
+    logger.success("Move tests passed");
     return;
   }
 

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -99,13 +99,14 @@ export async function setupLocalTesting(
   logger.newline();
 
   if (mode === 'local-node') {
-    const { runtime, localNode } = await setupWithLocalNode(
+    const { runtime, localNode, ownsNode } = await setupWithLocalNode(
       options, accountLabels, autoFund, defaultBalance
     );
     return {
       runtime,
       localNode,
       teardown: async () => {
+        if (!ownsNode) return;
         logger.newline();
         logger.step("Stopping local testing environment...");
         await localNode.stop();
@@ -140,24 +141,40 @@ async function setupWithLocalNode(
   accountLabels: readonly string[],
   autoFund: boolean,
   defaultBalance: number
-): Promise<{ runtime: MovehatRuntime; localNode: LocalNodeManager }> {
-  const nodeTestDir = options.nodeTestDir || join(process.cwd(), ".movehat", "local-node");
-  const nodeForceRestart = options.nodeForceRestart !== false;
-  const nodeFaucetPort = options.nodeFaucetPort || 8081;
-  const nodeApiPort = options.nodeApiPort || 8080;
-  const nodeReadyPort = options.nodeReadyPort || 8070;
-  const nodeSilent = options.nodeSilent ?? false;
+): Promise<{ runtime: MovehatRuntime; localNode: LocalNodeManager; ownsNode: boolean }> {
+  let localNode: LocalNodeManager;
+  let ownsNode: boolean;
+  let nodeInfo: import("../node/LocalNodeManager.js").LocalNodeInfo;
 
-  const localNode = new LocalNodeManager({
-    testDir: nodeTestDir,
-    forceRestart: nodeForceRestart,
-    faucetPort: nodeFaucetPort,
-    apiPort: nodeApiPort,
-    readyPort: nodeReadyPort,
-    silent: nodeSilent,
-  });
+  if (options.localNode) {
+    localNode = options.localNode;
+    ownsNode = false;
+    if (!localNode.isRunning()) {
+      throw new Error(
+        "localNode was provided but isRunning() is false. " +
+        "Start the node before passing it to setupLocalTesting."
+      );
+    }
+    nodeInfo = localNode.getNodeInfo();
+  } else {
+    const nodeTestDir = options.nodeTestDir || join(process.cwd(), ".movehat", "local-node");
+    const nodeForceRestart = options.nodeForceRestart !== false;
+    const nodeFaucetPort = options.nodeFaucetPort || 8081;
+    const nodeApiPort = options.nodeApiPort || 8080;
+    const nodeReadyPort = options.nodeReadyPort || 8070;
+    const nodeSilent = options.nodeSilent ?? false;
 
-  const nodeInfo = await localNode.start();
+    localNode = new LocalNodeManager({
+      testDir: nodeTestDir,
+      forceRestart: nodeForceRestart,
+      faucetPort: nodeFaucetPort,
+      apiPort: nodeApiPort,
+      readyPort: nodeReadyPort,
+      silent: nodeSilent,
+    });
+    ownsNode = true;
+    nodeInfo = await localNode.start();
+  }
 
   // Once the node is up, every later step (account creation, funding,
   // runtime init, autoDeploy) is fallible. If any of them throws we
@@ -246,11 +263,11 @@ async function setupWithLocalNode(
     logger.plain(`   Balance per account: ${defaultBalance / 100_000_000} MOVE`);
     logger.newline();
 
-    return { runtime, localNode };
+    return { runtime, localNode, ownsNode };
   } catch (error) {
-    // Best-effort cleanup. Swallow the stop() error so the original
-    // setup failure surfaces unchanged.
-    await localNode.stop().catch(() => {});
+    if (ownsNode) {
+      await localNode.stop().catch(() => {});
+    }
     throw error;
   }
 }

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -5,6 +5,7 @@ import type { MovehatRuntime } from "../types/runtime.js";
 import { ForkManager } from "../fork/manager.js";
 import { ForkServer } from "../fork/server.js";
 import { LocalNodeManager } from "../node/LocalNodeManager.js";
+import type { LocalNodeInfo } from "../node/LocalNodeManager.js";
 import { AccountManager } from "../core/AccountManager.js";
 import { logger } from "../ui/index.js";
 import type { LocalTestOptions } from "../types/config.js";
@@ -144,7 +145,7 @@ async function setupWithLocalNode(
 ): Promise<{ runtime: MovehatRuntime; localNode: LocalNodeManager; ownsNode: boolean }> {
   let localNode: LocalNodeManager;
   let ownsNode: boolean;
-  let nodeInfo: import("../node/LocalNodeManager.js").LocalNodeInfo;
+  let nodeInfo: LocalNodeInfo;
 
   if (options.localNode) {
     localNode = options.localNode;

--- a/packages/movehat/src/helpers/version-check.ts
+++ b/packages/movehat/src/helpers/version-check.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { homedir } from "os";
 import { isNewerVersion } from "./semver-utils.js";
 import { fetchLatestVersion } from "./npm-registry.js";
-import { box, colors, formatCommand } from "../ui/index.js";
+import { box, colors, formatCommand, logger } from "../ui/index.js";
 
 interface VersionCache {
   lastChecked: number;
@@ -89,7 +89,9 @@ export function checkForUpdates(currentVersion: string, packageName: string): vo
         { borderColor: 'warning', padding: 1 }
       );
 
-      console.error('\n' + updateMessage + '\n');
+      logger.newline();
+      logger.warning(updateMessage);
+      logger.newline();
     }
 
     // Update cache in background if needed (doesn't block)

--- a/packages/movehat/src/templates/.mocharc.json
+++ b/packages/movehat/src/templates/.mocharc.json
@@ -2,6 +2,7 @@
   "node-option": ["import=tsx"],
   "extensions": ["ts"],
   "spec": ["tests/**/*.test.ts"],
+  "require": ["tests/setup.ts"],
   "timeout": 30000,
   "color": true,
   "reporter": "spec"

--- a/packages/movehat/src/templates/tests/Counter.test.ts
+++ b/packages/movehat/src/templates/tests/Counter.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, before, after } from "mocha";
 import { expect } from "chai";
 import { Harness } from "movehat";
+import { getSharedNode } from "./setup.js";
 
 describe("Counter Contract", () => {
   let harness;
@@ -9,16 +10,12 @@ describe("Counter Contract", () => {
   let deployer, alice, bob;
 
   before(async function () {
-    this.timeout(60000); // Allow time for local node startup + deployment
+    this.timeout(60000);
 
-    // Hardhat-style Harness — the primary public API.
-    // createLocal spins up a Movement local node, funds the labeled
-    // accounts from the local faucet, and (via autoDeploy) builds +
-    // publishes the named modules so they're ready to use.
-    //
-    // The setupTestFixture helper still works if you prefer the older
-    // pattern; see `import { setupTestFixture } from "movehat/helpers"`.
+    // Reuses the shared Movement node started by root hooks (tests/setup.ts).
+    // Each spec still gets its own accounts + deployments for isolation.
     harness = await Harness.createLocal({
+      localNode: getSharedNode(),
       accountLabels: ["deployer", "alice", "bob"],
       autoDeploy: ["counter"],
     });

--- a/packages/movehat/src/templates/tests/setup.ts
+++ b/packages/movehat/src/templates/tests/setup.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck - This is a template file, dependencies are installed in user projects
+import { LocalNodeManager } from "movehat/helpers";
+
+let sharedNode;
+
+/**
+ * Returns the shared local Movement node started by root hooks.
+ * Pass the result as `{ localNode: getSharedNode() }` to
+ * Harness.createLocal() or setupTestFixture().
+ */
+export function getSharedNode() {
+  if (!sharedNode || !sharedNode.isRunning()) {
+    throw new Error(
+      "Shared node not available. " +
+        'Ensure tests/setup.ts is listed in .mocharc.json under "require".'
+    );
+  }
+  return sharedNode;
+}
+
+export const mochaHooks = {
+  async beforeAll() {
+    this.timeout(60000);
+    sharedNode = new LocalNodeManager({ forceRestart: true });
+    await sharedNode.start();
+  },
+
+  async afterAll() {
+    if (sharedNode) {
+      await sharedNode.stop();
+      sharedNode = undefined;
+    }
+  },
+};

--- a/packages/movehat/src/types/config.ts
+++ b/packages/movehat/src/types/config.ts
@@ -46,6 +46,9 @@ export type LocalTestingMode = 'local-node' | 'fork';
 export interface LocalTestOptions {
     mode?: LocalTestingMode;            // Testing mode: 'local-node' (full blockchain) or 'fork' (read-only snapshot) (default: 'local-node')
 
+    // Shared node (when mode='local-node')
+    localNode?: import("../node/LocalNodeManager.js").LocalNodeManager; // Pre-started node to reuse; skips spawn when provided
+
     // Local Node options (when mode='local-node')
     nodeTestDir?: string;               // Directory for node data (default: .movehat/local-node)
     nodeForceRestart?: boolean;         // Clean node state and start fresh (default: true)

--- a/packages/movehat/src/types/fork.ts
+++ b/packages/movehat/src/types/fork.ts
@@ -45,3 +45,16 @@ export interface AccountResource {
    */
   data: unknown;
 }
+
+export interface CoinStore {
+  coin: { value: string };
+  deposit_events: {
+    counter: string;
+    guid: { id: { addr: string; creation_num: string } };
+  };
+  withdraw_events: {
+    counter: string;
+    guid: { id: { addr: string; creation_num: string } };
+  };
+  frozen: boolean;
+}


### PR DESCRIPTION
## Summary

Single feature: shared local-node support via mocha root hooks (PR #293, issue #235).

- New `localNode` option on `LocalTestOptions` — reuse a pre-started node instead of spawning per file
- New `tests/setup.ts` root hooks template — one node for the entire test suite
- `Harness.cleanup()` is ownership-aware — injected nodes survive cleanup
- Template + example updated to the shared-node pattern
- Backward compatible — omitting `localNode` spawns a fresh node as before

## Impact

| Metric | Before | After |
|---|---|---|
| Node spawns (3 specs) | 3 | **1** |
| Wall-clock time | ~65s | **~50s** (~23% faster) |

## Tier reporting

- **Tier 1**: `pass` (pre-push green on both commits)
- **Tier 2** (`pnpm test:example`): `pass` — 9 passing in 50s, single node lifecycle
- **Tier 3**: `N/A` — no release in this batch

## Files (12 changed, +150/-43)

Core: `types/config.ts`, `helpers/setupLocalTesting.ts`, `harness/Harness.ts`
Template: `templates/tests/setup.ts` (NEW), `templates/tests/Counter.test.ts`, `templates/.mocharc.json`
Example: `tests/setup.ts` (NEW), `tests/Counter.test.ts`, `tests/greeting.test.ts`, `tests/message.test.ts`, `.mocharc.json`
Docs: `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared local-node support for tests with a configurable injectible node, reducing suite wall-clock time (~23%).

* **Security**
  * Added runtime validation of API/storage responses to catch invalid data early.

* **Docs**
  * Documentation: compile command now auto-updates Move.toml with detected named addresses.

* **Refactor**
  * Replaced direct console output with centralized logger for CLI/user-facing messages.

* **Chores**
  * Updated test templates and configs to demonstrate shared node usage and setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->