### PR TITLE
refactor: fork boundary validation + zero any in src/fork/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Runtime validation at every fork API and storage boundary. All
+  Movement REST API responses (`getLedgerInfo`, `getAccount`,
+  `getAccountResource`, `getAccountResources`) and on-disk JSON reads
+  (`loadMetadata`, `getAccount`, `listAccounts`) are now validated
+  against their expected shapes before use. Malformed upstream
+  responses throw descriptive errors instead of silently propagating
+  corrupt data. New `CoinStore` interface formalizes the coin-store
+  resource shape; the last `any` in `src/fork/` is eliminated. New
+  `src/fork/validation.ts` with 8 assertion functions. Closes #111.
+
 ### Added
 
 - Shared local-node support via mocha root hooks. New `localNode`

--- a/examples/counter-example/scripts/demo-fork.ts
+++ b/examples/counter-example/scripts/demo-fork.ts
@@ -51,14 +51,14 @@ async function main() {
   console.log(`   Resource: Counter\n`);
 
   try {
-    const counterState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE);
-    
+    const counterState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE) as Record<string, unknown>;
+
     console.log("✅ Counter state retrieved!");
     console.log(`   Value: ${counterState.value}\n`);
     console.log("   Raw resource data:");
     console.log(`   ${JSON.stringify(counterState, null, 2)}\n`);
-  } catch (error: any) {
-    console.log(`❌ Could not read Counter: ${error.message}\n`);
+  } catch (error: unknown) {
+    console.log(`❌ Could not read Counter: ${(error as Error).message}\n`);
   }
 
   // Step 3: Try to read a non-existent counter (for a random account)
@@ -71,7 +71,7 @@ async function main() {
   try {
     await fork.getResource(randomAccount, COUNTER_RESOURCE);
     console.log("   ✅ Counter exists (unexpected!)\n");
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.log("   ❌ Counter not found (expected - account hasn't initialized one)\n");
   }
 
@@ -81,16 +81,16 @@ async function main() {
   console.log("   This changes the local fork WITHOUT affecting testnet!\n");
 
   // Read current state
-  const currentState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE);
+  const currentState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE) as Record<string, unknown>;
   const originalValue = currentState.value;
-  
+
   // Modify locally
   currentState.value = "999";
   await fork.setResource(COUNTER_ADDRESS, COUNTER_RESOURCE, currentState);
-  
+
   // Read back
-  const modifiedState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE);
-  
+  const modifiedState = await fork.getResource(COUNTER_ADDRESS, COUNTER_RESOURCE) as Record<string, unknown>;
+
   console.log(`   Original value: ${originalValue}`);
   console.log(`   Modified value: ${modifiedState.value}`);
   console.log("\n   💡 The real testnet contract still has value = " + originalValue);

--- a/packages/movehat/src/__tests__/fork/api.test.ts
+++ b/packages/movehat/src/__tests__/fork/api.test.ts
@@ -87,8 +87,11 @@ function setupGetCapture(): {
       const body = JSON.stringify({
         chain_id: 250,
         ledger_version: "1",
+        oldest_ledger_version: "0",
         ledger_timestamp: "0",
+        node_role: "full_node",
         epoch: "0",
+        oldest_block_height: "0",
         block_height: "0",
       });
       callback(makeFakeResponse(body));

--- a/packages/movehat/src/commands/fork/fund.ts
+++ b/packages/movehat/src/commands/fork/fund.ts
@@ -49,10 +49,12 @@ export default async function forkFundCommand(options: ForkFundOptions) {
     // Verify
     const resourceType = `0x1::coin::CoinStore<${coinType}>`;
     const coinStore = await forkManager.getResource(options.account, resourceType);
+    const { assertCoinStore } = await import('../../fork/validation.js');
+    const validated = assertCoinStore(coinStore);
 
     logger.newline();
     logger.success("Account funded successfully!");
-    logger.plain(`   New balance: ${coinStore.coin.value}`);
+    logger.plain(`   New balance: ${validated.coin.value}`);
     logger.newline();
 
   } catch (error) {

--- a/packages/movehat/src/fork/__tests__/storage.test.ts
+++ b/packages/movehat/src/fork/__tests__/storage.test.ts
@@ -152,9 +152,9 @@ describe('ForkStorage', () => {
     it('should list all accounts', () => {
       vol.fromJSON({
         [`${forkPath}/accounts.json`]: JSON.stringify({
-          '0x1': { sequenceNumber: '0' },
-          '0x2': { sequenceNumber: '5' },
-          '0x3': { sequenceNumber: '10' },
+          '0x1': { sequenceNumber: '0', authenticationKey: '0xaa' },
+          '0x2': { sequenceNumber: '5', authenticationKey: '0xbb' },
+          '0x3': { sequenceNumber: '10', authenticationKey: '0xcc' },
         }),
       });
 
@@ -170,7 +170,7 @@ describe('ForkStorage', () => {
     it('should clear all accounts', () => {
       vol.fromJSON({
         [`${forkPath}/accounts.json`]: JSON.stringify({
-          '0x1': { sequenceNumber: '0' },
+          '0x1': { sequenceNumber: '0', authenticationKey: '0xaa' },
         }),
       });
 

--- a/packages/movehat/src/fork/api.ts
+++ b/packages/movehat/src/fork/api.ts
@@ -3,6 +3,12 @@ import http from 'http';
 import { URL } from 'url';
 import type { LedgerInfo, AccountData, AccountResource } from '../types/fork.js';
 import { normalizeAddressShort } from '../utils/address.js';
+import {
+  assertLedgerInfo,
+  assertAccountData,
+  assertAccountResource,
+  assertAccountResourceArray,
+} from './validation.js';
 
 export interface MovementApiClientOptions {
   /** Abort the request after this many ms (default: 30_000). */
@@ -263,7 +269,8 @@ export class MovementApiClient {
    * Get ledger information
    */
   async getLedgerInfo(): Promise<LedgerInfo> {
-    return this.get<LedgerInfo>(this.apiPath('/'));
+    const raw = await this.get<unknown>(this.apiPath('/'));
+    return assertLedgerInfo(raw);
   }
 
   /**
@@ -272,19 +279,21 @@ export class MovementApiClient {
   async getAccount(address: string): Promise<AccountData> {
     const normalizedAddress = normalizeAddressShort(address);
 
-    return this.get<AccountData>(this.apiPath(`/accounts/${normalizedAddress}`));
+    const raw = await this.get<unknown>(this.apiPath(`/accounts/${normalizedAddress}`));
+    return assertAccountData(raw);
   }
 
   /**
    * Get a specific account resource
    */
-  async getAccountResource(address: string, resourceType: string): Promise<any> {
+  async getAccountResource(address: string, resourceType: string): Promise<AccountResource> {
     const normalizedAddress = normalizeAddressShort(address);
 
     // URL encode the resource type
     const encodedType = encodeURIComponent(resourceType);
 
-    return this.get<any>(this.apiPath(`/accounts/${normalizedAddress}/resource/${encodedType}`));
+    const raw = await this.get<unknown>(this.apiPath(`/accounts/${normalizedAddress}/resource/${encodedType}`));
+    return assertAccountResource(raw);
   }
 
   /**
@@ -293,7 +302,8 @@ export class MovementApiClient {
   async getAccountResources(address: string): Promise<AccountResource[]> {
     const normalizedAddress = normalizeAddressShort(address);
 
-    return this.get<AccountResource[]>(this.apiPath(`/accounts/${normalizedAddress}/resources`));
+    const raw = await this.get<unknown>(this.apiPath(`/accounts/${normalizedAddress}/resources`));
+    return assertAccountResourceArray(raw);
   }
 
   /**

--- a/packages/movehat/src/fork/manager.ts
+++ b/packages/movehat/src/fork/manager.ts
@@ -1,9 +1,10 @@
 import { createHash } from 'node:crypto';
 import { MovementApiClient } from './api.js';
 import { ForkStorage } from './storage.js';
-import type { ForkMetadata, AccountState } from '../types/fork.js';
+import type { ForkMetadata, AccountState, CoinStore } from '../types/fork.js';
 import { normalizeAddress } from '../utils/address.js';
 import { logger } from '../ui/index.js';
+import { assertCoinStore } from './validation.js';
 
 /**
  * Derive a deterministic 32-byte hex placeholder for the `authentication_key`
@@ -138,7 +139,7 @@ export class ForkManager {
     return accountState;
   }
 
-  async getResource(address: string, resourceType: string): Promise<any> {
+  async getResource(address: string, resourceType: string): Promise<unknown> {
     const normalizedAddress = normalizeAddress(address);
 
     let resource = this.storage.getResource(normalizedAddress, resourceType);
@@ -168,7 +169,7 @@ export class ForkManager {
     return resource;
   }
 
-  async getAllResources(address: string): Promise<Record<string, any>> {
+  async getAllResources(address: string): Promise<Record<string, unknown>> {
     const normalizedAddress = normalizeAddress(address);
 
     let resources = this.storage.getAllResources(normalizedAddress);
@@ -227,16 +228,11 @@ export class ForkManager {
     const normalizedAddress = normalizeAddress(address);
     const resourceType = `0x1::coin::CoinStore<${coinType}>`;
 
-    // Try to get existing coin store. The coin store is a CoinStore<T>
-    // resource whose `data` is Movement-side untyped JSON; we shape it
-    // locally as a structural object with `coin.value: string`.
-    // any: full CoinStore schema lives at the Movement REST boundary —
-    // proper validation deferred to the boundary-validation follow-up of #57.
-    let coinStore: any;
+    let coinStore: CoinStore;
     try {
-      coinStore = await this.getResource(normalizedAddress, resourceType);
+      const raw = await this.getResource(normalizedAddress, resourceType);
+      coinStore = assertCoinStore(raw);
     } catch (error) {
-      // Only catch "not found" errors, rethrow others (network, API, etc.)
       const msg = error instanceof Error ? error.message : String(error);
       if (!msg.includes('not found')) {
         throw error;
@@ -266,7 +262,7 @@ export class ForkManager {
       };
     }
 
-    const currentBalance = BigInt(coinStore.coin.value ?? '0');
+    const currentBalance = BigInt(coinStore.coin.value);
     const newBalance = currentBalance + BigInt(amount);
     coinStore.coin.value = newBalance.toString();
 

--- a/packages/movehat/src/fork/storage.ts
+++ b/packages/movehat/src/fork/storage.ts
@@ -2,6 +2,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync, readdirS
 import { join } from 'path';
 import type { ForkMetadata, AccountState } from '../types/fork.js';
 import { isHexAddress } from '../utils/address.js';
+import { assertForkMetadata, assertAccountStateRecord } from './validation.js';
 
 /**
  * Sanitize address to create a safe filename. Validates the address through
@@ -128,7 +129,7 @@ export class ForkStorage {
       throw new Error(`Fork metadata not found at ${metadataPath}`);
     }
 
-    return readJsonFile<ForkMetadata>(metadataPath, 'fork metadata');
+    return assertForkMetadata(readJsonFile<unknown>(metadataPath, 'fork metadata'));
   }
 
   /**
@@ -141,7 +142,7 @@ export class ForkStorage {
       return null;
     }
 
-    const accounts = readJsonFile<Record<string, AccountState>>(accountsPath, 'fork accounts');
+    const accounts = assertAccountStateRecord(readJsonFile<unknown>(accountsPath, 'fork accounts'));
     return accounts[address] || null;
   }
 
@@ -153,7 +154,7 @@ export class ForkStorage {
 
     let accounts: Record<string, AccountState> = {};
     if (existsSync(accountsPath)) {
-      accounts = readJsonFile<Record<string, AccountState>>(accountsPath, 'fork accounts');
+      accounts = assertAccountStateRecord(readJsonFile<unknown>(accountsPath, 'fork accounts'));
     }
 
     accounts[address] = state;
@@ -236,7 +237,7 @@ export class ForkStorage {
       return [];
     }
 
-    const accounts = readJsonFile<Record<string, AccountState>>(accountsPath, 'fork accounts');
+    const accounts = assertAccountStateRecord(readJsonFile<unknown>(accountsPath, 'fork accounts'));
     return Object.keys(accounts);
   }
 

--- a/packages/movehat/src/fork/test.ts
+++ b/packages/movehat/src/fork/test.ts
@@ -136,7 +136,7 @@ export async function viewForkResource(
   account: string,
   resourceType: string,
   options: { adapter?: ChildProcessAdapter } = {}
-): Promise<any> {
+): Promise<unknown> {
   try {
     // runCli uses spawn-with-args (no shell) to prevent command injection.
     const { stdout, stderr, exitCode } = await runCli(

--- a/packages/movehat/src/fork/validation.ts
+++ b/packages/movehat/src/fork/validation.ts
@@ -1,0 +1,132 @@
+import type {
+  LedgerInfo,
+  AccountData,
+  AccountResource,
+  ForkMetadata,
+  AccountState,
+  CoinStore,
+} from "../types/fork.js";
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function hasString(o: Record<string, unknown>, key: string): boolean {
+  return typeof o[key] === "string";
+}
+
+export function assertLedgerInfo(v: unknown): LedgerInfo {
+  if (
+    !isObject(v) ||
+    typeof v.chain_id !== "number" ||
+    !hasString(v, "epoch") ||
+    !hasString(v, "ledger_version") ||
+    !hasString(v, "oldest_ledger_version") ||
+    !hasString(v, "ledger_timestamp") ||
+    !hasString(v, "node_role") ||
+    !hasString(v, "oldest_block_height") ||
+    !hasString(v, "block_height")
+  ) {
+    throw new Error("Invalid LedgerInfo: missing or incorrectly typed fields");
+  }
+  return v as unknown as LedgerInfo;
+}
+
+export function assertAccountData(v: unknown): AccountData {
+  if (
+    !isObject(v) ||
+    !hasString(v, "sequence_number") ||
+    !hasString(v, "authentication_key")
+  ) {
+    throw new Error(
+      "Invalid AccountData: expected object with 'sequence_number' and 'authentication_key' strings"
+    );
+  }
+  return v as unknown as AccountData;
+}
+
+export function assertAccountResource(v: unknown): AccountResource {
+  if (!isObject(v) || !hasString(v, "type") || !("data" in v)) {
+    throw new Error(
+      "Invalid AccountResource: expected object with 'type' string and 'data' field"
+    );
+  }
+  return v as unknown as AccountResource;
+}
+
+export function assertAccountResourceArray(v: unknown): AccountResource[] {
+  if (!Array.isArray(v)) {
+    throw new Error("Invalid resources response: expected array");
+  }
+  for (let i = 0; i < v.length; i++) {
+    if (!isObject(v[i]) || !hasString(v[i], "type") || !("data" in v[i])) {
+      throw new Error(
+        `Invalid AccountResource at index ${i}: expected object with 'type' and 'data'`
+      );
+    }
+  }
+  return v as unknown as AccountResource[];
+}
+
+export function assertForkMetadata(v: unknown): ForkMetadata {
+  if (
+    !isObject(v) ||
+    !hasString(v, "network") ||
+    !hasString(v, "nodeUrl") ||
+    typeof v.chainId !== "number" ||
+    !hasString(v, "ledgerVersion") ||
+    !hasString(v, "timestamp") ||
+    !hasString(v, "epoch") ||
+    !hasString(v, "blockHeight") ||
+    !hasString(v, "createdAt")
+  ) {
+    throw new Error("Invalid ForkMetadata: missing or incorrectly typed fields");
+  }
+  return v as unknown as ForkMetadata;
+}
+
+export function assertAccountState(v: unknown): AccountState {
+  if (
+    !isObject(v) ||
+    !hasString(v, "sequenceNumber") ||
+    !hasString(v, "authenticationKey")
+  ) {
+    throw new Error(
+      "Invalid AccountState: expected object with 'sequenceNumber' and 'authenticationKey' strings"
+    );
+  }
+  return v as unknown as AccountState;
+}
+
+export function assertAccountStateRecord(
+  v: unknown
+): Record<string, AccountState> {
+  if (!isObject(v)) {
+    throw new Error("Invalid account state record: expected object");
+  }
+  for (const [key, val] of Object.entries(v)) {
+    if (
+      !isObject(val) ||
+      !hasString(val, "sequenceNumber") ||
+      !hasString(val, "authenticationKey")
+    ) {
+      throw new Error(
+        `Invalid AccountState for key "${key}": missing 'sequenceNumber' or 'authenticationKey'`
+      );
+    }
+  }
+  return v as unknown as Record<string, AccountState>;
+}
+
+export function assertCoinStore(v: unknown): CoinStore {
+  if (
+    !isObject(v) ||
+    !isObject(v.coin) ||
+    !hasString(v.coin as Record<string, unknown>, "value")
+  ) {
+    throw new Error(
+      "Invalid CoinStore: expected object with 'coin.value' string"
+    );
+  }
+  return v as unknown as CoinStore;
+}

--- a/packages/movehat/src/types/fork.ts
+++ b/packages/movehat/src/types/fork.ts
@@ -45,3 +45,16 @@ export interface AccountResource {
    */
   data: unknown;
 }
+
+export interface CoinStore {
+  coin: { value: string };
+  deposit_events: {
+    counter: string;
+    guid: { id: { addr: string; creation_num: string } };
+  };
+  withdraw_events: {
+    counter: string;
+    guid: { id: { addr: string; creation_num: string } };
+  };
+  frozen: boolean;
+}


### PR DESCRIPTION
## Summary

Adds runtime validation at every fork API response and storage read boundary. Closes the last deferred M1.7 work.

- New `src/fork/validation.ts` with 8 assertion functions (LedgerInfo, AccountData, AccountResource, ForkMetadata, AccountState, CoinStore)
- New `CoinStore` interface in `types/fork.ts`
- All `any` types in `src/fork/` replaced with `unknown`
- API methods validate responses before returning
- Storage reads validate JSON shape after parsing
- Test mocks updated to include all required fields

## Verification

```bash
grep -rn "any" packages/movehat/src/fork/ --include="*.ts" | grep -v __tests__ | grep -v "//\|/\*\| \*"
# 0 matches
```

## Tier reporting

- **Tier 1**: `pass`
- **Tier 2/3**: `N/A` — internal refactor, no behavior change for valid data

## Test plan

- [x] `pnpm build:movehat`: clean
- [x] `pnpm test`: 560 passing
- [x] `pnpm typecheck:example`: clean
- [x] Zero `any` in `src/fork/` (excluding tests/comments)

Closes #111