### PR TITLE
release: 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-05-30
+
 ### Added
 
 - movelite auto-spawn integration. `Harness.createLocal()` and
@@ -23,6 +25,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   install step. Supported platforms: macOS arm64/x64, Linux x64/arm64.
   Unsupported platforms (e.g. Windows) install movehat cleanly and
   fall back to the Movement node. Closes #300.
+
+- Shared local-node support via mocha root hooks. New `localNode`
+  option on `LocalTestOptions` lets `Harness.createLocal()` and
+  `setupTestFixture()` reuse a pre-started `LocalNodeManager`
+  instead of spawning a new one per test file. `movehat init` now
+  scaffolds a `tests/setup.ts` root hooks file that starts one
+  Movement node for the entire test suite and stops it at the end.
+  `Harness.cleanup()` is ownership-aware: when the node was injected
+  via `localNode`, cleanup poisons the harness but does not stop the
+  shared node. Reduces test-suite wall-clock time by ~23% for 3
+  specs (~65s -> ~50s), scaling to ~50%+ at 10+ specs. Closes #235.
+
+### Changed
+
+- M9.4 (PR #290 — AccountManager static-facade removal) reverted.
+  The static facade remains deprecated-but-functional indefinitely.
+  Users see a once-per-method `logger.warning` pointing to
+  `harness.accounts.<label>` / `harness.runtime.accountManager.*`
+  but existing code continues to work without migration. No 0.3.0
+  BREAKING release is planned. Closes #289.
 
 ### Security
 
@@ -51,28 +73,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to `logger.*` methods. All remaining `console.*` calls in `src/`
   are documented §9 exceptions (CLI table output, JSON passthrough,
   subprocess verbosity gate, banner rendering). Closes #223.
-
-### Added
-
-- Shared local-node support via mocha root hooks. New `localNode`
-  option on `LocalTestOptions` lets `Harness.createLocal()` and
-  `setupTestFixture()` reuse a pre-started `LocalNodeManager`
-  instead of spawning a new one per test file. `movehat init` now
-  scaffolds a `tests/setup.ts` root hooks file that starts one
-  Movement node for the entire test suite and stops it at the end.
-  `Harness.cleanup()` is ownership-aware: when the node was injected
-  via `localNode`, cleanup poisons the harness but does not stop the
-  shared node. Reduces test-suite wall-clock time by ~23% for 3
-  specs (~65s -> ~50s), scaling to ~50%+ at 10+ specs. Closes #235.
-
-### Changed
-
-- M9.4 (PR #290 — AccountManager static-facade removal) reverted.
-  The static facade remains deprecated-but-functional indefinitely.
-  Users see a once-per-method `logger.warning` pointing to
-  `harness.accounts.<label>` / `harness.runtime.accountManager.*`
-  but existing code continues to work without migration. No 0.3.0
-  BREAKING release is planned. Closes #289.
 
 ## [0.2.7] - 2026-05-22
 

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,10 @@ importers:
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
+    optionalDependencies:
+      movelite:
+        specifier: ^0.1.0
+        version: 0.1.0
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -2672,6 +2676,15 @@ packages:
   mocha@11.7.5:
     resolution: {integrity: sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+
+  movelite-darwin-arm64@0.1.0:
+    resolution: {integrity: sha512-qE7u6pHRwNwWjjkxTwzSBX0kQlUnoy/vDbJNceYtoU+qXCZ7Fd/1pP27R1DUyyAsKtVZq2rkB7MkuFd37K0mMw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  movelite@0.1.0:
+    resolution: {integrity: sha512-hk4k5QD7V5K1p/CieRMgU8/b8p2zjz0FQTd+g06nz2lU20+o90o359Z4ujVom7DxFCDLhNtOV4HIyf6Uf06CSA==}
     hasBin: true
 
   ms@2.1.3:
@@ -5994,6 +6007,14 @@ snapshots:
       yargs: 17.7.2
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
+
+  movelite-darwin-arm64@0.1.0:
+    optional: true
+
+  movelite@0.1.0:
+    optionalDependencies:
+      movelite-darwin-arm64: 0.1.0
+    optional: true
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
Release prep for 0.2.8. Finalizes CHANGELOG + version + lockfile so the develop -> main batch can ship.

## Changes
- `CHANGELOG.md`: `[Unreleased]` -> `[0.2.8] - 2026-05-30`; consolidated the two duplicate `### Added` blocks; fresh empty `[Unreleased]`.
- `packages/movehat/package.json`: 0.2.7 -> 0.2.8.
- `pnpm-lock.yaml`: sync movelite@0.1.0 (PR #301 couldn't lock it — not published then).

## 0.2.8 bundles (everything since 0.2.7)
movelite auto-spawn (#192), movelite optionalDependency (#300), shared local-node root hooks (#235), M9.4 revert (#289), fork/storage validation (#111), Move.toml docs (#212), console UX migration (#223).

## Verification
- `pnpm check:example`: PASS
- `pnpm --filter movehat test`: 560/560
- `node scripts/check-changelog.js`: PASS for 0.2.8
- `pnpm test:e2e` (Tier 3): 34/34 in 86s