### PR TITLE
feat: counted -v verbosity levels + getVerbosityLevel (traces PR1a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The global `-v` / `--verbose` flag is now **counted**: repeat it to raise the
+  verbosity level (`-v` … `-vvvv` → levels 1–4). Level 1 is unchanged — it
+  surfaces subprocess output exactly as before, and `MOVEHAT_VERBOSE=1` remains
+  its shorthand. The higher levels are reserved for the forthcoming movelite
+  transaction-trace renderer (decoded events at 2, the call tree at 3–4). A new
+  `MOVEHAT_VERBOSITY=<0-4>` env var sets the level directly and propagates across
+  the spawned test/script subprocess boundary. `isVerbose()` and its callers are
+  unaffected. Closes #316.
+
 ### Fixed
 
 - Restore tracking of `MAINTENANCE.md`, which was inadvertently untracked

--- a/packages/docs/content/docs/cli/global-flags.mdx
+++ b/packages/docs/content/docs/cli/global-flags.mdx
@@ -8,17 +8,27 @@ These flags are available on every `movehat` command. Pass them before or after 
 
 ## `-v`, `--verbose`
 
-Surface subprocess output that Movehat hides by default.
+`-v` is **counted** — repeat it to raise the verbosity level. Each level is additive on top of the previous one.
 
 ```bash
-movehat test --ts          # quiet (default)
-movehat test --ts -v       # surface all subprocess output
-MOVEHAT_VERBOSE=1 movehat test --ts   # equivalent — useful in scripts
+movehat test --ts          # L0 quiet (default)
+movehat test --ts -v       # L1 + subprocess output
+movehat test --ts -vv      # L2 + decoded events per transaction
+movehat test --ts -vvv     # L3 + the call tree of your own modules
+movehat test --ts -vvvv    # L4 + framework frames, natives, storage, return values
 ```
 
-By default Movehat hides routine chatter from the `movement node run-localnet` and `aptos move build / publish` subprocesses to keep the console readable. With `-v` enabled, every line from those processes is printed with a muted gray `›` prefix so you can see exactly what they're doing.
+| Level | Flag | Adds |
+|---|---|---|
+| 0 | _(none)_ | System logs only — the default quiet console. |
+| 1 | `-v` | Subprocess output from `movement node run-localnet` and `aptos move build / publish`, printed with a muted gray `›` prefix. |
+| 2 | `-vv` | A decoded list of the events each `contract.call(...)` emitted. |
+| 3 | `-vvv` | A Foundry-style execution trace showing the call tree of **your** modules (framework `0x1::*` frames filtered out). |
+| 4 | `-vvvv` | The full trace: framework frames, native calls, storage operations, and return values. |
 
-When to reach for `-v`:
+Levels 2–4 render execution traces, which are a **[movelite](/docs/guides/movelite)-only** capability — they require the trace endpoint the lightweight local runtime exposes. On the full Movement node the same flags still raise subprocess verbosity (level 1), but no call tree is rendered. See [Transaction traces](/docs/guides/traces) for the full output format.
+
+When to reach for level 1 (`-v`):
 
 - The local node fails to start and the spinner times out — `-v` reveals what `movement` is saying.
 - `aptos move build` is slow on a fresh clone — `-v` shows the git-dependency download progress.
@@ -51,8 +61,11 @@ Useful when your Move source changed but the local node's deployment cache still
 
 | Variable | Equivalent flag | Purpose |
 |---|---|---|
-| `MOVEHAT_VERBOSE=1` | `-v` / `--verbose` | Surface subprocess output |
+| `MOVEHAT_VERBOSE=1` | `-v` / `--verbose` | Surface subprocess output (level 1) |
+| `MOVEHAT_VERBOSITY=<0-4>` | `-v` … `-vvvv` | Set the exact verbosity level, including the trace levels (2–4) |
 | `MOVEHAT_NETWORK=<name>` | `--network <name>` | Default network for this shell |
 | `NO_COLOR=1` | — | Disable all ANSI colors and spinners |
+
+`MOVEHAT_VERBOSE=1` remains the level-1 shorthand. `MOVEHAT_VERBOSITY` sets the precise level and takes precedence — useful in scripts or CI that want trace output without passing repeated flags.
 
 `NO_COLOR=1` and non-TTY output (pipes, CI) auto-degrade gracefully — spinners disable, no carriage-return rewrites, output stays line-based and grep-friendly.

--- a/packages/docs/content/docs/guides/console-output.mdx
+++ b/packages/docs/content/docs/guides/console-output.mdx
@@ -68,6 +68,20 @@ movehat test --ts
 
 With verbose enabled, subprocess output prints with a muted gray `›` prefix so it visually separates from Movehat's own lines.
 
+### Verbosity levels
+
+`-v` is counted — repeating it raises the level, and each level is additive:
+
+| Level | Flag | Adds |
+|---|---|---|
+| 0 | _(none)_ | System logs only (the default). |
+| 1 | `-v` | Subprocess output (gray `›` prefix). |
+| 2 | `-vv` | A decoded list of the events each `contract.call(...)` emitted. |
+| 3 | `-vvv` | A Foundry-style call tree of your own modules. |
+| 4 | `-vvvv` | The full trace — framework frames, natives, storage, return values. |
+
+Levels 2–4 render execution traces and only do so on the [movelite](/docs/guides/movelite) backend; see [Transaction traces](/docs/guides/traces). `MOVEHAT_VERBOSITY=<0-4>` sets the level directly without repeating flags.
+
 ## Critical signals always surface
 
 Movehat never silences a real failure. Lines matching these patterns reach your terminal regardless of verbosity:

--- a/packages/movehat/src/cli.ts
+++ b/packages/movehat/src/cli.ts
@@ -50,7 +50,12 @@ program
   .version(version)
   .option('--network <name>', 'Network to use (testnet, mainnet, local, etc.)')
   .option('--redeploy', 'Force redeploy even if already deployed')
-  .option('-v, --verbose', 'Show subprocess output (movement node, aptos move) for debugging')
+  .option(
+    '-v, --verbose',
+    'Increase output verbosity (repeatable: -v subprocess output, -vv..-vvvv transaction traces on movelite)',
+    (_value: string, previous: number) => previous + 1,
+    0
+  )
   .hook('preAction', (thisCommand) => {
     // Store network option in environment for commands to access
     const options = thisCommand.opts();
@@ -60,8 +65,13 @@ program
     if (options.redeploy) {
       process.env.MH_CLI_REDEPLOY = 'true';
     }
-    if (options.verbose) {
+    // `-v` is counted (0..4). Level >= 1 keeps the legacy MOVEHAT_VERBOSE=1
+    // contract (isVerbose + its callers); MOVEHAT_VERBOSITY carries the
+    // numeric level across the spawned test/script subprocess boundary.
+    const level: number = options.verbose ?? 0;
+    if (level >= 1) {
       process.env.MOVEHAT_VERBOSE = '1';
+      process.env.MOVEHAT_VERBOSITY = String(level);
     }
   });
 

--- a/packages/movehat/src/ui/__tests__/logger.test.ts
+++ b/packages/movehat/src/ui/__tests__/logger.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { configureLogger, isVerbose, divider, phase } from "../logger.js";
+import {
+  configureLogger,
+  isVerbose,
+  getVerbosityLevel,
+  divider,
+  phase,
+} from "../logger.js";
 
 describe("logger — verbosity", () => {
   let originalEnv: string | undefined;
@@ -46,6 +52,62 @@ describe("logger — verbosity", () => {
     expect(isVerbose()).toBe(false);
     process.env.MOVEHAT_VERBOSE = "0";
     expect(isVerbose()).toBe(false);
+  });
+});
+
+describe("logger — getVerbosityLevel", () => {
+  let origLevel: string | undefined;
+  let origVerbose: string | undefined;
+
+  beforeEach(() => {
+    origLevel = process.env.MOVEHAT_VERBOSITY;
+    origVerbose = process.env.MOVEHAT_VERBOSE;
+    delete process.env.MOVEHAT_VERBOSITY;
+    delete process.env.MOVEHAT_VERBOSE;
+  });
+
+  afterEach(() => {
+    if (origLevel === undefined) delete process.env.MOVEHAT_VERBOSITY;
+    else process.env.MOVEHAT_VERBOSITY = origLevel;
+    if (origVerbose === undefined) delete process.env.MOVEHAT_VERBOSE;
+    else process.env.MOVEHAT_VERBOSE = origVerbose;
+  });
+
+  it("defaults to 0 when neither env var is set", () => {
+    expect(getVerbosityLevel()).toBe(0);
+  });
+
+  it("reads the numeric level from MOVEHAT_VERBOSITY", () => {
+    for (const n of [0, 1, 2, 3, 4]) {
+      process.env.MOVEHAT_VERBOSITY = String(n);
+      expect(getVerbosityLevel()).toBe(n);
+    }
+  });
+
+  it("clamps out-of-range values into 0..4", () => {
+    process.env.MOVEHAT_VERBOSITY = "9";
+    expect(getVerbosityLevel()).toBe(4);
+    process.env.MOVEHAT_VERBOSITY = "-3";
+    expect(getVerbosityLevel()).toBe(0);
+  });
+
+  it("ignores a non-numeric MOVEHAT_VERBOSITY and falls through", () => {
+    process.env.MOVEHAT_VERBOSITY = "loud";
+    expect(getVerbosityLevel()).toBe(0);
+    process.env.MOVEHAT_VERBOSITY = "loud";
+    process.env.MOVEHAT_VERBOSE = "1";
+    expect(getVerbosityLevel()).toBe(1);
+  });
+
+  it("falls back to level 1 for the legacy MOVEHAT_VERBOSE=1 when MOVEHAT_VERBOSITY is unset", () => {
+    process.env.MOVEHAT_VERBOSE = "1";
+    expect(getVerbosityLevel()).toBe(1);
+  });
+
+  it("MOVEHAT_VERBOSITY takes precedence over the legacy MOVEHAT_VERBOSE", () => {
+    process.env.MOVEHAT_VERBOSE = "1";
+    process.env.MOVEHAT_VERBOSITY = "3";
+    expect(getVerbosityLevel()).toBe(3);
   });
 });
 

--- a/packages/movehat/src/ui/logger.ts
+++ b/packages/movehat/src/ui/logger.ts
@@ -48,6 +48,29 @@ export const isVerbose = (): boolean =>
   config.verbosity === 'verbose' || process.env.MOVEHAT_VERBOSE === '1';
 
 /**
+ * Numeric verbosity level (0..4) for level-gated output such as the
+ * transaction-trace renderer. Driven by the counted `-v` CLI flag via the
+ * `MOVEHAT_VERBOSITY` env var, so it survives the spawned test/script
+ * subprocess boundary the same way {@link isVerbose} reads `MOVEHAT_VERBOSE`.
+ * Falls back to the legacy boolean `MOVEHAT_VERBOSE=1` (level 1) for callers
+ * that set only that.
+ *
+ * - 0 default — system logs only
+ * - 1 `-v`    — + subprocess stdout (see {@link isVerbose})
+ * - 2 `-vv`   — + decoded events per call
+ * - 3 `-vvv`  — + user-module call tree
+ * - 4 `-vvvv` — + framework frames, natives, storage, return values
+ */
+export const getVerbosityLevel = (): number => {
+  const raw = process.env.MOVEHAT_VERBOSITY;
+  if (raw !== undefined) {
+    const n = parseInt(raw, 10);
+    if (!Number.isNaN(n)) return Math.max(0, Math.min(4, n));
+  }
+  return process.env.MOVEHAT_VERBOSE === '1' ? 1 : 0;
+};
+
+/**
  * Configure logger globally
  *
  * @param newConfig - Partial configuration to merge with current config
@@ -295,6 +318,7 @@ export const item = (text: string, indent: number = 0): void => {
 export const logger = {
   configure: configureLogger,
   isVerbose,
+  getVerbosityLevel,
   info,
   success,
   error,


### PR DESCRIPTION
Tracks #315. Closes #316. First of three sub-PRs for the movelite transaction-trace renderer.

## Summary

Foundational verbosity infrastructure — makes a numeric verbosity level (0–4) available so later PRs can gate trace rendering on it. **No trace rendering in this PR.**

- `cli.ts`: `-v/--verbose` becomes a **counted** Commander option (`-v`..`-vvvv` → 1..4). preAction keeps setting `MOVEHAT_VERBOSE=1` for level ≥ 1 (back-compat with `isVerbose()` + its ~10 callers) and additionally sets `MOVEHAT_VERBOSITY=<level>`.
- `logger.ts`: new `getVerbosityLevel(): number` — reads `MOVEHAT_VERBOSITY` (clamped 0–4), falling back to the legacy `MOVEHAT_VERBOSE=1` (level 1). `isVerbose()` and its callers untouched.
- Docs: `cli/global-flags.mdx` (counted `-v`, L0–L4 table, `MOVEHAT_VERBOSITY`) + `guides/console-output.mdx` (verbosity-levels subsection).

## Why env-var propagation

`contract.call()` runs inside the spawned mocha/script subprocess, so the level must travel via an env var (`MOVEHAT_VERBOSITY`) — the same reason `isVerbose()` reads `MOVEHAT_VERBOSE`. In-process logger config would never reach `call()` under `movehat test`.

## How tested

- `pnpm --filter movehat test` — 569/569 (6 new `getVerbosityLevel` tests: env→level, clamp, non-numeric, back-compat, precedence).
- Verified Commander counts occurrences: `-vvvv`→4, `-v -v -v`→3.
- `pnpm check:example` (Tier-1) green. `pnpm build:docs` clean.
- Tier 2 (§6.2): `cli.ts` is `src/**` but the change is the flag-parsing surface only (no runtime/packaging behavior touched); `test:example`/`test:smoke` N/A. The counted-flag behavior is covered by the unit tests + the Commander check above.

## Note on forward doc links

The L2–L4 / `/docs/guides/traces` references resolve once PR1c lands. All three sub-PRs ship together in one `develop→main` batch (docs deploy only from main), so the live docs site is never inconsistent. `build:docs` passes with the forward links.

## Checklist

- [x] `pnpm test` green
- [x] CHANGELOG `[Unreleased]` (`### Changed`)
- [x] §8 self-review (below)