### PR TITLE
chore: bump bundled movelite optional dep to ^0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- Bump the bundled `movelite` optional dependency from `^0.1.0` to `^0.2.0`.
+  The 0.2.0 binary adds the `POST /v1/transactions/trace` endpoint that the
+  upcoming Foundry-style trace renderer will consume; bumping the dependency
+  makes that endpoint reachable through the published package. No user-visible
+  behavior change in this PR — local boot, fallback, and the existing API
+  behave identically; the trace renderer lands separately.
+
 ## [0.2.9] - 2026-06-01
 
 ### Fixed

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -71,7 +71,7 @@
     "tsx": "^4.7.0"
   },
   "optionalDependencies": {
-    "movelite": "^0.1.0"
+    "movelite": "^0.2.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.0.0
-        version: 21.0.0(@types/node@24.10.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+        version: 21.0.0(@types/node@24.12.4)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
       '@commitlint/config-conventional':
         specifier: ^21.0.0
         version: 21.0.0
@@ -62,7 +62,7 @@ importers:
         version: 15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-mdx:
         specifier: ^14.2.5
-        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
+        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       fumadocs-ui:
         specifier: ^15.6.12
         version: 15.8.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
@@ -129,8 +129,8 @@ importers:
         version: 4.21.0
     optionalDependencies:
       movelite:
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.2.0
+        version: 0.2.0
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -1585,6 +1585,9 @@ packages:
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
+  '@types/node@24.13.1':
+    resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
+
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
 
@@ -2681,23 +2684,28 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
-  movelite-darwin-arm64@0.1.0:
-    resolution: {integrity: sha512-qE7u6pHRwNwWjjkxTwzSBX0kQlUnoy/vDbJNceYtoU+qXCZ7Fd/1pP27R1DUyyAsKtVZq2rkB7MkuFd37K0mMw==}
+  movelite-darwin-arm64@0.2.0:
+    resolution: {integrity: sha512-kAwcGbl0UA8WOX8YkftDEDFub599qLknRAX64AQT8xA+Gp3gUtWhAKktc9q+oGV3ZhYEl562JN9QxqEhspokAA==}
     cpu: [arm64]
     os: [darwin]
 
-  movelite-linux-arm64@0.1.0:
-    resolution: {integrity: sha512-NDReuGtDZROh5uRXSbnbGQ99/KkE+RbRs0wRQ25i/gtTcd9XiaawL793S1DNCImJKvGZ/C/lt2W+YVV0RehEwg==}
+  movelite-darwin-x64@0.2.0:
+    resolution: {integrity: sha512-TXYAZcm2N/IE+ZdMh3vNg/1oAgTAW6UTql9TVc3PNBeZGRambi1OTpd3Id0kTINvq16T7bacwbpwmgzOHpWwPw==}
+    cpu: [x64]
+    os: [darwin]
+
+  movelite-linux-arm64@0.2.0:
+    resolution: {integrity: sha512-xE0ZLR9vaB6eyvzHsSVA6+oRIyjCYGys/OryNMXV1lR9gix6THVdcoW8qsHrjfj+ndPC+T55ZuQsFA/csjmMgA==}
     cpu: [arm64]
     os: [linux]
 
-  movelite-linux-x64@0.1.0:
-    resolution: {integrity: sha512-Pw1exAJ3tk1fQTeEdAA/qpn4b7sI1LtLHU3ixQsTc1LKYOSeACjIe9KpJdhriUKqdnRgp7UEVh7v9DBLBxyklg==}
+  movelite-linux-x64@0.2.0:
+    resolution: {integrity: sha512-BvI+Zs6yw5iZwK+FEZVX6JBziQhwHcb4Pxs0kOXXdSj2D8tRzZVQuKkc3VLLzNDr6akzW4+6JcEo6ZEHt0UL4g==}
     cpu: [x64]
     os: [linux]
 
-  movelite@0.1.0:
-    resolution: {integrity: sha512-hk4k5QD7V5K1p/CieRMgU8/b8p2zjz0FQTd+g06nz2lU20+o90o359Z4ujVom7DxFCDLhNtOV4HIyf6Uf06CSA==}
+  movelite@0.2.0:
+    resolution: {integrity: sha512-AEc6EfM1B66wNMJmizqVs91HP2X14DZQ1o/VzqHzJK8dF9KX/GvYG04lDqVtTrSLL4dngJnxHfz8X0Hwjae0jQ==}
     hasBin: true
 
   ms@2.1.3:
@@ -3181,6 +3189,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -3430,11 +3441,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@21.0.0(@types/node@24.10.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+  '@commitlint/cli@21.0.0(@types/node@24.12.4)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 21.0.0
       '@commitlint/lint': 21.0.0
-      '@commitlint/load': 21.0.0(@types/node@24.10.1)(typescript@5.9.3)
+      '@commitlint/load': 21.0.0(@types/node@24.12.4)(typescript@5.9.3)
       '@commitlint/read': 21.0.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 21.0.0
       tinyexec: 1.0.2
@@ -3479,14 +3490,14 @@ snapshots:
       '@commitlint/rules': 21.0.0
       '@commitlint/types': 21.0.0
 
-  '@commitlint/load@21.0.0(@types/node@24.10.1)(typescript@5.9.3)':
+  '@commitlint/load@21.0.0(@types/node@24.12.4)(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 21.0.0
       '@commitlint/execute-rule': 21.0.0
       '@commitlint/resolve-extends': 21.0.0
       '@commitlint/types': 21.0.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.10.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.12.4)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
       es-toolkit: 1.46.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -4564,7 +4575,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -4594,7 +4605,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -4614,6 +4625,10 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/node@24.13.1':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/prompts@2.4.9':
     dependencies:
       '@types/node': 24.10.1
@@ -4629,7 +4644,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
 
   '@types/unist@2.0.11': {}
 
@@ -4865,9 +4880,9 @@ snapshots:
       '@simple-libs/stream-utils': 1.2.0
       meow: 13.2.0
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@24.10.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@24.12.4)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 24.12.4
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
@@ -5133,7 +5148,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
+  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -5160,7 +5175,7 @@ snapshots:
       mdast-util-mdx-jsx: 3.2.0
       next: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6025,20 +6040,24 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
-  movelite-darwin-arm64@0.1.0:
+  movelite-darwin-arm64@0.2.0:
     optional: true
 
-  movelite-linux-arm64@0.1.0:
+  movelite-darwin-x64@0.2.0:
     optional: true
 
-  movelite-linux-x64@0.1.0:
+  movelite-linux-arm64@0.2.0:
     optional: true
 
-  movelite@0.1.0:
+  movelite-linux-x64@0.2.0:
+    optional: true
+
+  movelite@0.2.0:
     optionalDependencies:
-      movelite-darwin-arm64: 0.1.0
-      movelite-linux-arm64: 0.1.0
-      movelite-linux-x64: 0.1.0
+      movelite-darwin-arm64: 0.2.0
+      movelite-darwin-x64: 0.2.0
+      movelite-linux-arm64: 0.2.0
+      movelite-linux-x64: 0.2.0
     optional: true
 
   ms@2.1.3: {}
@@ -6587,6 +6606,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici-types@7.18.2: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -6671,6 +6692,23 @@ snapshots:
       lightningcss: 1.30.2
       tsx: 4.21.0
       yaml: 2.9.0
+
+  vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.27.0
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.12.4
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      tsx: 4.21.0
+      yaml: 2.9.0
+    optional: true
 
   vitest@4.0.16(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
## What

Bumps the `movelite` optional dependency in `packages/movehat/package.json` from `^0.1.0` to `^0.2.0`, and regenerates `pnpm-lock.yaml`.

The movelite 0.2.0 shim and all four platform binaries (`darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`) are published on npm with matching `optionalDependencies` pins. The 0.2.0 binary exposes `POST /v1/transactions/trace` — the endpoint the upcoming Foundry-style trace renderer will consume. Bumping the dependency is the prerequisite that makes that endpoint reachable through the published movehat package.

## Why now

`^0.1.0` resolves to `>=0.1.0 <0.2.0`, so consumers would never receive the 0.2.0 binary (and thus the trace endpoint) without this bump. Now that the shim 0.2.0 is on npm, the bump is safe to merge — it does not break install on any platform (optional dep, graceful fallback unchanged).

## Scope / no behavior change

No user-visible behavior change in this PR: local boot, Movement-node fallback, and the existing API behave identically. The trace renderer (verbosity-by-level + indented call tree) lands in a separate follow-up PR that wires `contract.ts` to the new endpoint.

## Lockfile note

`pnpm update movelite` also refreshed `@types/node` `24.10.1` -> `24.12.4` within its existing `^24.10.1` range (dev-only, semver-compatible). Benign re-resolution churn; no runtime dependency changed besides movelite and its transitives.

## Verification

- `pnpm check:example` (Tier-1: `build:movehat` + `typecheck:example`) — pass.
- Installed shim verified `movelite@0.2.0`; binary `movelite-darwin-arm64@0.2.0` resolved in the pnpm store.
- Published chain re-verified live: `npm view movelite version` = `0.2.0`, optionalDeps all `0.2.0`.

Tier 2 / Tier 3: N/A — no `src/**`, `bin/**`, or template files touched; this is a dependency-spec + lockfile change only.

## Changelog

`[Unreleased]` -> `### Internal` entry added (per the CHANGELOG model).

No linked issue: this is a prerequisite chore for the not-yet-ticketed trace feature.