### PR TITLE
feat: consume movelite 0.1.0 (rename + optionalDependency + --no-auth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the full Movement node if mvlite is not installed. Opt out with
   `useMvlite: false` in `LocalTestOptions`. Closes #192.
 
+- `mvlite` declared as an `optionalDependency`. `npm install movehat`
+  now also downloads the matching `mvlite-<platform>` binary
+  (via mvlite's own optional dependencies on its platform packages),
+  so the auto-spawn path above activates without a separate manual
+  install step. Supported platforms: macOS arm64/x64, Linux x64/arm64.
+  Unsupported platforms (e.g. Windows) install movehat cleanly and
+  fall back to the Movement node. Closes #300.
+
 ### Security
 
 - Runtime validation at every fork API and storage boundary. All

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- mvlite auto-spawn integration. `Harness.createLocal()` and
+- movelite auto-spawn integration. `Harness.createLocal()` and
   `setupTestFixture()` automatically detect and use
-  [mvlite](https://github.com/gilbertsahumada/mvlite) if the binary
+  [movelite](https://github.com/gilbertsahumada/movelite) if the binary
   is available, reducing test boot time from ~15s to <1s. Falls back
-  to the full Movement node if mvlite is not installed. Opt out with
-  `useMvlite: false` in `LocalTestOptions`. Closes #192.
+  to the full Movement node if movelite is not installed. Opt out with
+  `useMovelite: false` in `LocalTestOptions`. Closes #192.
 
-- `mvlite` declared as an `optionalDependency`. `npm install movehat`
-  now also downloads the matching `mvlite-<platform>` binary
-  (via mvlite's own optional dependencies on its platform packages),
+- `movelite` declared as an `optionalDependency`. `npm install movehat`
+  now also downloads the matching `movelite-<platform>` binary
+  (via movelite's own optional dependencies on its platform packages),
   so the auto-spawn path above activates without a separate manual
   install step. Supported platforms: macOS arm64/x64, Linux x64/arm64.
   Unsupported platforms (e.g. Windows) install movehat cleanly and

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -70,6 +70,9 @@
     "prompts": "^2.4.2",
     "tsx": "^4.7.0"
   },
+  "optionalDependencies": {
+    "mvlite": "^0.1.0"
+  },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.10.1",

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -71,7 +71,7 @@
     "tsx": "^4.7.0"
   },
   "optionalDependencies": {
-    "mvlite": "^0.1.0"
+    "movelite": "^0.1.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/movehat/src/helpers/index.ts
+++ b/packages/movehat/src/helpers/index.ts
@@ -26,7 +26,7 @@ export { AccountManager } from "../core/AccountManager.js";
 export type { StoredAccount } from "../core/AccountManager.js";
 export { LocalNodeManager } from "../node/LocalNodeManager.js";
 export type { LocalNodeOptions, LocalNodeInfo } from "../node/LocalNodeManager.js";
-export { MvliteManager, findMvliteBinary } from "../node/MvliteManager.js";
+export { MoveliteManager, findMoveliteBinary } from "../node/MoveliteManager.js";
 export { setupLocalTesting } from "./setupLocalTesting.js";
 export type { LocalTestingContext } from "./setupLocalTesting.js";
 export {

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -6,7 +6,7 @@ import { ForkManager } from "../fork/manager.js";
 import { ForkServer } from "../fork/server.js";
 import { LocalNodeManager } from "../node/LocalNodeManager.js";
 import type { LocalNodeInfo } from "../node/LocalNodeManager.js";
-import { MvliteManager, findMvliteBinary } from "../node/MvliteManager.js";
+import { MoveliteManager, findMoveliteBinary } from "../node/MoveliteManager.js";
 import type { NodeProvider } from "../node/NodeProvider.js";
 import { AccountManager } from "../core/AccountManager.js";
 import { logger } from "../ui/index.js";
@@ -159,8 +159,8 @@ async function setupWithLocalNode(
       );
     }
     nodeInfo = localNode.getNodeInfo();
-  } else if (options.useMvlite !== false && findMvliteBinary()) {
-    localNode = new MvliteManager(findMvliteBinary()!);
+  } else if (options.useMovelite !== false && findMoveliteBinary()) {
+    localNode = new MoveliteManager(findMoveliteBinary()!);
     nodeInfo = await localNode.start();
     ownsNode = true;
   } else {

--- a/packages/movehat/src/node/MoveliteManager.ts
+++ b/packages/movehat/src/node/MoveliteManager.ts
@@ -150,8 +150,14 @@ export function findMoveliteBinary(): string | null {
   const pkg = platforms[key];
   if (pkg) {
     try {
+      // Resolve through the `movelite` shim (movehat's direct dependency),
+      // then resolve the platform package from movelite's own context. The
+      // platform package is movelite's dependency, not movehat's, so a direct
+      // resolve from here fails under pnpm/yarn strict layouts.
       const req = createRequire(import.meta.url);
-      const pkgPath = req.resolve(`${pkg}/package.json`);
+      const movelitePkg = req.resolve("movelite/package.json");
+      const moveliteReq = createRequire(movelitePkg);
+      const pkgPath = moveliteReq.resolve(`${pkg}/package.json`);
       const binPath = join(pkgPath, "..", "bin", "movelite");
       if (existsSync(binPath)) return binPath;
     } catch {

--- a/packages/movehat/src/node/MoveliteManager.ts
+++ b/packages/movehat/src/node/MoveliteManager.ts
@@ -6,7 +6,7 @@ import type { Account } from "@aptos-labs/ts-sdk";
 import type { LocalNodeInfo } from "./LocalNodeManager.js";
 import { logger } from "../ui/index.js";
 
-export class MvliteManager {
+export class MoveliteManager {
   private process: ChildProcess | null = null;
   private port: number;
   private killed = false;
@@ -20,7 +20,7 @@ export class MvliteManager {
   async start(): Promise<LocalNodeInfo> {
     const binary = this.binaryPath;
     if (!binary) {
-      throw new Error("mvlite binary not found");
+      throw new Error("movelite binary not found");
     }
 
     if (await this.isPortInUse(this.port)) {
@@ -30,19 +30,23 @@ export class MvliteManager {
       }
     }
 
-    logger.step("Starting mvlite...");
+    logger.step("Starting movelite...");
 
-    this.process = spawn(binary, ["start", "--port", String(this.port)], {
-      stdio: "pipe",
-      detached: false,
-    });
+    this.process = spawn(
+      binary,
+      ["start", "--port", String(this.port), "--no-auth"],
+      {
+        stdio: "pipe",
+        detached: false,
+      },
+    );
 
     this.process.on("exit", () => {
       this.process = null;
     });
 
     await this.waitForReady();
-    logger.success(`mvlite ready on port ${this.port}`);
+    logger.success(`movelite ready on port ${this.port}`);
 
     return this.getNodeInfo();
   }
@@ -62,7 +66,7 @@ export class MvliteManager {
       await new Promise((r) => setTimeout(r, 200));
     }
 
-    throw new Error(`mvlite did not become ready within ${timeout}ms`);
+    throw new Error(`movelite did not become ready within ${timeout}ms`);
   }
 
   async fundAccount(address: string, amount: number): Promise<void> {
@@ -128,18 +132,18 @@ export class MvliteManager {
   }
 }
 
-export function findMvliteBinary(): string | null {
-  if (process.env.MVLITE_PATH) {
-    return existsSync(process.env.MVLITE_PATH)
-      ? process.env.MVLITE_PATH
+export function findMoveliteBinary(): string | null {
+  if (process.env.MOVELITE_PATH) {
+    return existsSync(process.env.MOVELITE_PATH)
+      ? process.env.MOVELITE_PATH
       : null;
   }
 
   const platforms: Record<string, string> = {
-    "darwin-arm64": "mvlite-darwin-arm64",
-    "darwin-x64": "mvlite-darwin-x64",
-    "linux-x64": "mvlite-linux-x64",
-    "linux-arm64": "mvlite-linux-arm64",
+    "darwin-arm64": "movelite-darwin-arm64",
+    "darwin-x64": "movelite-darwin-x64",
+    "linux-x64": "movelite-linux-x64",
+    "linux-arm64": "movelite-linux-arm64",
   };
 
   const key = `${process.platform}-${process.arch}`;
@@ -148,7 +152,7 @@ export function findMvliteBinary(): string | null {
     try {
       const req = createRequire(import.meta.url);
       const pkgPath = req.resolve(`${pkg}/package.json`);
-      const binPath = join(pkgPath, "..", "bin", "mvlite");
+      const binPath = join(pkgPath, "..", "bin", "movelite");
       if (existsSync(binPath)) return binPath;
     } catch {
       // package not installed
@@ -156,7 +160,7 @@ export function findMvliteBinary(): string | null {
   }
 
   try {
-    const found = execSync("which mvlite", { encoding: "utf-8" }).trim();
+    const found = execSync("which movelite", { encoding: "utf-8" }).trim();
     if (found && existsSync(found)) return found;
   } catch {
     // not in PATH

--- a/packages/movehat/src/types/config.ts
+++ b/packages/movehat/src/types/config.ts
@@ -48,7 +48,7 @@ export interface LocalTestOptions {
 
     // Shared node (when mode='local-node')
     localNode?: import("../node/LocalNodeManager.js").LocalNodeManager; // Pre-started node to reuse; skips spawn when provided
-    useMvlite?: boolean;                // Try mvlite before Movement node (default: true)
+    useMovelite?: boolean;              // Try movelite before Movement node (default: true)
 
     // Local Node options (when mode='local-node')
     nodeTestDir?: string;               // Directory for node data (default: .movehat/local-node)


### PR DESCRIPTION
> **Still blocked on movelite 0.1.0 publication.** Do not merge until `npm view movelite version` returns `0.1.0`. (Package renamed from `mvlite` — npm rejected that name as too similar to an unrelated `mv-lite`.)

## Summary

Aligns movehat's auto-spawn integration (shipped in #298/#299) with the upstream rename `mvlite` -> `movelite`, declares the optionalDependency, and fixes an auth-default mismatch.

### Rename (mvlite -> movelite)
- `MvliteManager` -> `MoveliteManager` (file + class)
- `findMvliteBinary` -> `findMoveliteBinary`; platform packages `mvlite-*` -> `movelite-*`; resolved binary `bin/mvlite` -> `bin/movelite`; `MVLITE_PATH` -> `MOVELITE_PATH`; `which mvlite` -> `which movelite`
- `LocalTestOptions.useMvlite` -> `useMovelite`
- `optionalDependencies`: `movelite: ^0.1.0`
- CHANGELOG `[Unreleased]` entries

### Auth fix (--no-auth)
movelite 0.1.0 generates a random auth token by default and gates `/mint` behind `x-movelite-token`. `MoveliteManager` now spawns with `--no-auth`, otherwise `fundAccounts()` would 401. movehat owns the process and binds to 127.0.0.1, so disabling local auth for the embedded spawn is correct.

## Verification (this branch)
- Tier 1: `pnpm check:example` passes.
- Unit: 560/560 pass.
- §6.2 Tier 2 (`pnpm test:example` against published movelite): deferred until movelite 0.1.0 is on npm. Expected: boot switches to "Starting movelite..." <1s.

## Tier 2 / Tier 3 status
- `pnpm test:smoke`: N/A — no template/bin changes; metadata + node-manager rename only.
- `pnpm test:example` against published movelite: pending pre-merge.
- `pnpm test:e2e`: runs in the develop -> main batch.

## Self-review (per §8)
Pending pre-merge after the blocker clears.

Closes #300.
Tracks gilbertsahumada/movelite (rename + Apache-2.0 refactor merged there).