### PR TITLE
feat: render Foundry-style execution traces + docs (traces PR1c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Foundry-style execution traces for `contract.call(...)` on the movelite
+  backend. At verbosity level 2 (`-vv`) Movehat prints a decoded list of the
+  events a call emitted; at level 3 (`-vvv`) it renders the call tree of your
+  own modules (framework `0x1::*` frames and natives filtered out, with their
+  events bubbled up to your nearest frame); at level 4 (`-vvvv`) the full tree —
+  framework frames, native calls, storage operations, and return values. Aborts
+  show the full tree plus the abort code and stack. Per-frame gas is shown in
+  internal VM units, distinct from the transaction's octa `gas_used` in the
+  footer. Traces are movelite-only (the Movement node does not expose the trace
+  endpoint) and opt-in by verbosity, so the default test loop is unaffected. A
+  render failure degrades to a warning and never fails a committed transaction.
+  New guide at `guides/traces.mdx`. Closes #318.
+
 ### Changed
 
 - The global `-v` / `--verbose` flag is now **counted**: repeat it to raise the

--- a/packages/docs/content/docs/guides/meta.json
+++ b/packages/docs/content/docs/guides/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Guides",
-  "pages": ["compilation", "testing", "movelite", "networks-and-modes", "multi-contract", "tutorial-fork-testing", "tutorial-deploy-live", "tutorial-ci", "deployment", "fork", "scripts", "console-output"]
+  "pages": ["compilation", "testing", "movelite", "traces", "networks-and-modes", "multi-contract", "tutorial-fork-testing", "tutorial-deploy-live", "tutorial-ci", "deployment", "fork", "scripts", "console-output"]
 }

--- a/packages/docs/content/docs/guides/movelite.mdx
+++ b/packages/docs/content/docs/guides/movelite.mdx
@@ -113,6 +113,15 @@ If you expected movelite but see the Movement-node line, the binary was not
 found for your platform — movehat fell back. That is expected on unsupported
 platforms and harmless; your tests still pass, just slower.
 
+## Transaction traces
+
+Because movelite runs an instrumented VM, it can return a Foundry-style execution
+trace for every `contract.call(...)` — the call tree, decoded arguments, gas,
+events, and abort stack. Raise verbosity with `-vv` … `-vvvv` to see it. This is a
+movelite-only capability; the full Movement node does not expose the trace
+endpoint. See [Transaction traces](/docs/guides/traces) for the output format and
+verbosity levels.
+
 ## When to reach for the Movement node
 
 movelite is built for the fast local-test loop. Prefer the full Movement node

--- a/packages/docs/content/docs/guides/traces.mdx
+++ b/packages/docs/content/docs/guides/traces.mdx
@@ -1,0 +1,88 @@
+---
+title: Transaction traces
+description: Foundry-style execution traces for contract.call(...) on the movelite backend, shown at raised verbosity
+icon: ListTree
+---
+
+When you raise verbosity with `-vv`, `-vvv`, or `-vvvv`, Movehat renders a
+Foundry-style execution trace for every `contract.call(...)` — an indented call
+tree with per-frame `module::function`, decoded arguments, gas, return values,
+events, and (on failure) the abort stack.
+
+> Traces are a **[movelite](/docs/guides/movelite)-only** capability. They come
+> from an instrumented VM endpoint that the lightweight local runtime exposes;
+> the full Movement node's REST API does not expose internal call frames. On the
+> Movement node the same flags still raise subprocess verbosity, but no call
+> tree is rendered.
+
+## Enabling traces
+
+Traces escalate with the counted `-v` flag (see [Global flags](/docs/cli/global-flags)):
+
+```bash
+movehat test --ts -vv      # decoded events per call
+movehat test --ts -vvv     # the call tree of your own modules
+movehat test --ts -vvvv    # the full tree: framework frames, natives, storage, returns
+```
+
+| Level | Flag | What it renders |
+|---|---|---|
+| 2 | `-vv` | A flat, decoded list of the events each call emitted. |
+| 3 | `-vvv` | The call tree of **your** modules. Framework (`0x1::*`) frames and native calls are filtered out; events they emit bubble up to your nearest frame. |
+| 4 | `-vvvv` | The complete tree — framework frames, native calls, storage operations, and return values. |
+
+Traces fire only at level 2 and above, so the default test loop stays fast — the
+trace endpoint is opt-in per call and the normal path pays no tracing cost.
+
+## What a trace looks like
+
+A `counter::increment()` call at `-vvvv`:
+
+```text
+Trace
+0xe10b..fe37::counter::increment() [327179]
+  load_resource 0xe10b..fe37::counter::Counter @0xe10b..fe37
+  move_to 0xe10b..fe37::counter::Counter
+  borrow_global_mut 0xe10b..fe37::counter::Counter
+  0x1::signer::address_of({ 0, 0xe10b..fe37 }) [6799]
+    ← 0xe10b..fe37
+    0x1::signer::borrow_address({ 0, 0xe10b..fe37 }) [735]
+      ← 0xe10b..fe37
+
+✔ Executed successfully · gas_used: 440 octas · traced in 13ms
+```
+
+Each line is an entry function or one of the calls it makes, indented by depth.
+Your own modules render in bold cyan; framework frames, native calls, and gas
+figures are dimmed; events are yellow; storage operations are magenta; return
+values (`←`) are green. At `-vvv` the framework helpers above would be hidden,
+leaving just your `increment()` frame and any events it produced.
+
+### A note on gas
+
+The bracketed number after each frame — `[327179]` — is that frame's self gas in
+**internal VM units**. The `gas_used` in the footer — `440 octas` — is the
+transaction's gas in **octas**, the external unit you actually pay. The two
+scales are not comparable; never add a frame's internal gas to the octa total.
+
+## Aborts
+
+When a call aborts, the trace shows the full tree (so the failing frame is
+visible even at `-vvv`), followed by the abort code and the stack from the
+innermost frame outward:
+
+```text
+✖ Aborted: code 1 in 0xe10b..fe37::counter
+  at 0xe10b..fe37::counter::increment @14
+
+✖ Aborted · gas_used: 7 octas · traced in 9ms
+```
+
+The returned result still reports `success: false` and the `vm_status` — the
+trace is additional detail, it does not change what `contract.call(...)` returns.
+
+## Scope
+
+Only `contract.call(...)` (state-changing transactions) is traced. `view(...)`
+is a read-only query and is never traced. Traces require the movelite backend;
+on the Movement node, `createLive`, or a fork, calls run normally with no tree.

--- a/packages/movehat/src/core/contract.ts
+++ b/packages/movehat/src/core/contract.ts
@@ -6,6 +6,7 @@ import {
 } from "@aptos-labs/ts-sdk";
 import { logger } from "../ui/index.js";
 import { traceTransaction } from "./trace/client.js";
+import { renderTrace } from "./trace/renderer.js";
 
 export interface TransactionResult {
   hash: string;
@@ -55,15 +56,24 @@ export class MoveContract {
 
     // Trace path: on movelite at raised verbosity, route through the
     // instrumented `/transactions/trace?commit=true` endpoint, which executes
-    // AND commits in one pass (so we must NOT also submit). PR1c renders the
-    // returned call tree here; for now it maps straight to the result.
-    if (this.traceRpcUrl && logger.getVerbosityLevel() >= 2) {
+    // AND commits in one pass (so we must NOT also submit), then render the
+    // returned call tree.
+    const traceLevel = logger.getVerbosityLevel();
+    if (this.traceRpcUrl && traceLevel >= 2) {
       const { response, elapsedMs } = await traceTransaction({
         rpcUrl: this.traceRpcUrl,
         transaction,
         senderAuthenticator: signature,
       });
-      void elapsedMs; // consumed by the renderer in PR1c
+
+      // A render failure must never fail a transaction that already committed.
+      try {
+        renderTrace(response, { level: traceLevel, elapsedMs });
+      } catch (renderError) {
+        const msg =
+          renderError instanceof Error ? renderError.message : String(renderError);
+        logger.warning(`Failed to render trace: ${msg}`);
+      }
 
       logger.success(
         `Transaction ${response.txn_hash} committed with status: ${response.vm_status}`

--- a/packages/movehat/src/core/trace/__tests__/renderer.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/renderer.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import { formatTraceLines } from "../renderer.js";
+import type { CallNode, TraceResponse } from "../types.js";
+import sample from "./fixtures/counter-increment.json" with { type: "json" };
+
+const real = sample as unknown as TraceResponse;
+const text = (lines: string[]) => lines.join("\n");
+
+// Minimal CallNode factory for crafted fixtures.
+const node = (over: Partial<CallNode>): CallNode => ({
+  kind: "function",
+  module: "0xabc::user",
+  function: "f",
+  type_args: [],
+  args: [],
+  return: [],
+  gas: 100,
+  events: [],
+  storage: [],
+  children: [],
+  ...over,
+});
+
+describe("formatTraceLines — real counter-increment fixture", () => {
+  it("level 2: flat event list + footer, no call tree", () => {
+    const out = text(formatTraceLines(real, 2, 5));
+    expect(out).toContain("Events");
+    expect(out).toMatch(/emit .*::counter::Incremented/);
+    // No tree frame label for the entry function at level 2.
+    expect(out).not.toContain("increment(");
+    expect(out).toMatch(/gas_used: \d+ octas/);
+    expect(out).toContain("traced in 5ms");
+  });
+
+  it("level 3: shows the user frame, filters 0x1:: framework frames", () => {
+    const out = text(formatTraceLines(real, 3, 5));
+    expect(out).toContain("::counter::increment(");
+    // Framework helpers are hidden at level 3.
+    expect(out).not.toContain("0x1::signer");
+    expect(out).not.toContain("0x1::event");
+  });
+
+  it("level 4: shows framework frames, natives, storage, and returns", () => {
+    const out = text(formatTraceLines(real, 4, 5));
+    expect(out).toContain("0x1::signer::address_of");
+    expect(out).toContain("0x1::event::emit");
+    expect(out).toContain("load_resource");
+    expect(out).toContain("←"); // a return value from a framework helper
+  });
+
+  it("never emits raw ANSI escape codes (color is gated)", () => {
+    for (const lvl of [2, 3, 4]) {
+      expect(text(formatTraceLines(real, lvl, 5))).not.toContain("\x1b[");
+    }
+  });
+
+  it("shortens long addresses in frame paths", () => {
+    const out = text(formatTraceLines(real, 3, 5));
+    expect(out).toMatch(/0x[0-9a-f]{4}\.\.[0-9a-f]{4}::counter/);
+  });
+});
+
+describe("formatTraceLines — level 3 event bubbling", () => {
+  it("surfaces an event emitted by a hidden framework frame under the user ancestor", () => {
+    const trace: TraceResponse = {
+      txn_hash: "0x1",
+      success: true,
+      gas_used: 10,
+      vm_status: "Executed successfully",
+      abort: null,
+      root: node({
+        module: "0xabc::user",
+        function: "do_thing",
+        children: [
+          node({
+            kind: "function",
+            module: "0x1::event",
+            function: "emit",
+            events: [{ type: "0xabc::user::Did", data: { ok: true } }],
+            children: [
+              node({
+                kind: "native",
+                module: "0x1::event",
+                function: "write_module_event_to_store",
+              }),
+            ],
+          }),
+        ],
+      }),
+    };
+
+    const out = text(formatTraceLines(trace, 3, 1));
+    // The user frame shows...
+    expect(out).toContain("0xabc::user::do_thing");
+    // ...the event bubbles up even though its emitting frame is hidden...
+    expect(out).toContain("emit 0xabc::user::Did");
+    // ...and the framework frame itself stays hidden at level 3.
+    expect(out).not.toContain("0x1::event::emit");
+  });
+});
+
+describe("formatTraceLines — abort", () => {
+  const aborted: TraceResponse = {
+    txn_hash: "0x9",
+    success: false,
+    gas_used: 7,
+    vm_status: "Move abort",
+    abort: {
+      code: 1,
+      sub_status: null,
+      module: "0xabc::user",
+      stack: [
+        { module: "0xabc::user", function: "guard", offset: 14 },
+        { module: null, function: null, offset: null },
+      ],
+    },
+    root: node({
+      module: "0xabc::user",
+      function: "do_thing",
+      children: [
+        node({ kind: "native", module: "0x1::vector", function: "borrow" }),
+      ],
+    }),
+  };
+
+  it("renders the abort header, stack, and a failed footer", () => {
+    const out = text(formatTraceLines(aborted, 3, 2));
+    expect(out).toMatch(/Aborted: code 1/);
+    expect(out).toContain("at 0xabc::user::guard @14");
+    expect(out).toContain("at <unknown>::<unknown>"); // null module/function/offset
+    expect(out).not.toContain("@null"); // null offset omitted, not printed
+  });
+
+  it("forces the full tree on abort even at level 3 (native frame visible)", () => {
+    const out = text(formatTraceLines(aborted, 3, 2));
+    expect(out).toContain("0x1::vector::borrow");
+  });
+});

--- a/packages/movehat/src/core/trace/renderer.ts
+++ b/packages/movehat/src/core/trace/renderer.ts
@@ -1,0 +1,239 @@
+import { logger } from "../../ui/index.js";
+import { colors, rgbToAnsi, shouldUseColor } from "../../ui/colors.js";
+import { symbols } from "../../ui/symbols.js";
+
+import type {
+  AbortInfo,
+  CallNode,
+  TracedArg,
+  TracedEvent,
+  TraceResponse,
+} from "./types.js";
+
+// rgbToAnsi emits raw escapes unconditionally, so guard these two ourselves
+// (unlike colors.*, which already no-op when color is disabled).
+const orange = (s: string): string =>
+  shouldUseColor() ? `${rgbToAnsi(255, 165, 0)}${s}\x1b[0m` : s;
+const brightBlue = (s: string): string =>
+  shouldUseColor() ? `${rgbToAnsi(90, 170, 255)}${s}\x1b[0m` : s;
+
+const indent = (depth: number): string => "  ".repeat(depth);
+
+/** Shorten a 0x-prefixed address for display (`0xf903..9b16`); leave short
+ *  framework addresses like `0x1` untouched. */
+const shortAddr = (addr: string): string =>
+  addr.startsWith("0x") && addr.length > 12
+    ? `${addr.slice(0, 6)}..${addr.slice(-4)}`
+    : addr;
+
+/** Shorten the address part of a `address::module[::Name]` path. */
+const shortenPath = (path: string): string => {
+  const [addr, ...rest] = path.split("::");
+  if (addr === undefined || rest.length === 0) return path;
+  return [shortAddr(addr), ...rest].join("::");
+};
+
+const isFramework = (module: string | null): boolean =>
+  module !== null && module.startsWith("0x1::");
+
+/** Visible at level 3 (user-module tree): not a framework frame, not a native. */
+const isUserFrame = (node: CallNode): boolean =>
+  !isFramework(node.module) && node.kind !== "native";
+
+const NUMERIC = /^\d+$/;
+
+const leafValue = (value: unknown): string => {
+  const s = String(value);
+  if (NUMERIC.test(s)) return orange(s);
+  if (s.startsWith("0x") && s.length > 12) return shortAddr(s);
+  return s;
+};
+
+const formatArgValue = (arg: TracedArg): string => {
+  if (arg.value === null) return "()";
+  if (arg.type === "struct" && typeof arg.value === "object") {
+    return `{ ${Object.values(arg.value as Record<string, unknown>)
+      .map(leafValue)
+      .join(", ")} }`;
+  }
+  return leafValue(arg.value);
+};
+
+const formatArgs = (args: TracedArg[]): string =>
+  args.map(formatArgValue).join(", ");
+
+const frameName = (node: CallNode): string => {
+  const base = node.module
+    ? `${shortenPath(node.module)}::${node.function ?? "?"}`
+    : node.function ?? `<${node.kind}>`;
+  return base;
+};
+
+const frameLabel = (node: CallNode): string => {
+  const name = frameName(node);
+  const colored =
+    isFramework(node.module) || node.kind === "native"
+      ? colors.dim(name)
+      : colors.bold(colors.info(name));
+  const gas = colors.dim(` [${node.gas}]`);
+  return `${colored}(${formatArgs(node.args)})${gas}`;
+};
+
+const formatData = (data: unknown): string => {
+  if (data === null || data === undefined) return "";
+  try {
+    return colors.dim(JSON.stringify(data));
+  } catch {
+    return colors.dim(String(data));
+  }
+};
+
+const eventLine = (event: TracedEvent): string =>
+  `${colors.warning(`emit ${shortenPath(event.type)}`)} ${formatData(event.data)}`.trimEnd();
+
+const storageLine = (op: { op: string; type: string; address: string | null }): string =>
+  `${colors.primary(`${op.op} ${shortenPath(op.type)}`)}${
+    op.address ? colors.dim(` @${shortAddr(op.address)}`) : ""
+  }`;
+
+/** Non-unit return values only; null when nothing to show. */
+const returnLine = (ret: TracedArg[]): string | null => {
+  const meaningful = ret.filter((r) => r.type !== "()" && r.value !== null);
+  if (meaningful.length === 0) return null;
+  return colors.success(`← ${meaningful.map(formatArgValue).join(", ")}`);
+};
+
+/** Collect every event in the tree with its emitting module — for the flat
+ *  level-2 view. */
+const collectEvents = (
+  node: CallNode,
+  out: { module: string | null; event: TracedEvent }[]
+): void => {
+  for (const e of node.events) out.push({ module: node.module, event: e });
+  for (const c of node.children) collectEvents(c, out);
+};
+
+/** Level 3: descend through hidden (framework / native) frames, bubbling their
+ *  events up and surfacing the nearest visible frames as children. */
+const gatherHidden = (
+  children: CallNode[],
+  bubbled: TracedEvent[],
+  visible: CallNode[]
+): void => {
+  for (const child of children) {
+    if (isUserFrame(child)) {
+      visible.push(child);
+    } else {
+      bubbled.push(...child.events);
+      gatherHidden(child.children, bubbled, visible);
+    }
+  }
+};
+
+const renderNode = (
+  node: CallNode,
+  depth: number,
+  showFull: boolean,
+  lines: string[]
+): void => {
+  lines.push(indent(depth) + frameLabel(node));
+  const childDepth = depth + 1;
+
+  if (showFull) {
+    for (const e of node.events) lines.push(indent(childDepth) + eventLine(e));
+    for (const s of node.storage) lines.push(indent(childDepth) + storageLine(s));
+    const ret = returnLine(node.return);
+    if (ret) lines.push(indent(childDepth) + ret);
+    for (const c of node.children) renderNode(c, childDepth, showFull, lines);
+    return;
+  }
+
+  // Level 3: own events + events bubbled from hidden descendants, then the
+  // nearest visible child frames.
+  const bubbled: TracedEvent[] = [];
+  const visibleChildren: CallNode[] = [];
+  gatherHidden(node.children, bubbled, visibleChildren);
+  for (const e of [...node.events, ...bubbled]) {
+    lines.push(indent(childDepth) + eventLine(e));
+  }
+  for (const c of visibleChildren) renderNode(c, childDepth, showFull, lines);
+};
+
+const formatAbort = (abort: AbortInfo): string[] => {
+  const lines: string[] = [];
+  let header = colors.error(`${symbols.error} Aborted: code ${abort.code}`);
+  if (abort.sub_status !== null) {
+    header += colors.error(` (sub_status ${abort.sub_status})`);
+  }
+  if (abort.module !== null) {
+    header += colors.dim(` in ${shortenPath(abort.module)}`);
+  }
+  lines.push(header);
+  for (const entry of abort.stack) {
+    const mod = entry.module !== null ? shortenPath(entry.module) : "<unknown>";
+    const fn = entry.function ?? "<unknown>";
+    const off = entry.offset !== null ? ` @${entry.offset}` : "";
+    lines.push("  " + colors.error(`at ${mod}::${fn}${off}`));
+  }
+  return lines;
+};
+
+const formatFooter = (response: TraceResponse, elapsedMs: number): string => {
+  const status = response.success
+    ? colors.success(`${symbols.success} Executed successfully`)
+    : colors.error(`${symbols.error} Aborted`);
+  const sep = colors.dim(" · ");
+  const gas = colors.dim(`gas_used: ${response.gas_used} octas`);
+  const timed = brightBlue(`traced in ${Math.round(elapsedMs)}ms`);
+  return `${status}${sep}${gas}${sep}${timed}`;
+};
+
+/**
+ * Pure formatter — turns a trace into display lines. Snapshot-testable without
+ * touching stdout. `level` is the verbosity level (2..4); per-frame `gas` is in
+ * internal VM units while the footer `gas_used` is in octas (never mixed).
+ */
+export function formatTraceLines(
+  response: TraceResponse,
+  level: number,
+  elapsedMs: number
+): string[] {
+  const lines: string[] = [];
+
+  if (level <= 2) {
+    const events: { module: string | null; event: TracedEvent }[] = [];
+    collectEvents(response.root, events);
+    if (events.length === 0) {
+      lines.push(colors.dim("(no events emitted)"));
+    } else {
+      lines.push(colors.bold("Events"));
+      for (const { event } of events) lines.push("  " + eventLine(event));
+    }
+  } else {
+    // Aborts always show the full tree so the failing frame is visible.
+    const showFull = level >= 4 || !response.success;
+    lines.push(colors.bold("Trace"));
+    renderNode(response.root, 0, showFull, lines);
+  }
+
+  if (!response.success && response.abort) {
+    lines.push("");
+    lines.push(...formatAbort(response.abort));
+  }
+
+  lines.push("");
+  lines.push(formatFooter(response, elapsedMs));
+  return lines;
+}
+
+/** Render a trace to the terminal. Wraps {@link formatTraceLines}. */
+export function renderTrace(
+  response: TraceResponse,
+  opts: { level: number; elapsedMs: number }
+): void {
+  logger.newline();
+  for (const line of formatTraceLines(response, opts.level, opts.elapsedMs)) {
+    logger.plain(line);
+  }
+  logger.newline();
+}


### PR DESCRIPTION
Tracks #315. Closes #318. Final of three sub-PRs — wires the renderer, so traces now appear on screen.

## Summary

- **NEW `core/trace/renderer.ts`** — `formatTraceLines(response, level, elapsedMs)` (pure, snapshot-testable) + `renderTrace` (I/O). Approved palette via `ui/colors`; the orange (numeric args / shortened long addresses) and bright-blue (timing) helpers guard on `shouldUseColor()` themselves because `rgbToAnsi` is unguarded.
  - **L2** flat decoded-event list. **L3** user-module tree (`0x1::*` frames + natives filtered; their events bubble to the nearest visible user frame; full tree forced on abort). **L4** full tree (framework frames, natives, storage, returns).
  - Per-frame gas in internal VM units; footer `gas_used` in octas (never mixed) + elapsed ms. Abort header + innermost-first stack (null offset/module/function handled).
- **`contract.ts`** — wire `renderTrace` into the trace branch; a render failure degrades to `logger.warning` and never fails an already-committed transaction.
- **Docs** — new `guides/traces.mdx` (movelite-only, L2/L3/L4, a real rendered sample, internal-vs-octa gas, abort) + `guides/meta.json` entry + `guides/movelite.mdx` cross-link.

## Sample (`counter::increment()` at `-vvvv`, real movelite)

```text
Trace
0xe10b..fe37::counter::increment() [327179]
  load_resource 0xe10b..fe37::counter::Counter @0xe10b..fe37
  move_to 0xe10b..fe37::counter::Counter
  borrow_global_mut 0xe10b..fe37::counter::Counter
  0x1::signer::address_of({ 0, 0xe10b..fe37 }) [6799]
    ← 0xe10b..fe37
    0x1::signer::borrow_address({ 0, 0xe10b..fe37 }) [735]
      ← 0xe10b..fe37

✔ Executed successfully · gas_used: 440 octas · traced in 13ms
```

## How tested

- **Real movelite, end-to-end**: `increment()` at `-vvvv` renders the tree above and commits (`success: true`).
- **NO_COLOR / non-TTY**: piped output's Trace section is escape-free (verified by byte-scanning for `\x1b`). (Pre-existing: the Publisher's `Building package` / `Publishing` spinner lines still emit color when piped — unrelated to this PR, flagged for a separate §9 fix.)
- **Unit** (582/582, 8 new): real-fixture L2/L3/L4 structure, crafted L3 event-bubbling (event on a hidden `0x1::` frame surfaces under the user frame), crafted abort (header + stack + forced full tree + null-field handling), and a no-raw-escape guard.
- **Tier 1 + Tier 2**: `check:example`, `test:smoke`, `test:example` (9 passing) green. `build:docs` clean (traces page generated).

## Note on glyphs

The renderer prints `✔` / `✖` / `←` — these are the platform-aware `figures` symbols already used across the CLI and the `console-output.mdx` docs, not emoji.

## Checklist

- [x] `pnpm test` 582/582
- [x] Tier 2: `test:smoke` + `test:example` pass
- [x] CHANGELOG `[Unreleased]` (`### Added`)
- [x] Docs ride with the feature (§6.4)
- [x] §8 self-review (below)