### PR TITLE
chore: release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-12
+
 ### Added
 
 - Foundry-style execution traces for `contract.call(...)` on the movelite

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {


### PR DESCRIPTION
Release-prep for **movehat 0.3.0** (minor bump — new movelite-only Foundry-style execution-trace renderer).

- `packages/movehat/package.json`: `0.2.9` -> `0.3.0`
- `CHANGELOG.md`: finalize `[Unreleased]` -> `[0.3.0] - 2026-06-12`, fresh empty `[Unreleased]`

Develop-targeted prep; the version + finalized changelog ride the `develop -> main` batch. Issue auto-close happens on the batch PR to `main`.

Tracks #315