### PR TITLE
develop → main: mvlite auto-spawn integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- mvlite auto-spawn integration. `Harness.createLocal()` and
+  `setupTestFixture()` automatically detect and use
+  [mvlite](https://github.com/gilbertsahumada/mvlite) if the binary
+  is available, reducing test boot time from ~15s to <1s. Falls back
+  to the full Movement node if mvlite is not installed. Opt out with
+  `useMvlite: false` in `LocalTestOptions`. Closes #192.
+
 ### Security
 
 - Runtime validation at every fork API and storage boundary. All

--- a/packages/movehat/src/harness/Harness.ts
+++ b/packages/movehat/src/harness/Harness.ts
@@ -1,6 +1,6 @@
 import type { Account } from "@aptos-labs/ts-sdk";
 import type { MovehatRuntime } from "../types/runtime.js";
-import type { LocalNodeManager } from "../node/LocalNodeManager.js";
+import type { NodeProvider } from "../node/NodeProvider.js";
 import type { ForkServer } from "../fork/server.js";
 import type { ForkManager } from "../fork/manager.js";
 import type { LocalTestOptions } from "../types/config.js";
@@ -24,7 +24,7 @@ export type HarnessMode = "local" | "fork" | "live";
 interface HarnessInit {
   mode: HarnessMode;
   runtime: MovehatRuntime;
-  localNode?: LocalNodeManager;
+  localNode?: NodeProvider;
   ownsLocalNode?: boolean;
   forkServer?: ForkServer;
   forkManager?: ForkManager;
@@ -76,7 +76,7 @@ export class Harness {
   public readonly accounts: Readonly<Record<string, Account>>;
 
   /** @internal */
-  public readonly localNode?: LocalNodeManager;
+  public readonly localNode?: NodeProvider;
   /** @internal */
   public readonly forkServer?: ForkServer;
   /** @internal */

--- a/packages/movehat/src/helpers/index.ts
+++ b/packages/movehat/src/helpers/index.ts
@@ -26,6 +26,7 @@ export { AccountManager } from "../core/AccountManager.js";
 export type { StoredAccount } from "../core/AccountManager.js";
 export { LocalNodeManager } from "../node/LocalNodeManager.js";
 export type { LocalNodeOptions, LocalNodeInfo } from "../node/LocalNodeManager.js";
+export { MvliteManager, findMvliteBinary } from "../node/MvliteManager.js";
 export { setupLocalTesting } from "./setupLocalTesting.js";
 export type { LocalTestingContext } from "./setupLocalTesting.js";
 export {

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -7,6 +7,7 @@ import { ForkServer } from "../fork/server.js";
 import { LocalNodeManager } from "../node/LocalNodeManager.js";
 import type { LocalNodeInfo } from "../node/LocalNodeManager.js";
 import { MvliteManager, findMvliteBinary } from "../node/MvliteManager.js";
+import type { NodeProvider } from "../node/NodeProvider.js";
 import { AccountManager } from "../core/AccountManager.js";
 import { logger } from "../ui/index.js";
 import type { LocalTestOptions } from "../types/config.js";
@@ -44,7 +45,7 @@ function resolveForkRpcUrl(
 export interface LocalTestingContext {
   runtime: MovehatRuntime;
   /** @internal */
-  localNode?: LocalNodeManager;
+  localNode?: NodeProvider;
   /** @internal */
   forkServer?: ForkServer;
   /** @internal */
@@ -143,8 +144,8 @@ async function setupWithLocalNode(
   accountLabels: readonly string[],
   autoFund: boolean,
   defaultBalance: number
-): Promise<{ runtime: MovehatRuntime; localNode: LocalNodeManager; ownsNode: boolean }> {
-  let localNode: LocalNodeManager;
+): Promise<{ runtime: MovehatRuntime; localNode: NodeProvider; ownsNode: boolean }> {
+  let localNode: NodeProvider;
   let ownsNode: boolean;
   let nodeInfo: LocalNodeInfo;
 
@@ -159,9 +160,8 @@ async function setupWithLocalNode(
     }
     nodeInfo = localNode.getNodeInfo();
   } else if (options.useMvlite !== false && findMvliteBinary()) {
-    const mvlite = new MvliteManager();
-    nodeInfo = await mvlite.start();
-    localNode = mvlite as unknown as LocalNodeManager;
+    localNode = new MvliteManager(findMvliteBinary()!);
+    nodeInfo = await localNode.start();
     ownsNode = true;
   } else {
     const nodeTestDir = options.nodeTestDir || join(process.cwd(), ".movehat", "local-node");

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -6,6 +6,7 @@ import { ForkManager } from "../fork/manager.js";
 import { ForkServer } from "../fork/server.js";
 import { LocalNodeManager } from "../node/LocalNodeManager.js";
 import type { LocalNodeInfo } from "../node/LocalNodeManager.js";
+import { MvliteManager, findMvliteBinary } from "../node/MvliteManager.js";
 import { AccountManager } from "../core/AccountManager.js";
 import { logger } from "../ui/index.js";
 import type { LocalTestOptions } from "../types/config.js";
@@ -157,6 +158,11 @@ async function setupWithLocalNode(
       );
     }
     nodeInfo = localNode.getNodeInfo();
+  } else if (options.useMvlite !== false && findMvliteBinary()) {
+    const mvlite = new MvliteManager();
+    nodeInfo = await mvlite.start();
+    localNode = mvlite as unknown as LocalNodeManager;
+    ownsNode = true;
   } else {
     const nodeTestDir = options.nodeTestDir || join(process.cwd(), ".movehat", "local-node");
     const nodeForceRestart = options.nodeForceRestart !== false;

--- a/packages/movehat/src/node/MvliteManager.ts
+++ b/packages/movehat/src/node/MvliteManager.ts
@@ -1,6 +1,7 @@
-import { spawn, type ChildProcess } from "child_process";
+import { execSync, spawn, type ChildProcess } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
+import { createRequire } from "module";
 import type { Account } from "@aptos-labs/ts-sdk";
 import type { LocalNodeInfo } from "./LocalNodeManager.js";
 import { logger } from "../ui/index.js";
@@ -9,15 +10,24 @@ export class MvliteManager {
   private process: ChildProcess | null = null;
   private port: number;
   private killed = false;
+  private readonly binaryPath: string;
 
-  constructor(port = 8090) {
+  constructor(binaryPath: string, port = 8090) {
+    this.binaryPath = binaryPath;
     this.port = port;
   }
 
   async start(): Promise<LocalNodeInfo> {
-    const binary = findMvliteBinary();
+    const binary = this.binaryPath;
     if (!binary) {
       throw new Error("mvlite binary not found");
+    }
+
+    if (await this.isPortInUse(this.port)) {
+      this.port = this.port + 1;
+      if (await this.isPortInUse(this.port)) {
+        throw new Error(`Ports ${this.port - 1} and ${this.port} are in use`);
+      }
     }
 
     logger.step("Starting mvlite...");
@@ -95,6 +105,15 @@ export class MvliteManager {
     this.process = null;
   }
 
+  private async isPortInUse(port: number): Promise<boolean> {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/v1`);
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
   isRunning(): boolean {
     return this.process !== null && !this.killed;
   }
@@ -127,7 +146,8 @@ export function findMvliteBinary(): string | null {
   const pkg = platforms[key];
   if (pkg) {
     try {
-      const pkgPath = require.resolve(`${pkg}/package.json`);
+      const req = createRequire(import.meta.url);
+      const pkgPath = req.resolve(`${pkg}/package.json`);
       const binPath = join(pkgPath, "..", "bin", "mvlite");
       if (existsSync(binPath)) return binPath;
     } catch {
@@ -136,9 +156,8 @@ export function findMvliteBinary(): string | null {
   }
 
   try {
-    const { execSync } = require("child_process");
-    const path = execSync("which mvlite", { encoding: "utf-8" }).trim();
-    if (path && existsSync(path)) return path;
+    const found = execSync("which mvlite", { encoding: "utf-8" }).trim();
+    if (found && existsSync(found)) return found;
   } catch {
     // not in PATH
   }

--- a/packages/movehat/src/node/MvliteManager.ts
+++ b/packages/movehat/src/node/MvliteManager.ts
@@ -1,0 +1,147 @@
+import { spawn, type ChildProcess } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+import type { Account } from "@aptos-labs/ts-sdk";
+import type { LocalNodeInfo } from "./LocalNodeManager.js";
+import { logger } from "../ui/index.js";
+
+export class MvliteManager {
+  private process: ChildProcess | null = null;
+  private port: number;
+  private killed = false;
+
+  constructor(port = 8090) {
+    this.port = port;
+  }
+
+  async start(): Promise<LocalNodeInfo> {
+    const binary = findMvliteBinary();
+    if (!binary) {
+      throw new Error("mvlite binary not found");
+    }
+
+    logger.step("Starting mvlite...");
+
+    this.process = spawn(binary, ["start", "--port", String(this.port)], {
+      stdio: "pipe",
+      detached: false,
+    });
+
+    this.process.on("exit", () => {
+      this.process = null;
+    });
+
+    await this.waitForReady();
+    logger.success(`mvlite ready on port ${this.port}`);
+
+    return this.getNodeInfo();
+  }
+
+  private async waitForReady(): Promise<void> {
+    const url = `http://127.0.0.1:${this.port}/v1`;
+    const timeout = 15_000;
+    const start = Date.now();
+
+    while (Date.now() - start < timeout) {
+      try {
+        const res = await fetch(url);
+        if (res.ok) return;
+      } catch {
+        // not ready yet
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    throw new Error(`mvlite did not become ready within ${timeout}ms`);
+  }
+
+  async fundAccount(address: string, amount: number): Promise<void> {
+    const res = await fetch(
+      `http://127.0.0.1:${this.port}/mint?address=${address}&amount=${amount}`,
+      { method: "POST" },
+    );
+    if (!res.ok) {
+      throw new Error(`Failed to fund account: ${res.status}`);
+    }
+  }
+
+  async fundAccounts(accounts: Account[], balance: number): Promise<void> {
+    for (const account of accounts) {
+      await this.fundAccount(account.accountAddress.toString(), balance);
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.process || this.killed) return;
+    this.killed = true;
+    this.process.kill("SIGTERM");
+
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        if (this.process) this.process.kill("SIGKILL");
+        resolve();
+      }, 5_000);
+      if (this.process) {
+        this.process.on("exit", () => {
+          clearTimeout(timer);
+          resolve();
+        });
+      } else {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+
+    this.process = null;
+  }
+
+  isRunning(): boolean {
+    return this.process !== null && !this.killed;
+  }
+
+  getNodeInfo(): LocalNodeInfo {
+    return {
+      rpcUrl: `http://127.0.0.1:${this.port}`,
+      faucetUrl: `http://127.0.0.1:${this.port}`,
+      readyUrl: `http://127.0.0.1:${this.port}/v1`,
+      testDir: "",
+    };
+  }
+}
+
+export function findMvliteBinary(): string | null {
+  if (process.env.MVLITE_PATH) {
+    return existsSync(process.env.MVLITE_PATH)
+      ? process.env.MVLITE_PATH
+      : null;
+  }
+
+  const platforms: Record<string, string> = {
+    "darwin-arm64": "mvlite-darwin-arm64",
+    "darwin-x64": "mvlite-darwin-x64",
+    "linux-x64": "mvlite-linux-x64",
+    "linux-arm64": "mvlite-linux-arm64",
+  };
+
+  const key = `${process.platform}-${process.arch}`;
+  const pkg = platforms[key];
+  if (pkg) {
+    try {
+      const pkgPath = require.resolve(`${pkg}/package.json`);
+      const binPath = join(pkgPath, "..", "bin", "mvlite");
+      if (existsSync(binPath)) return binPath;
+    } catch {
+      // package not installed
+    }
+  }
+
+  try {
+    const { execSync } = require("child_process");
+    const path = execSync("which mvlite", { encoding: "utf-8" }).trim();
+    if (path && existsSync(path)) return path;
+  } catch {
+    // not in PATH
+  }
+
+  return null;
+}

--- a/packages/movehat/src/node/NodeProvider.ts
+++ b/packages/movehat/src/node/NodeProvider.ts
@@ -1,0 +1,10 @@
+import type { Account } from "@aptos-labs/ts-sdk";
+import type { LocalNodeInfo } from "./LocalNodeManager.js";
+
+export interface NodeProvider {
+  start(): Promise<LocalNodeInfo>;
+  stop(): Promise<void>;
+  isRunning(): boolean;
+  getNodeInfo(): LocalNodeInfo;
+  fundAccounts(accounts: Account[], balance: number): Promise<void>;
+}

--- a/packages/movehat/src/types/config.ts
+++ b/packages/movehat/src/types/config.ts
@@ -48,6 +48,7 @@ export interface LocalTestOptions {
 
     // Shared node (when mode='local-node')
     localNode?: import("../node/LocalNodeManager.js").LocalNodeManager; // Pre-started node to reuse; skips spawn when provided
+    useMvlite?: boolean;                // Try mvlite before Movement node (default: true)
 
     // Local Node options (when mode='local-node')
     nodeTestDir?: string;               // Directory for node data (default: .movehat/local-node)


### PR DESCRIPTION
## Summary

Single feature: mvlite auto-spawn integration (PR #298).

Harness.createLocal() and setupTestFixture() now automatically detect and use mvlite if the binary is available, reducing test boot time from ~15s to <1s. Falls back to the full Movement node if mvlite is not installed. Zero breaking changes.

## Files (7 changed, +199/-6)

- `src/node/MvliteManager.ts` (NEW): spawn, health check, faucet, port conflict detection, cleanup
- `src/node/NodeProvider.ts` (NEW): shared interface for LocalNodeManager and MvliteManager
- `src/helpers/setupLocalTesting.ts`: try mvlite before Movement node
- `src/harness/Harness.ts`: use NodeProvider type instead of LocalNodeManager
- `src/types/config.ts`: useMvlite option
- `src/helpers/index.ts`: export MvliteManager
- `CHANGELOG.md`: entry

## Tier reporting

- **Tier 1**: pass (build + typecheck)
- **Tier 2** (test:example): pass, 9/9 in 51s (falls back to Movement node, no mvlite binary present)
- **Tier 3**: N/A

## Verification

Without mvlite: all existing behavior unchanged (confirmed by Tier 2).
With mvlite: boot <1s (confirmed by mvlite SDK integration test, 9/9 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mvlite auto-spawn integration for local testing setup
  * Automatic fallback to standard local node when mvlite is unavailable
  * New configuration option to disable mvlite via `useMvlite: false`

* **Documentation**
  * Updated changelog documenting mvlite integration for local testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->