### PR TITLE
ci: movelite backend gate on Linux + Node 24 opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Opt the pinned JS actions into the Node 24 runtime ahead of GitHub's
+# 2026-06-16 forced switch (the actions still run on Node 20 otherwise and
+# emit deprecation warnings). This is GitHub's recommended opt-in; it does not
+# change the action versions, so there is no breaking-change risk.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Build and type check
   build:
@@ -151,7 +158,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [build, unit-tests]
-    timeout-minutes: 5
+    timeout-minutes: 12
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
@@ -255,6 +262,17 @@ jobs:
             echo "::error::Integration suite contains vi.mock or vi.spyOn — zero-mock invariant violated."
             exit 1
           fi
+
+      - name: movelite backend gate (#302)
+        # First time the example's deploy loop runs on Linux CI: the full
+        # Movement node can't start here (MintFunder bug — see MOVEHAT_SKIP_LOCAL_NODE
+        # above), but movelite can. pnpm install pulled movelite-linux-x64
+        # (movehat's optionalDependency); this asserts it spawns and deploys
+        # via the SDK path. The Movement CLI installed above provides the
+        # `movement move build` compile step.
+        run: MOVEHAT_EXPECT_BACKEND=movelite pnpm assert-backend
+        env:
+          MOVEMENT_RPC_URL: https://testnet.movementnetwork.xyz/v1
 
   # Code quality checks
   quality:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -11,6 +11,11 @@ on:
       - '.github/workflows/docs-deploy.yml'
   workflow_dispatch:
 
+# Opt the pinned JS actions into the Node 24 runtime ahead of GitHub's
+# 2026-06-16 forced switch. GitHub's recommended opt-in; no version change.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # Allow only one concurrent deployment, skipping older queued runs.
 concurrency:
   group: 'docs-deploy'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,12 @@ on:
         required: true
         type: string
 
+# Opt the pinned JS actions into the Node 24 runtime ahead of GitHub's
+# 2026-06-16 forced switch. GitHub's recommended opt-in; no version change,
+# so no breaking-change risk to the publish pipeline.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -39,5 +39,11 @@
     "@commitlint/cli": "^21.0.0",
     "@commitlint/config-conventional": "^21.0.0",
     "husky": "^9.1.7"
+  },
+  "pnpm": {
+    "supportedArchitectures": {
+      "os": ["darwin", "linux"],
+      "cpu": ["x64", "arm64"]
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1558,8 +1558,8 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/http-cache-semantics@4.0.4':
-    resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
@@ -1581,6 +1581,9 @@ packages:
 
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
+
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
@@ -2683,6 +2686,16 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  movelite-linux-arm64@0.1.0:
+    resolution: {integrity: sha512-NDReuGtDZROh5uRXSbnbGQ99/KkE+RbRs0wRQ25i/gtTcd9XiaawL793S1DNCImJKvGZ/C/lt2W+YVV0RehEwg==}
+    cpu: [arm64]
+    os: [linux]
+
+  movelite-linux-x64@0.1.0:
+    resolution: {integrity: sha512-Pw1exAJ3tk1fQTeEdAA/qpn4b7sI1LtLHU3ixQsTc1LKYOSeACjIe9KpJdhriUKqdnRgp7UEVh7v9DBLBxyklg==}
+    cpu: [x64]
+    os: [linux]
+
   movelite@0.1.0:
     resolution: {integrity: sha512-hk4k5QD7V5K1p/CieRMgU8/b8p2zjz0FQTd+g06nz2lU20+o90o359Z4ujVom7DxFCDLhNtOV4HIyf6Uf06CSA==}
     hasBin: true
@@ -2827,8 +2840,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  pump@3.0.3:
-    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -4549,9 +4562,9 @@ snapshots:
 
   '@types/cacheable-request@6.0.3':
     dependencies:
-      '@types/http-cache-semantics': 4.0.4
+      '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 24.10.1
+      '@types/node': 24.12.4
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -4575,13 +4588,13 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/http-cache-semantics@4.0.4': {}
+  '@types/http-cache-semantics@4.2.0': {}
 
   '@types/js-yaml@4.0.9': {}
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 24.12.4
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -4594,6 +4607,10 @@ snapshots:
   '@types/ms@2.1.0': {}
 
   '@types/node@24.10.1':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/node@24.12.4':
     dependencies:
       undici-types: 7.16.0
 
@@ -4612,7 +4629,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 24.12.4
 
   '@types/unist@2.0.11': {}
 
@@ -5192,7 +5209,7 @@ snapshots:
 
   get-stream@5.2.0:
     dependencies:
-      pump: 3.0.3
+      pump: 3.0.4
 
   get-tsconfig@4.13.0:
     dependencies:
@@ -6011,9 +6028,17 @@ snapshots:
   movelite-darwin-arm64@0.1.0:
     optional: true
 
+  movelite-linux-arm64@0.1.0:
+    optional: true
+
+  movelite-linux-x64@0.1.0:
+    optional: true
+
   movelite@0.1.0:
     optionalDependencies:
       movelite-darwin-arm64: 0.1.0
+      movelite-linux-arm64: 0.1.0
+      movelite-linux-x64: 0.1.0
     optional: true
 
   ms@2.1.3: {}
@@ -6160,7 +6185,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  pump@3.0.3:
+  pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0


### PR DESCRIPTION
## What

- **#3 — movelite gate in CI:** a step in the `e2e-tests` job runs `MOVEHAT_EXPECT_BACKEND=movelite pnpm assert-backend` on ubuntu. First time the example's deploy loop runs on Linux CI — the full Movement node can't start there (MintFunder bug, hence `MOVEHAT_SKIP_LOCAL_NODE`), but movelite can. Reuses the job's Movement CLI (for the `movement move build` compile step) instead of duplicating ~80 lines.
- **#4 — Node 24 opt-in:** `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on `ci.yml` / `publish.yml` / `docs-deploy.yml`. GitHub's recommended opt-in ahead of the 2026-06-16 forced switch — no action-version change, so no breaking-change risk to the publish pipeline.
- **Cross-platform lockfile:** `pnpm.supportedArchitectures` (darwin + linux, x64 + arm64) + `pnpm update movelite` so the lockfile carries `movelite-linux-x64`. Without this the gate fell back to the Movement node and timed out — the lockfile's `movelite@0.1.0` snapshot predated the Linux packages' publication.

## Verification

Dispatched `ci.yml` on this branch (run 26766277272) — **all jobs green**, including:
```
movelite backend gate (#302): success
  ✓ Backend matched: 'movelite'
  ✓ Boot within budget: 6355ms <= 20000ms
```
Every job ran with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` — no Node 20 deprecation warnings, nothing broke.

Tracks #302.