### PR TITLE
develop → main: 0.2.8 (movelite integration + accumulated work)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the full Movement node if mvlite is not installed. Opt out with
   `useMvlite: false` in `LocalTestOptions`. Closes #192.
 
+- `mvlite` declared as an `optionalDependency`. `npm install movehat`
+  now also downloads the matching `mvlite-<platform>` binary
+  (via mvlite's own optional dependencies on its platform packages),
+  so the auto-spawn path above activates without a separate manual
+  install step. Supported platforms: macOS arm64/x64, Linux x64/arm64.
+  Unsupported platforms (e.g. Windows) install movehat cleanly and
+  fall back to the Movement node. Closes #300.
+
 ### Security
 
 - Runtime validation at every fork API and storage boundary. All

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-05-30
+
 ### Added
 
 - movelite auto-spawn integration. `Harness.createLocal()` and
@@ -23,6 +25,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   install step. Supported platforms: macOS arm64/x64, Linux x64/arm64.
   Unsupported platforms (e.g. Windows) install movehat cleanly and
   fall back to the Movement node. Closes #300.
+
+- Shared local-node support via mocha root hooks. New `localNode`
+  option on `LocalTestOptions` lets `Harness.createLocal()` and
+  `setupTestFixture()` reuse a pre-started `LocalNodeManager`
+  instead of spawning a new one per test file. `movehat init` now
+  scaffolds a `tests/setup.ts` root hooks file that starts one
+  Movement node for the entire test suite and stops it at the end.
+  `Harness.cleanup()` is ownership-aware: when the node was injected
+  via `localNode`, cleanup poisons the harness but does not stop the
+  shared node. Reduces test-suite wall-clock time by ~23% for 3
+  specs (~65s -> ~50s), scaling to ~50%+ at 10+ specs. Closes #235.
+
+### Changed
+
+- M9.4 (PR #290 — AccountManager static-facade removal) reverted.
+  The static facade remains deprecated-but-functional indefinitely.
+  Users see a once-per-method `logger.warning` pointing to
+  `harness.accounts.<label>` / `harness.runtime.accountManager.*`
+  but existing code continues to work without migration. No 0.3.0
+  BREAKING release is planned. Closes #289.
 
 ### Security
 
@@ -51,28 +73,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to `logger.*` methods. All remaining `console.*` calls in `src/`
   are documented §9 exceptions (CLI table output, JSON passthrough,
   subprocess verbosity gate, banner rendering). Closes #223.
-
-### Added
-
-- Shared local-node support via mocha root hooks. New `localNode`
-  option on `LocalTestOptions` lets `Harness.createLocal()` and
-  `setupTestFixture()` reuse a pre-started `LocalNodeManager`
-  instead of spawning a new one per test file. `movehat init` now
-  scaffolds a `tests/setup.ts` root hooks file that starts one
-  Movement node for the entire test suite and stops it at the end.
-  `Harness.cleanup()` is ownership-aware: when the node was injected
-  via `localNode`, cleanup poisons the harness but does not stop the
-  shared node. Reduces test-suite wall-clock time by ~23% for 3
-  specs (~65s -> ~50s), scaling to ~50%+ at 10+ specs. Closes #235.
-
-### Changed
-
-- M9.4 (PR #290 — AccountManager static-facade removal) reverted.
-  The static facade remains deprecated-but-functional indefinitely.
-  Users see a once-per-method `logger.warning` pointing to
-  `harness.accounts.<label>` / `harness.runtime.accountManager.*`
-  but existing code continues to work without migration. No 0.3.0
-  BREAKING release is planned. Closes #289.
 
 ## [0.2.7] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- mvlite auto-spawn integration. `Harness.createLocal()` and
+- movelite auto-spawn integration. `Harness.createLocal()` and
   `setupTestFixture()` automatically detect and use
-  [mvlite](https://github.com/gilbertsahumada/mvlite) if the binary
+  [movelite](https://github.com/gilbertsahumada/movelite) if the binary
   is available, reducing test boot time from ~15s to <1s. Falls back
-  to the full Movement node if mvlite is not installed. Opt out with
-  `useMvlite: false` in `LocalTestOptions`. Closes #192.
+  to the full Movement node if movelite is not installed. Opt out with
+  `useMovelite: false` in `LocalTestOptions`. Closes #192.
 
-- `mvlite` declared as an `optionalDependency`. `npm install movehat`
-  now also downloads the matching `mvlite-<platform>` binary
-  (via mvlite's own optional dependencies on its platform packages),
+- `movelite` declared as an `optionalDependency`. `npm install movehat`
+  now also downloads the matching `movelite-<platform>` binary
+  (via movelite's own optional dependencies on its platform packages),
   so the auto-spawn path above activates without a separate manual
   install step. Supported platforms: macOS arm64/x64, Linux x64/arm64.
   Unsupported platforms (e.g. Windows) install movehat cleanly and

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -70,6 +70,9 @@
     "prompts": "^2.4.2",
     "tsx": "^4.7.0"
   },
+  "optionalDependencies": {
+    "mvlite": "^0.1.0"
+  },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.10.1",

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -71,7 +71,7 @@
     "tsx": "^4.7.0"
   },
   "optionalDependencies": {
-    "mvlite": "^0.1.0"
+    "movelite": "^0.1.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/movehat/src/helpers/index.ts
+++ b/packages/movehat/src/helpers/index.ts
@@ -26,7 +26,7 @@ export { AccountManager } from "../core/AccountManager.js";
 export type { StoredAccount } from "../core/AccountManager.js";
 export { LocalNodeManager } from "../node/LocalNodeManager.js";
 export type { LocalNodeOptions, LocalNodeInfo } from "../node/LocalNodeManager.js";
-export { MvliteManager, findMvliteBinary } from "../node/MvliteManager.js";
+export { MoveliteManager, findMoveliteBinary } from "../node/MoveliteManager.js";
 export { setupLocalTesting } from "./setupLocalTesting.js";
 export type { LocalTestingContext } from "./setupLocalTesting.js";
 export {

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -6,7 +6,7 @@ import { ForkManager } from "../fork/manager.js";
 import { ForkServer } from "../fork/server.js";
 import { LocalNodeManager } from "../node/LocalNodeManager.js";
 import type { LocalNodeInfo } from "../node/LocalNodeManager.js";
-import { MvliteManager, findMvliteBinary } from "../node/MvliteManager.js";
+import { MoveliteManager, findMoveliteBinary } from "../node/MoveliteManager.js";
 import type { NodeProvider } from "../node/NodeProvider.js";
 import { AccountManager } from "../core/AccountManager.js";
 import { logger } from "../ui/index.js";
@@ -159,8 +159,8 @@ async function setupWithLocalNode(
       );
     }
     nodeInfo = localNode.getNodeInfo();
-  } else if (options.useMvlite !== false && findMvliteBinary()) {
-    localNode = new MvliteManager(findMvliteBinary()!);
+  } else if (options.useMovelite !== false && findMoveliteBinary()) {
+    localNode = new MoveliteManager(findMoveliteBinary()!);
     nodeInfo = await localNode.start();
     ownsNode = true;
   } else {

--- a/packages/movehat/src/node/MoveliteManager.ts
+++ b/packages/movehat/src/node/MoveliteManager.ts
@@ -150,8 +150,14 @@ export function findMoveliteBinary(): string | null {
   const pkg = platforms[key];
   if (pkg) {
     try {
+      // Resolve through the `movelite` shim (movehat's direct dependency),
+      // then resolve the platform package from movelite's own context. The
+      // platform package is movelite's dependency, not movehat's, so a direct
+      // resolve from here fails under pnpm/yarn strict layouts.
       const req = createRequire(import.meta.url);
-      const pkgPath = req.resolve(`${pkg}/package.json`);
+      const movelitePkg = req.resolve("movelite/package.json");
+      const moveliteReq = createRequire(movelitePkg);
+      const pkgPath = moveliteReq.resolve(`${pkg}/package.json`);
       const binPath = join(pkgPath, "..", "bin", "movelite");
       if (existsSync(binPath)) return binPath;
     } catch {

--- a/packages/movehat/src/node/MoveliteManager.ts
+++ b/packages/movehat/src/node/MoveliteManager.ts
@@ -6,7 +6,7 @@ import type { Account } from "@aptos-labs/ts-sdk";
 import type { LocalNodeInfo } from "./LocalNodeManager.js";
 import { logger } from "../ui/index.js";
 
-export class MvliteManager {
+export class MoveliteManager {
   private process: ChildProcess | null = null;
   private port: number;
   private killed = false;
@@ -20,7 +20,7 @@ export class MvliteManager {
   async start(): Promise<LocalNodeInfo> {
     const binary = this.binaryPath;
     if (!binary) {
-      throw new Error("mvlite binary not found");
+      throw new Error("movelite binary not found");
     }
 
     if (await this.isPortInUse(this.port)) {
@@ -30,19 +30,23 @@ export class MvliteManager {
       }
     }
 
-    logger.step("Starting mvlite...");
+    logger.step("Starting movelite...");
 
-    this.process = spawn(binary, ["start", "--port", String(this.port)], {
-      stdio: "pipe",
-      detached: false,
-    });
+    this.process = spawn(
+      binary,
+      ["start", "--port", String(this.port), "--no-auth"],
+      {
+        stdio: "pipe",
+        detached: false,
+      },
+    );
 
     this.process.on("exit", () => {
       this.process = null;
     });
 
     await this.waitForReady();
-    logger.success(`mvlite ready on port ${this.port}`);
+    logger.success(`movelite ready on port ${this.port}`);
 
     return this.getNodeInfo();
   }
@@ -62,7 +66,7 @@ export class MvliteManager {
       await new Promise((r) => setTimeout(r, 200));
     }
 
-    throw new Error(`mvlite did not become ready within ${timeout}ms`);
+    throw new Error(`movelite did not become ready within ${timeout}ms`);
   }
 
   async fundAccount(address: string, amount: number): Promise<void> {
@@ -128,18 +132,18 @@ export class MvliteManager {
   }
 }
 
-export function findMvliteBinary(): string | null {
-  if (process.env.MVLITE_PATH) {
-    return existsSync(process.env.MVLITE_PATH)
-      ? process.env.MVLITE_PATH
+export function findMoveliteBinary(): string | null {
+  if (process.env.MOVELITE_PATH) {
+    return existsSync(process.env.MOVELITE_PATH)
+      ? process.env.MOVELITE_PATH
       : null;
   }
 
   const platforms: Record<string, string> = {
-    "darwin-arm64": "mvlite-darwin-arm64",
-    "darwin-x64": "mvlite-darwin-x64",
-    "linux-x64": "mvlite-linux-x64",
-    "linux-arm64": "mvlite-linux-arm64",
+    "darwin-arm64": "movelite-darwin-arm64",
+    "darwin-x64": "movelite-darwin-x64",
+    "linux-x64": "movelite-linux-x64",
+    "linux-arm64": "movelite-linux-arm64",
   };
 
   const key = `${process.platform}-${process.arch}`;
@@ -148,7 +152,7 @@ export function findMvliteBinary(): string | null {
     try {
       const req = createRequire(import.meta.url);
       const pkgPath = req.resolve(`${pkg}/package.json`);
-      const binPath = join(pkgPath, "..", "bin", "mvlite");
+      const binPath = join(pkgPath, "..", "bin", "movelite");
       if (existsSync(binPath)) return binPath;
     } catch {
       // package not installed
@@ -156,7 +160,7 @@ export function findMvliteBinary(): string | null {
   }
 
   try {
-    const found = execSync("which mvlite", { encoding: "utf-8" }).trim();
+    const found = execSync("which movelite", { encoding: "utf-8" }).trim();
     if (found && existsSync(found)) return found;
   } catch {
     // not in PATH

--- a/packages/movehat/src/types/config.ts
+++ b/packages/movehat/src/types/config.ts
@@ -48,7 +48,7 @@ export interface LocalTestOptions {
 
     // Shared node (when mode='local-node')
     localNode?: import("../node/LocalNodeManager.js").LocalNodeManager; // Pre-started node to reuse; skips spawn when provided
-    useMvlite?: boolean;                // Try mvlite before Movement node (default: true)
+    useMovelite?: boolean;              // Try movelite before Movement node (default: true)
 
     // Local Node options (when mode='local-node')
     nodeTestDir?: string;               // Directory for node data (default: .movehat/local-node)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,10 @@ importers:
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
+    optionalDependencies:
+      movelite:
+        specifier: ^0.1.0
+        version: 0.1.0
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -2672,6 +2676,15 @@ packages:
   mocha@11.7.5:
     resolution: {integrity: sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+
+  movelite-darwin-arm64@0.1.0:
+    resolution: {integrity: sha512-qE7u6pHRwNwWjjkxTwzSBX0kQlUnoy/vDbJNceYtoU+qXCZ7Fd/1pP27R1DUyyAsKtVZq2rkB7MkuFd37K0mMw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  movelite@0.1.0:
+    resolution: {integrity: sha512-hk4k5QD7V5K1p/CieRMgU8/b8p2zjz0FQTd+g06nz2lU20+o90o359Z4ujVom7DxFCDLhNtOV4HIyf6Uf06CSA==}
     hasBin: true
 
   ms@2.1.3:
@@ -5994,6 +6007,14 @@ snapshots:
       yargs: 17.7.2
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
+
+  movelite-darwin-arm64@0.1.0:
+    optional: true
+
+  movelite@0.1.0:
+    optionalDependencies:
+      movelite-darwin-arm64: 0.1.0
+    optional: true
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
Batch release 0.2.8 — everything merged to develop since 0.2.7.

## Headline: movelite integration
- Auto-spawn: `Harness.createLocal()` / `setupTestFixture()` detect a local [movelite](https://github.com/gilbertsahumada/movelite) binary and use it (boot <1s) instead of the Movement node, falling back gracefully when absent (#192).
- `movelite` declared as `optionalDependency`; `npm install movehat` pulls the matching platform binary automatically (#300). pnpm two-hop resolution fix so it works under strict layouts.
- Spawns movelite with `--no-auth` (movelite 0.1.0 gates /mint behind a token by default).

## Also in this batch
- Shared local-node via mocha root hooks (#235)
- M9.4 AccountManager static-facade-removal reverted; facade stays deprecated-but-functional (#289)
- Fork/storage runtime validation at every boundary (#111)
- `movehat compile` Move.toml auto-update docs (#212)
- console UX §9 migration completed (#223)

## Verification (per §6.3 — Tier 3 mandatory for batch)
- `pnpm check:example` (Tier 1): PASS
- `pnpm --filter movehat test`: 560/560
- `pnpm test:e2e` (Tier 3): **34/34 in 86s**
- movelite integration verified end-to-end against published movelite@0.1.0 (findBinary resolves, spawn/ready/fund/stop clean)
- `node scripts/check-changelog.js`: PASS for 0.2.8

## Platform status (movelite)
- macOS arm64: movelite published → fast-boot live
- Linux / macOS x64: binaries built (artifacts), publish pending (follow-up; movehat falls back to Movement node meanwhile)
- Windows: Movement-node fallback (aptos-core doesn't build on Windows)

## Publish
On merge + GitHub release `v0.2.8`, `publish.yml` ships movehat@0.2.8 to npm via Trusted Publishers (tokenless + provenance).

Closes #111, #192, #212, #223, #235, #289, #300.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.2.8

* **New Features**
  * Added optional dependency for automatic platform binary downloading, enabling lightweight runtime support without manual installation.

* **Changed**
  * Renamed lightweight runtime implementation; updated configuration option naming accordingly.
  * Improved binary resolution and startup error handling with fallback support on unsupported platforms.

* **Documentation**
  * Updated changelog with implementation details and feature descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilbertsahumada/movehat/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->