### PR TITLE
docs: surface traces + movelite in feature lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 - **Hardhat-style Harness API** — `Harness.createLocal`, `createFork`, `createLive` factory methods with explicit lifecycle (`cleanup()`) and use-after-cleanup safety (Proxy poisoning).
 - **Three execution modes** — full local blockchain, read-only fork of a remote network, or live testnet/mainnet binding.
 - **Auto-deploy in tests + auto-detect named addresses** — contracts compile and deploy automatically; no manual address wiring.
+- **Fast local boot with movelite** — on supported platforms an auto-installed [movelite](https://github.com/gilbertsahumada/movelite) binary boots the local test chain in under a second instead of ~15s, with transparent fallback to the full Movement node.
+- **Foundry-style execution traces** — raise verbosity (`-vv` … `-vvvv`) to render an indented call tree for each `contract.call(...)` with decoded arguments, gas, events, and the abort stack (movelite backend).
 - **Native fork system** — local JSON-backed snapshots of Movement L1 state, no BCS compatibility issues.
 - **TypeScript-first** — single `PRIVATE_KEY` across all networks (Hardhat-style); deployments tracked per-network in `deployments/`.
 - **SLSA-provenance releases** — every npm release ships with [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) provenance. Verify with `npm view movehat@<version>`.

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -111,8 +111,10 @@ await harness.cleanup();
 |----------------------------|----------------------|--------------------|--------------------|
 | **Language**               | Move + TypeScript    | Solidity + TS/JS   | Solidity           |
 | **Local blockchain**       | Built-in             | Built-in           | Built-in (anvil)   |
+| **Fast local boot**        | movelite (sub-second)| Built-in           | Built-in (anvil)   |
 | **Fork system**            | Built-in JSON        | External           | Built-in           |
 | **Auto-detected addresses**| Yes                  | N/A                | Manual             |
+| **Execution traces**       | `-vvvv` (movelite)   | Plugin             | `-vvvv` built-in   |
 
 ## What's next?
 

--- a/packages/movehat/README.md
+++ b/packages/movehat/README.md
@@ -21,6 +21,8 @@
 - **Hardhat-style Harness API** — `Harness.createLocal`, `createFork`, `createLive` factory methods with explicit lifecycle (`cleanup()`) and use-after-cleanup safety (Proxy poisoning).
 - **Three execution modes** — full local blockchain, read-only fork of a remote network, or live testnet/mainnet binding.
 - **Auto-deploy in tests + auto-detect named addresses** — contracts compile and deploy automatically; no manual address wiring.
+- **Fast local boot with movelite** — on supported platforms an auto-installed [movelite](https://github.com/gilbertsahumada/movelite) binary boots the local test chain in under a second instead of ~15s, with transparent fallback to the full Movement node.
+- **Foundry-style execution traces** — raise verbosity (`-vv` … `-vvvv`) to render an indented call tree for each `contract.call(...)` with decoded arguments, gas, events, and the abort stack (movelite backend).
 - **Native fork system** — local JSON-backed snapshots of Movement L1 state, no BCS compatibility issues.
 - **TypeScript-first** — single `PRIVATE_KEY` across all networks (Hardhat-style); deployments tracked per-network in `deployments/`.
 - **SLSA-provenance releases** — every npm release ships with [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) provenance. Verify with `npm view movehat@<version>`.


### PR DESCRIPTION
Closes #322. Tracks #315. Completes the §6.4 docs-sync for the traces feature (the high-level lists were missed in PR1c).

## Summary

The reference docs for traces (`guides/traces.mdx`) and movelite (`guides/movelite.mdx`) exist, but the feature lists users hit first did not mention either.

- `README.md` + `packages/movehat/README.md` (npm-published): add a **movelite fast-boot** bullet and a **Foundry-style execution traces** bullet to the Features list (kept in sync).
- `packages/docs/content/docs/index.mdx` "Why Movehat?" table: add a **Fast local boot** row (movelite) and an **Execution traces** row (`-vvvv` on movelite — the Foundry parallel).

## How tested

- `pnpm build:docs` clean. (Caught and fixed an MDX gotcha: `(<1s)` parsed `<1s` as a JSX tag and failed the build → reworded to "sub-second".)
- No emojis; no new Aptos references (the one `0x1::aptos_coin` in index.mdx is a pre-existing fork-example type, untouched).

## No CHANGELOG entry

The traces feature is already logged under `[Unreleased] ### Added` (#318); this PR only surfaces existing features in the README/comparison and adds no behavior — documented skip per §11.

## Checklist

- [x] `build:docs` clean
- [x] READMEs kept in sync
- [x] §8 self-review (below)