### PR TITLE
docs: document movehat compile Move.toml auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+
+- Document that `movehat compile` auto-updates `Move.toml` with
+  detected named addresses. New "Move.toml Auto-Update" section in
+  `/docs/cli/compile`. CLI `--help` description updated to mention
+  the behavior. Closes #212.
+
 ### Added
 
 - Shared local-node support via mocha root hooks. New `localNode`

--- a/packages/docs/content/docs/cli/compile.mdx
+++ b/packages/docs/content/docs/cli/compile.mdx
@@ -29,7 +29,15 @@ module counter::counter {
 }
 ```
 
-Movehat detects `counter` as a named address. No manual configuration needed — just like Hardhat.
+Movehat detects `counter` as a named address. No manual configuration needed -- just like Hardhat.
+
+## Move.toml Auto-Update
+
+Movehat automatically updates your `Move.toml` when it detects named addresses that are missing from the `[addresses]` or `[dev-addresses]` sections. This ensures the Movement CLI can resolve every named address at compile time.
+
+For example, if your Move source declares `module counter::counter` but `Move.toml` has no `[addresses]` entry for `counter`, Movehat adds it with a placeholder dev address (`0xcafe`) before invoking the compiler. The mutation is idempotent -- running `movehat compile` multiple times produces the same result.
+
+This is intentional Hardhat-style UX: the framework manages build configuration so you can focus on writing Move code.
 
 ## Prerequisites
 

--- a/packages/movehat/src/cli.ts
+++ b/packages/movehat/src/cli.ts
@@ -74,7 +74,7 @@ program
 
 program
     .command('compile')
-    .description('Compile Move smart contracts using Movement CLI')
+    .description('Compile Move smart contracts (auto-detects named addresses and updates Move.toml)')
     .action(compileCommand);
 
 program


### PR DESCRIPTION
## Summary

Documents that `movehat compile` auto-detects named addresses from Move source and writes missing entries to `Move.toml`. Product decision: status quo + documentation (no opt-in flag needed).

- New "Move.toml Auto-Update" section in `/docs/cli/compile.mdx`
- CLI `--help` description updated to mention the behavior

## Tier reporting

- **Tier 1**: `pass`
- **Tier 2/3**: `N/A` — docs-only change

Closes #212