### PR TITLE
chore: refresh bundled movelite to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behavior change in this PR — local boot, fallback, and the existing API
   behave identically; the trace renderer lands separately.
 
+- Refresh the bundled `movelite` to `0.2.1` (spec `^0.2.0` → `^0.2.1`, lockfile
+  pins the 0.2.1 shim and all four platform binaries). 0.2.1 validates the
+  request `Content-Type`, restricts the `Accept` header, and returns structured
+  JSON error bodies; Movehat already sends the canonical BCS content type with
+  no `Accept` header and now parses those JSON errors, so the success path,
+  trace contract, and renderer are unchanged. Verified end-to-end: `increment`
+  at `-vvvv` renders the call tree and commits against the 0.2.1 binary. The
+  refresh also opportunistically deduped a stray `@types/node` in the lockfile.
+
 ## [0.2.9] - 2026-06-01
 
 ### Fixed

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -71,7 +71,7 @@
     "tsx": "^4.7.0"
   },
   "optionalDependencies": {
-    "movelite": "^0.2.0"
+    "movelite": "^0.2.1"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.0.0
-        version: 21.0.0(@types/node@24.12.4)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+        version: 21.0.0(@types/node@24.13.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
       '@commitlint/config-conventional':
         specifier: ^21.0.0
         version: 21.0.0
@@ -62,7 +62,7 @@ importers:
         version: 15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-mdx:
         specifier: ^14.2.5
-        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
+        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.13.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       fumadocs-ui:
         specifier: ^15.6.12
         version: 15.8.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
@@ -129,8 +129,8 @@ importers:
         version: 4.21.0
     optionalDependencies:
       movelite:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -1582,11 +1582,11 @@ packages:
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
-  '@types/node@24.12.4':
-    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
-
   '@types/node@24.13.1':
     resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
+
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
@@ -2684,28 +2684,28 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
-  movelite-darwin-arm64@0.2.0:
-    resolution: {integrity: sha512-kAwcGbl0UA8WOX8YkftDEDFub599qLknRAX64AQT8xA+Gp3gUtWhAKktc9q+oGV3ZhYEl562JN9QxqEhspokAA==}
+  movelite-darwin-arm64@0.2.1:
+    resolution: {integrity: sha512-dnJn4jur0Cc9poxKxiqdOhDPANhSdE8BEZ4oX/eocATTJ+ismy8YdVCUnUQL5c/zaM927AyQTWxZ/ZsApkfLQA==}
     cpu: [arm64]
     os: [darwin]
 
-  movelite-darwin-x64@0.2.0:
-    resolution: {integrity: sha512-TXYAZcm2N/IE+ZdMh3vNg/1oAgTAW6UTql9TVc3PNBeZGRambi1OTpd3Id0kTINvq16T7bacwbpwmgzOHpWwPw==}
+  movelite-darwin-x64@0.2.1:
+    resolution: {integrity: sha512-v9IXQPXYidB2j0JMjuZ/KA9k2YARULNqKrCS8jrBKPCdsNXQx1+BzZNm45YhwU35dARO2aw3W+LHXPQ2jQBiSw==}
     cpu: [x64]
     os: [darwin]
 
-  movelite-linux-arm64@0.2.0:
-    resolution: {integrity: sha512-xE0ZLR9vaB6eyvzHsSVA6+oRIyjCYGys/OryNMXV1lR9gix6THVdcoW8qsHrjfj+ndPC+T55ZuQsFA/csjmMgA==}
+  movelite-linux-arm64@0.2.1:
+    resolution: {integrity: sha512-jDzs1WNUjYmiAAolsShmwW2tsf58OdVsOCkfhsQWslbTJMJIBriwLPdwm0EDnhskluVR6p+8y2iALXBPTz7LoA==}
     cpu: [arm64]
     os: [linux]
 
-  movelite-linux-x64@0.2.0:
-    resolution: {integrity: sha512-BvI+Zs6yw5iZwK+FEZVX6JBziQhwHcb4Pxs0kOXXdSj2D8tRzZVQuKkc3VLLzNDr6akzW4+6JcEo6ZEHt0UL4g==}
+  movelite-linux-x64@0.2.1:
+    resolution: {integrity: sha512-jj8D/IiHuzi0rl5J/SGB7dIkbWAE4c7jcVUkXq28Yvrc2RTAfEX3ZbXfQ+k+93S5wppaIqqIq/nRH1LtAWnp8g==}
     cpu: [x64]
     os: [linux]
 
-  movelite@0.2.0:
-    resolution: {integrity: sha512-AEc6EfM1B66wNMJmizqVs91HP2X14DZQ1o/VzqHzJK8dF9KX/GvYG04lDqVtTrSLL4dngJnxHfz8X0Hwjae0jQ==}
+  movelite@0.2.1:
+    resolution: {integrity: sha512-NdPthoiMFwYJpVVHGSwUDm/rqwkJOGX1QP9W6lQMO/eZe4YGxTL+6oqtXY+c0c0GB82VQh4G98AhbNf954+CUw==}
     hasBin: true
 
   ms@2.1.3:
@@ -3441,11 +3441,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@21.0.0(@types/node@24.12.4)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+  '@commitlint/cli@21.0.0(@types/node@24.13.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 21.0.0
       '@commitlint/lint': 21.0.0
-      '@commitlint/load': 21.0.0(@types/node@24.12.4)(typescript@5.9.3)
+      '@commitlint/load': 21.0.0(@types/node@24.13.1)(typescript@5.9.3)
       '@commitlint/read': 21.0.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 21.0.0
       tinyexec: 1.0.2
@@ -3490,14 +3490,14 @@ snapshots:
       '@commitlint/rules': 21.0.0
       '@commitlint/types': 21.0.0
 
-  '@commitlint/load@21.0.0(@types/node@24.12.4)(typescript@5.9.3)':
+  '@commitlint/load@21.0.0(@types/node@24.13.1)(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 21.0.0
       '@commitlint/execute-rule': 21.0.0
       '@commitlint/resolve-extends': 21.0.0
       '@commitlint/types': 21.0.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.12.4)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.13.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
       es-toolkit: 1.46.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -4575,7 +4575,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 24.13.1
+      '@types/node': 24.13.2
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -4605,7 +4605,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 24.13.1
+      '@types/node': 24.13.2
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -4621,11 +4621,11 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@24.12.4':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@24.13.1':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
 
@@ -4644,7 +4644,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 24.13.1
+      '@types/node': 24.13.2
 
   '@types/unist@2.0.11': {}
 
@@ -4880,9 +4880,9 @@ snapshots:
       '@simple-libs/stream-utils': 1.2.0
       meow: 13.2.0
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@24.12.4)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@24.13.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
@@ -5148,7 +5148,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
+  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.13.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -5175,7 +5175,7 @@ snapshots:
       mdast-util-mdx-jsx: 3.2.0
       next: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-      vite: 7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@24.13.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6040,24 +6040,24 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
-  movelite-darwin-arm64@0.2.0:
+  movelite-darwin-arm64@0.2.1:
     optional: true
 
-  movelite-darwin-x64@0.2.0:
+  movelite-darwin-x64@0.2.1:
     optional: true
 
-  movelite-linux-arm64@0.2.0:
+  movelite-linux-arm64@0.2.1:
     optional: true
 
-  movelite-linux-x64@0.2.0:
+  movelite-linux-x64@0.2.1:
     optional: true
 
-  movelite@0.2.0:
+  movelite@0.2.1:
     optionalDependencies:
-      movelite-darwin-arm64: 0.2.0
-      movelite-darwin-x64: 0.2.0
-      movelite-linux-arm64: 0.2.0
-      movelite-linux-x64: 0.2.0
+      movelite-darwin-arm64: 0.2.1
+      movelite-darwin-x64: 0.2.1
+      movelite-linux-arm64: 0.2.1
+      movelite-linux-x64: 0.2.1
     optional: true
 
   ms@2.1.3: {}
@@ -6693,7 +6693,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0):
+  vite@7.3.1(@types/node@24.13.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.0
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6702,7 +6702,7 @@ snapshots:
       rollup: 4.55.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2


### PR DESCRIPTION
## What

Refreshes the bundled `movelite` optional dependency to **0.2.1**:

- `packages/movehat/package.json`: spec `^0.2.0` -> `^0.2.1`
- `pnpm-lock.yaml`: pins the 0.2.1 shim + all four platform binaries (`movelite-{darwin,linux}-{arm64,x64}@0.2.1`)
- `CHANGELOG.md`: Internal entry

## Why

movelite 0.2.1 tightens the trace endpoint contract (validates request `Content-Type`, restricts `Accept`, returns structured JSON error bodies). Movehat is already compatible:

- sends the canonical BCS `Content-Type` with no `Accept` header -> passes the new validation
- parses the JSON error bodies (landed in #325), with plain-text fallback for older builds

The success path, trace JSON contract, and renderer are **unchanged** — this is a dependency refresh, not a behavior change.

## Verification

- npm chain confirmed: shim `0.2.1` + 4 platform binaries `0.2.1` with correct `os`/`cpu`
- `pnpm install --frozen-lockfile` passes (CI dependency gate)
- `pnpm --filter movehat build` clean; **584/584** unit tests green
- **Real e2e against the 0.2.1 binary**: `counter.increment()` at `-vvvv` renders the call tree, returns `{hash, success:true, vm_status:"Executed successfully"}`, and a follow-up `view get -> 1` proves `commit=true` committed
- piped + `NO_COLOR` output carries **zero** raw ANSI escapes

## Notes

- The lockfile refresh opportunistically deduped a stray `@types/node` (dev tooling only) that was already drifting on `develop`; harmless.

Tracks #315