### PR TITLE
feat: parse movelite JSON error body in trace client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   footer. Traces are movelite-only (the Movement node does not expose the trace
   endpoint) and opt-in by verbosity, so the default test loop is unaffected. A
   render failure degrades to a warning and never fails a committed transaction.
-  New guide at `guides/traces.mdx`. Closes #318.
+  A failed trace request surfaces movelite's structured JSON error `message`
+  (with `error_code` / `vm_error_code` when present), falling back to raw text
+  for older movelite builds. New guide at `guides/traces.mdx`. Closes #318,
+  Closes #324.
 
 ### Changed
 

--- a/packages/movehat/src/core/trace/__tests__/client.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/client.test.ts
@@ -71,6 +71,41 @@ describe("traceTransaction", () => {
       })
     ).rejects.toThrow(/400.*bad transaction/s);
   });
+
+  it("surfaces the `message` from a movelite JSON error body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: "transaction aborted",
+          error_code: "vm_error",
+          vm_error_code: 4004,
+        }),
+        { status: 400, statusText: "Bad Request" }
+      )
+    );
+
+    await expect(
+      traceTransaction({
+        rpcUrl: "http://127.0.0.1:8090/v1",
+        transaction: fakeTxn,
+        senderAuthenticator: fakeAuth,
+      })
+    ).rejects.toThrow(/transaction aborted \(vm_error, 4004\)/);
+  });
+
+  it("falls back to raw text when the error body is not JSON", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("plain text failure", { status: 500, statusText: "Error" })
+    );
+
+    await expect(
+      traceTransaction({
+        rpcUrl: "http://127.0.0.1:8090/v1",
+        transaction: fakeTxn,
+        senderAuthenticator: fakeAuth,
+      })
+    ).rejects.toThrow(/500.*plain text failure/s);
+  });
 });
 
 describe("trace JSON contract (counter-increment fixture)", () => {

--- a/packages/movehat/src/core/trace/client.ts
+++ b/packages/movehat/src/core/trace/client.ts
@@ -10,6 +10,34 @@ import type { TraceResponse } from "./types.js";
 const BCS_SIGNED_TXN_CONTENT_TYPE = "application/x.aptos.signed_transaction+bcs";
 
 /**
+ * Pull a readable detail out of a movelite error body. movelite (>= 0.2.1)
+ * returns structured JSON errors (`{ message, error_code, vm_error_code }`);
+ * older versions return plain text. Returns the `message` plus any codes when
+ * the body is JSON, otherwise the raw text unchanged.
+ */
+function extractErrorDetail(body: string): string {
+  if (!body) return "";
+  try {
+    const parsed = JSON.parse(body) as {
+      message?: unknown;
+      error_code?: unknown;
+      vm_error_code?: unknown;
+    };
+    if (parsed && typeof parsed.message === "string") {
+      const codes = [parsed.error_code, parsed.vm_error_code].filter(
+        (c) => c !== undefined && c !== null
+      );
+      return codes.length > 0
+        ? `${parsed.message} (${codes.join(", ")})`
+        : parsed.message;
+    }
+  } catch {
+    // Not JSON (e.g. older movelite plain-text errors) — fall through.
+  }
+  return body;
+}
+
+/**
  * Execute a signed transaction through movelite's instrumented VM and return
  * the Foundry-style call tree. `commit=true` runs the trace AND commits in a
  * single pass, so this is the sole execution — the caller must NOT also submit.
@@ -41,9 +69,10 @@ export async function traceTransaction(args: {
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
+    const detail = extractErrorDetail(body);
     throw new Error(
       `movelite trace request failed (${res.status} ${res.statusText})` +
-        (body ? `: ${body}` : "")
+        (detail ? `: ${detail}` : "")
     );
   }
 


### PR DESCRIPTION
Closes #324. Tracks #315.

## Summary

movelite 0.2.1 returns structured JSON error bodies (`{message, error_code, vm_error_code}`) instead of plain text. The trace client (`core/trace/client.ts`) previously embedded the raw body verbatim, so a failed trace POST would surface a JSON blob. It now extracts the `message` (plus `error_code` / `vm_error_code` when present) and falls back to the raw text when the body is not JSON — backward compatible with movelite 0.2.0's plain-text errors.

Confirmed compatible otherwise: the client already sends `Content-Type: application/x.aptos.signed_transaction+bcs` (passes 0.2.1's BCS validation) and no `Accept` header (no 406). The success endpoint and the trace JSON contract are unchanged, so the renderer is untouched.

## How tested

- `pnpm --filter movehat test` green (2 new client tests: JSON error → `message (codes)` extracted; plain text → raw preserved).
- Tier-1 `check:example` + Tier-2 `test:smoke` green. Happy path unchanged (error branch only).

## CHANGELOG

Folded into the existing unreleased traces `### Added` bullet (the feature has not shipped yet) with `Closes #324`.

## Checklist

- [x] `pnpm test` green
- [x] Tier-1 + smoke green
- [x] CHANGELOG updated
- [x] §8 self-review (below)