### PR TITLE
release: 0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-06-01
+
 ### Fixed
 
 - movelite auto-deploy now works. The 0.2.8 fast-boot path spawned movelite

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {


### PR DESCRIPTION
## Release 0.2.9

Moves `[Unreleased]` → `[0.2.9] - 2026-06-01` and bumps `packages/movehat/package.json` (0.2.8 → 0.2.9). Pure release prep — no code changes.

### Shipped since 0.2.8

- **Fix (#305):** movelite auto-deploy now works. The 0.2.8 fast-boot path spawned movelite but could not deploy onto it — `autoDeploy` published via the Movement CLI, which can't consume movelite's REST responses. `Publisher` now publishes via `@aptos-labs/ts-sdk` when the backend is movelite; CLI path unchanged for real nodes/forks/testnet.
- **Tests (#302):** backend-assertion gate (`scripts/assert-backend.sh`) guarding the fast-boot promise against a silent regression to the slow Movement node.
- Docs for movelite fast boot; SDK-path unit coverage (`Publisher.ts` 62% → 89%).

### Verification
- `check-changelog.js`: section for 0.2.9 present.
- `pnpm --filter movehat test`: 563 passing.
- `pnpm test:e2e` (Tier-3): **34/34 passing**.
- `pnpm typecheck:example`: clean.

Next: `develop → main` batch PR, then a `v0.2.9` GitHub Release triggers the npm publish (`publish.yml`, Trusted Publishers + provenance).