### PR TITLE
fix: render nested struct values in traces instead of [object Object]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Trace renderer: nested struct values in call arguments and return values now
+  render recursively (`{ 0, { 2, 0x… } }`) instead of collapsing to
+  `[object Object]`. The value formatter previously descended only one level, so
+  a struct field that was itself a struct printed as `[object Object]` — visible
+  in the level-4 full tree (framework frames such as `0x1::event::emit_event`)
+  and for any user call taking a nested-struct argument. Verified against a live
+  movelite `-vvvv` trace.
+
 - Restore tracking of `MAINTENANCE.md`, which was inadvertently untracked
   together with the genuinely-internal process docs during the docs cleanup.
   The README (including the npm-published package README) and the docs site

--- a/packages/movehat/src/core/trace/__tests__/renderer.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/renderer.test.ts
@@ -137,3 +137,34 @@ describe("formatTraceLines — abort", () => {
     expect(out).toContain("0x1::vector::borrow");
   });
 });
+
+describe("formatTraceLines — nested struct values", () => {
+  // A struct arg whose field is itself a struct: movelite decodes these as
+  // nested objects. The formatter must recurse, not render "[object Object]".
+  const nested: TraceResponse = {
+    txn_hash: "0xa",
+    success: true,
+    gas_used: 10,
+    vm_status: "Executed successfully",
+    abort: null,
+    root: node({
+      module: "0xabc::user",
+      function: "wrap",
+      args: [
+        {
+          type: "struct",
+          value: { "0": 7, "1": { "0": "0xabc", "1": 42 } },
+        },
+      ],
+      return: [{ type: "struct", value: { "0": { "0": 1 } } }],
+    }),
+  };
+
+  it("recurses into nested struct args and returns (no [object Object])", () => {
+    const out = text(formatTraceLines(nested, 4, 1));
+    expect(out).not.toContain("[object Object]");
+    // Inner struct rendered with its own braces.
+    expect(out).toContain("{ 7, { 0xabc, 42 } }");
+    expect(out).toContain("{ { 1 } }");
+  });
+});

--- a/packages/movehat/src/core/trace/renderer.ts
+++ b/packages/movehat/src/core/trace/renderer.ts
@@ -49,14 +49,21 @@ const leafValue = (value: unknown): string => {
   return s;
 };
 
-const formatArgValue = (arg: TracedArg): string => {
-  if (arg.value === null) return "()";
-  if (arg.type === "struct" && typeof arg.value === "object") {
-    return `{ ${Object.values(arg.value as Record<string, unknown>)
-      .map(leafValue)
+/** Format a decoded value. Struct (and vector) values arrive as objects with
+ *  by-index keys; their fields can themselves be structs, so recurse rather
+ *  than `String()`-ing a nested object into `[object Object]`. */
+const formatValue = (value: unknown): string => {
+  if (value !== null && typeof value === "object") {
+    return `{ ${Object.values(value as Record<string, unknown>)
+      .map(formatValue)
       .join(", ")} }`;
   }
-  return leafValue(arg.value);
+  return leafValue(value);
+};
+
+const formatArgValue = (arg: TracedArg): string => {
+  if (arg.value === null) return "()";
+  return formatValue(arg.value);
 };
 
 const formatArgs = (args: TracedArg[]): string =>


### PR DESCRIPTION
## Problem

The trace value formatter (`renderer.ts`) descended only one level into struct values. A struct field that was itself a struct got `String()`-ed into `[object Object]`.

This surfaced in the level-4 full tree on framework frames (e.g. `0x1::event::emit_event`, `0x1::account::new_event_handle`) and would also hit any user call taking a nested-struct argument:

```
0x1::event::emit_event({ 0, [object Object] }, { 0x9d7c..1fa8, [object Object] })
```

## Fix

Replace the single-level `arg.type === "struct"` branch with a recursive `formatValue()` that recurses into any object value (structs and vectors), so nested structs render with their own braces:

```
0x1::event::emit_event({ 0, { { 2, 0xaddf..b17e } } }, { 0xaddf..b17e, { 0x616c696365 } })
```

## Verification

- New unit test (`renderer.test.ts`): nested struct args + returns render recursively, asserts no `[object Object]`.
- **585/585** unit tests green.
- **Live movelite 0.2.1 `-vvvv` trace** (registry `register`, which has nested-struct framework calls): rebuilt `dist`, re-ran — **zero** `[object Object]`, nested structs render as `{ 0, { { 2, 0x… } } }`.

## Notes

Found while validating the abort path against real movelite 0.2.1 for the upcoming 0.3.0 release. Cosmetic only — does not affect `{hash, success, vm_status}` or commit behavior.

Tracks #318