### PR TITLE
feat: trace types + client + MoveContract wiring (traces PR1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Trace transaction types + HTTP client + `MoveContract` wiring (no renderer
+  yet). `core/trace/{types,client}.ts` model movelite's `/v1/transactions/trace`
+  contract and POST the BCS-signed transaction with `commit=true`. On movelite
+  at verbosity level >= 2, `contract.call(...)` now routes through that endpoint
+  (a single instrumented execution that also commits) instead of the normal
+  submit, preserving the `{hash, success, vm_status}` return shape; on the
+  Movement node and below level 2 the existing submit path is unchanged. The
+  call tree is rendered in a following change. Closes #317.
+
 - Bump the bundled `movelite` optional dependency from `^0.1.0` to `^0.2.0`.
   The 0.2.0 binary adds the `POST /v1/transactions/trace` endpoint that the
   upcoming Foundry-style trace renderer will consume; bumping the dependency

--- a/packages/movehat/src/core/contract.ts
+++ b/packages/movehat/src/core/contract.ts
@@ -5,6 +5,7 @@ import {
   type MoveFunctionId,
 } from "@aptos-labs/ts-sdk";
 import { logger } from "../ui/index.js";
+import { traceTransaction } from "./trace/client.js";
 
 export interface TransactionResult {
   hash: string;
@@ -16,7 +17,11 @@ export class MoveContract {
   constructor(
     private aptos: Aptos,
     private moduleAddress: string,
-    private moduleName: string
+    private moduleName: string,
+    // movelite RPC base (ending in `/v1`). Presence enables Foundry-style
+    // execution traces at verbosity level >= 2. Undefined on the Movement node
+    // (no trace endpoint) — calls use the normal submit path.
+    private traceRpcUrl?: string
   ) {}
 
   async call(
@@ -47,6 +52,30 @@ export class MoveContract {
       signer,
       transaction,
     });
+
+    // Trace path: on movelite at raised verbosity, route through the
+    // instrumented `/transactions/trace?commit=true` endpoint, which executes
+    // AND commits in one pass (so we must NOT also submit). PR1c renders the
+    // returned call tree here; for now it maps straight to the result.
+    if (this.traceRpcUrl && logger.getVerbosityLevel() >= 2) {
+      const { response, elapsedMs } = await traceTransaction({
+        rpcUrl: this.traceRpcUrl,
+        transaction,
+        senderAuthenticator: signature,
+      });
+      void elapsedMs; // consumed by the renderer in PR1c
+
+      logger.success(
+        `Transaction ${response.txn_hash} committed with status: ${response.vm_status}`
+      );
+      logger.newline();
+
+      return {
+        hash: response.txn_hash,
+        success: response.success,
+        vm_status: response.vm_status,
+      };
+    }
 
     const committedTxn = await this.aptos.transaction.submit.simple({
       transaction,
@@ -97,7 +126,8 @@ export class MoveContract {
 export function getContract(
     aptos: Aptos,
     moduleAddress: string,
-    moduleName: string
+    moduleName: string,
+    traceRpcUrl?: string
 ): MoveContract {
-    return new MoveContract(aptos, moduleAddress, moduleName);
+    return new MoveContract(aptos, moduleAddress, moduleName, traceRpcUrl);
 }

--- a/packages/movehat/src/core/trace/__tests__/client.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/client.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AccountAuthenticator, AnyRawTransaction } from "@aptos-labs/ts-sdk";
+
+import { traceTransaction } from "../client.js";
+import type { TraceResponse } from "../types.js";
+import sample from "./fixtures/counter-increment.json" with { type: "json" };
+
+// Stub the only SDK runtime symbol the client uses, so the test needs no real
+// signing material.
+vi.mock("@aptos-labs/ts-sdk", () => ({
+  generateSignedTransaction: vi.fn(() => new Uint8Array([1, 2, 3, 4])),
+}));
+
+const fakeTxn = {} as AnyRawTransaction;
+const fakeAuth = {} as AccountAuthenticator;
+
+describe("traceTransaction", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("POSTs the signed bytes to /transactions/trace?commit=true with the BCS content type", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(sample), { status: 200 })
+    );
+
+    const { response, elapsedMs } = await traceTransaction({
+      rpcUrl: "http://127.0.0.1:8090/v1",
+      transaction: fakeTxn,
+      senderAuthenticator: fakeAuth,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "http://127.0.0.1:8090/v1/transactions/trace?commit=true"
+    );
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/x.aptos.signed_transaction+bcs"
+    );
+    // No Accept header is sent (response must be JSON, not BCS).
+    expect((init.headers as Record<string, string>)["Accept"]).toBeUndefined();
+    expect(init.body).toBeInstanceOf(Uint8Array);
+
+    expect(response.txn_hash).toBe(sample.txn_hash);
+    expect(response.success).toBe(true);
+    expect(typeof elapsedMs).toBe("number");
+    expect(elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("throws on a non-2xx response, surfacing status and body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("bad transaction", { status: 400, statusText: "Bad Request" })
+    );
+
+    await expect(
+      traceTransaction({
+        rpcUrl: "http://127.0.0.1:8090/v1",
+        transaction: fakeTxn,
+        senderAuthenticator: fakeAuth,
+      })
+    ).rejects.toThrow(/400.*bad transaction/s);
+  });
+});
+
+describe("trace JSON contract (counter-increment fixture)", () => {
+  const trace = sample as unknown as TraceResponse;
+
+  it("carries the response-level fields", () => {
+    expect(trace.success).toBe(true);
+    expect(trace.abort).toBeNull();
+    expect(trace.vm_status).toBe("Executed successfully");
+    // gas_used is octas (small); root.gas is internal VM units (large) — distinct.
+    expect(trace.gas_used).toBeLessThan(trace.root.gas);
+  });
+
+  it("decodes the user entry frame and its args", () => {
+    expect(trace.root.kind).toBe("function");
+    expect(trace.root.module).toContain("::counter");
+    expect(trace.root.function).toBe("increment");
+    // u64 args arrive as strings.
+    expect(trace.root.args[0]).toEqual({ type: "u64", value: "5" });
+  });
+
+  it("models storage ops with the address-nullability quirk", () => {
+    const ops = trace.root.storage;
+    // load_resource carries the resolved address; mutating ops
+    // (borrow_global_mut / move_to) carry a null address.
+    const load = ops.find((o) => o.op === "load_resource");
+    const nullAddrOp = ops.find((o) => o.address === null);
+    expect(load?.address).toBeTypeOf("string");
+    expect(nullAddrOp).toBeDefined();
+    expect(nullAddrOp?.address).toBeNull();
+  });
+});

--- a/packages/movehat/src/core/trace/__tests__/fixtures/counter-increment.json
+++ b/packages/movehat/src/core/trace/__tests__/fixtures/counter-increment.json
@@ -1,0 +1,147 @@
+{
+  "txn_hash": "0xa5c7180f93dae13c9c91cdb104a8cbea3747201253f4fb99c0973e213834fe1f",
+  "success": true,
+  "gas_used": 4,
+  "vm_status": "Executed successfully",
+  "abort": null,
+  "root": {
+    "kind": "function",
+    "module": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter",
+    "function": "increment",
+    "type_args": [],
+    "args": [
+      {
+        "type": "u64",
+        "value": "5"
+      }
+    ],
+    "return": [
+      {
+        "type": "()",
+        "value": null
+      }
+    ],
+    "gas": 949862,
+    "events": [
+      {
+        "type": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter::Incremented",
+        "data": {
+          "value": "13"
+        }
+      }
+    ],
+    "storage": [
+      {
+        "op": "load_resource",
+        "type": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter::Counter",
+        "address": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16"
+      },
+      {
+        "op": "borrow_global_mut",
+        "type": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter::Counter",
+        "address": null
+      }
+    ],
+    "children": [
+      {
+        "kind": "function",
+        "module": "0x1::signer",
+        "function": "address_of",
+        "type_args": [],
+        "args": [
+          {
+            "type": "struct",
+            "value": {
+              "0": "0",
+              "1": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16"
+            }
+          }
+        ],
+        "return": [
+          {
+            "type": "address",
+            "value": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16"
+          }
+        ],
+        "gas": 6799,
+        "events": [],
+        "storage": [],
+        "children": [
+          {
+            "kind": "native",
+            "module": "0x1::signer",
+            "function": "borrow_address",
+            "type_args": [],
+            "args": [
+              {
+                "type": "struct",
+                "value": {
+                  "0": "0",
+                  "1": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16"
+                }
+              }
+            ],
+            "return": [
+              {
+                "type": "address",
+                "value": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16"
+              }
+            ],
+            "gas": 735,
+            "events": [],
+            "storage": [],
+            "children": []
+          }
+        ]
+      },
+      {
+        "kind": "function",
+        "module": "0x1::event",
+        "function": "emit",
+        "type_args": [
+          "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter::Incremented"
+        ],
+        "args": [
+          {
+            "type": "struct",
+            "value": {
+              "0": "13"
+            }
+          }
+        ],
+        "return": [
+          {
+            "type": "()",
+            "value": null
+          }
+        ],
+        "gas": 5871,
+        "events": [],
+        "storage": [],
+        "children": [
+          {
+            "kind": "native",
+            "module": "0x1::event",
+            "function": "write_module_event_to_store",
+            "type_args": [
+              "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter::Incremented"
+            ],
+            "args": [
+              {
+                "type": "struct",
+                "value": {
+                  "0": "13"
+                }
+              }
+            ],
+            "return": [],
+            "gas": 24886,
+            "events": [],
+            "storage": [],
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/movehat/src/core/trace/client.ts
+++ b/packages/movehat/src/core/trace/client.ts
@@ -1,0 +1,52 @@
+import {
+  generateSignedTransaction,
+  type AccountAuthenticator,
+  type AnyRawTransaction,
+} from "@aptos-labs/ts-sdk";
+
+import type { TraceResponse } from "./types.js";
+
+/** Content type movelite requires for BCS-signed transaction bodies. */
+const BCS_SIGNED_TXN_CONTENT_TYPE = "application/x.aptos.signed_transaction+bcs";
+
+/**
+ * Execute a signed transaction through movelite's instrumented VM and return
+ * the Foundry-style call tree. `commit=true` runs the trace AND commits in a
+ * single pass, so this is the sole execution — the caller must NOT also submit.
+ *
+ * @param rpcUrl movelite RPC base, already ending in `/v1`.
+ * @throws if the endpoint returns a non-2xx status (a submission failure).
+ */
+export async function traceTransaction(args: {
+  rpcUrl: string;
+  transaction: AnyRawTransaction;
+  senderAuthenticator: AccountAuthenticator;
+}): Promise<{ response: TraceResponse; elapsedMs: number }> {
+  const { rpcUrl, transaction, senderAuthenticator } = args;
+
+  const bytes = generateSignedTransaction({ transaction, senderAuthenticator });
+  const url = `${rpcUrl}/transactions/trace?commit=true`;
+
+  const start = performance.now();
+  const res = await fetch(url, {
+    method: "POST",
+    // No Accept header (response is JSON); no auth header (movelite runs --no-auth).
+    // Copy into a fresh ArrayBuffer-backed Uint8Array: the SDK returns
+    // `Uint8Array<ArrayBufferLike>`, which the fetch `BodyInit` type rejects
+    // under this TS lib config (the ArrayBuffer / SharedArrayBuffer split).
+    headers: { "Content-Type": BCS_SIGNED_TXN_CONTENT_TYPE },
+    body: new Uint8Array(bytes),
+  });
+  const elapsedMs = performance.now() - start;
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `movelite trace request failed (${res.status} ${res.statusText})` +
+        (body ? `: ${body}` : "")
+    );
+  }
+
+  const response = (await res.json()) as TraceResponse;
+  return { response, elapsedMs };
+}

--- a/packages/movehat/src/core/trace/types.ts
+++ b/packages/movehat/src/core/trace/types.ts
@@ -1,0 +1,75 @@
+/**
+ * TypeScript mirror of the JSON contract movelite's `/v1/transactions/trace`
+ * endpoint serializes. Field names and shapes match the Rust structs exactly;
+ * do not rename keys (`return` is keyed literally, `address` is nullable, etc.).
+ */
+
+/** A decoded argument or return value. `value` shape depends on `type`:
+ *  primitives like `u64` arrive as strings (`"5"`); a `struct` arrives as an
+ *  object keyed by field index (`{ "0": .., "1": .. }`); the unit type `()` has
+ *  `value: null`. */
+export interface TracedArg {
+  type: string;
+  value: unknown;
+}
+
+/** An event emitted within a frame. `data` is the decoded event payload. */
+export interface TracedEvent {
+  type: string;
+  data: unknown;
+}
+
+/** A storage access. `address` is populated for `load_resource` and null for
+ *  `move_to` / `borrow_global_mut`. */
+export interface StorageOp {
+  op: string;
+  type: string;
+  address: string | null;
+}
+
+/** One frame of the abort stack, innermost first. Any field may be null when
+ *  the VM could not resolve it. */
+export interface AbortStackEntry {
+  module: string | null;
+  function: string | null;
+  offset: number | null;
+}
+
+/** Abort details, present only when `TraceResponse.success` is false. */
+export interface AbortInfo {
+  code: number;
+  sub_status: number | null;
+  module: string | null;
+  stack: AbortStackEntry[];
+}
+
+/** A single call frame in the execution tree. */
+export interface CallNode {
+  kind: "function" | "native" | "script";
+  module: string | null;
+  function: string | null;
+  type_args: string[];
+  args: TracedArg[];
+  /** Keyed literally as `return` to match the wire format. */
+  return: TracedArg[];
+  /**
+   * Self gas of this frame in **internal** VM gas units. These are much larger
+   * than, and NOT comparable to, the external octa `gas_used` on the response —
+   * never mix the two when rendering.
+   */
+  gas: number;
+  events: TracedEvent[];
+  storage: StorageOp[];
+  children: CallNode[];
+}
+
+/** The full trace response. */
+export interface TraceResponse {
+  txn_hash: string;
+  success: boolean;
+  /** Transaction-level gas in octas (the external unit). */
+  gas_used: number;
+  vm_status: string;
+  abort: AbortInfo | null;
+  root: CallNode;
+}

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -226,9 +226,15 @@ async function setupWithLocalNode(
       throw new Error("Failed to get deployer private key");
     }
 
+    // movelite exposes the /transactions/trace endpoint that powers
+    // Foundry-style execution traces; a real Movement node does not. Compute
+    // this once and reuse it for both the trace wiring and SDK publish below.
+    const isMovelite = localNode instanceof MoveliteManager;
+
     const runtime = await initRuntime({
       network: "local",
       accountManager,
+      ...(isMovelite ? { traceRpcUrl: `${nodeInfo.rpcUrl}/v1` } : {}),
       configOverride: {
         networks: {
           local: {
@@ -251,7 +257,7 @@ async function setupWithLocalNode(
 
       // movelite's REST responses can't drive the Movement CLI publish flow,
       // so deploy through the TypeScript SDK when it is the spawned backend.
-      const sdkPublish = localNode instanceof MoveliteManager;
+      const sdkPublish = isMovelite;
 
       try {
         for (const moduleName of options.autoDeploy) {

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -35,6 +35,14 @@ export interface InitRuntimeOptions {
    * key it extracts ends up on the same manager the runtime exposes.
    */
   accountManager?: AccountManager;
+  /**
+   * movelite RPC base URL (already ending in `/v1`) enabling Foundry-style
+   * execution traces on `contract.call(...)` at verbosity level >= 2. Set only
+   * when the active backend is movelite (its `/transactions/trace` endpoint
+   * does not exist on a real Movement node). When omitted, contracts use the
+   * normal submit path and never trace.
+   */
+  traceRpcUrl?: string;
 }
 
 /**
@@ -98,7 +106,7 @@ export async function initRuntime(
 
   // Helper functions
   const getContractHelper = (address: string, moduleName: string): MoveContract => {
-    return getContract(aptos, address, moduleName);
+    return getContract(aptos, address, moduleName, options.traceRpcUrl);
   };
 
   const deployContract = async (


### PR DESCRIPTION
Tracks #315. Closes #317. Gated on PR1a (#319, `getVerbosityLevel`). Second of three sub-PRs.

## Summary

Plumbing for the execution-trace renderer — **no tree rendering yet** (that is PR1c).

- **NEW `core/trace/types.ts`** — TS mirror of movelite's `/v1/transactions/trace` JSON contract. Keys match the wire format (literal `return`; per-frame `gas` documented as internal VM units, distinct from the octa `gas_used`).
- **NEW `core/trace/client.ts`** — `traceTransaction(...)`: `generateSignedTransaction` → POST the BCS bytes to `${rpcUrl}/transactions/trace?commit=true`. `rpcUrl` already ends in `/v1`; BCS content type; no Accept; no auth (movelite runs `--no-auth`). `commit=true` is the sole commit. Non-2xx → throw. Times the POST for the renderer.
- **`contract.ts`** — optional 4th ctor param `traceRpcUrl`; `getContract` forwards it. `call()` branches: when `traceRpcUrl` is set AND `getVerbosityLevel() >= 2`, route through `traceTransaction` and map to `{hash, success, vm_status}`; otherwise the existing `submit.simple` + `waitForTransaction` path is unchanged. **Never also submits** (commit=true already committed).
- **`runtime.ts` / `setupLocalTesting.ts`** — thread `traceRpcUrl` down; set only on the movelite backend (`isMovelite` computed once, reused for `sdkPublish`). `createLive`/`createFork` never set it.

## How tested

- **Real movelite, end-to-end**: `increment` at `MOVEHAT_VERBOSITY=2` commits through the trace endpoint (`view` 0 → 1, proving `commit=true` mutated state); the default path (level 0) still commits unchanged on movelite. (Verified with a throwaway script, since `test:example` pins the shared Movement node and does not exercise movelite.)
- **Unit** (`pnpm --filter movehat test`, 574/574, 5 new): mock `fetch` + `generateSignedTransaction`, assert URL / headers (BCS content type, no Accept) / body / parse / non-2xx throw; fixture conformance (gas vs gas_used, u64-as-string args, storage `address` nullability). Fixture is a captured real `trace-sample.json`.
- **Tier 2 (§6.2)**: `pnpm test:smoke` pass; `pnpm test:example` 9 passing (shared-node path, confirms no regression to the normal submit flow). Tier-1 + this PR's `src` change covered.

## Notes

- A trace POST failure **throws** rather than falling back to `submit.simple` — with `commit=true` a fallback submit would risk a double-commit. A `success:false` (HTTP 200) is an abort, rendered/returned as `{success:false}`, not a fallback.
- `view()` is untouched (read-only, never traces).

## Checklist

- [x] `pnpm test` 574/574
- [x] Tier 2: `test:smoke` pass, `test:example` pass
- [x] CHANGELOG `[Unreleased]` (`### Internal`)
- [x] §8 self-review (below)