### PR TITLE
release: movehat 0.3.0 — Foundry-style execution traces + movelite 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behavior change in this PR — local boot, fallback, and the existing API
   behave identically; the trace renderer lands separately.
 
+- Refresh the bundled `movelite` to `0.2.1` (spec `^0.2.0` → `^0.2.1`, lockfile
+  pins the 0.2.1 shim and all four platform binaries). 0.2.1 validates the
+  request `Content-Type`, restricts the `Accept` header, and returns structured
+  JSON error bodies; Movehat already sends the canonical BCS content type with
+  no `Accept` header and now parses those JSON errors, so the success path,
+  trace contract, and renderer are unchanged. Verified end-to-end: `increment`
+  at `-vvvv` renders the call tree and commits against the 0.2.1 binary. The
+  refresh also opportunistically deduped a stray `@types/node` in the lockfile.
+
 ## [0.2.9] - 2026-06-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Foundry-style execution traces for `contract.call(...)` on the movelite
+  backend. At verbosity level 2 (`-vv`) Movehat prints a decoded list of the
+  events a call emitted; at level 3 (`-vvv`) it renders the call tree of your
+  own modules (framework `0x1::*` frames and natives filtered out, with their
+  events bubbled up to your nearest frame); at level 4 (`-vvvv`) the full tree —
+  framework frames, native calls, storage operations, and return values. Aborts
+  show the full tree plus the abort code and stack. Per-frame gas is shown in
+  internal VM units, distinct from the transaction's octa `gas_used` in the
+  footer. Traces are movelite-only (the Movement node does not expose the trace
+  endpoint) and opt-in by verbosity, so the default test loop is unaffected. A
+  render failure degrades to a warning and never fails a committed transaction.
+  New guide at `guides/traces.mdx`. Closes #318.
+
 ### Changed
 
 - The global `-v` / `--verbose` flag is now **counted**: repeat it to raise the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   footer. Traces are movelite-only (the Movement node does not expose the trace
   endpoint) and opt-in by verbosity, so the default test loop is unaffected. A
   render failure degrades to a warning and never fails a committed transaction.
-  New guide at `guides/traces.mdx`. Closes #318.
+  A failed trace request surfaces movelite's structured JSON error `message`
+  (with `error_code` / `vm_error_code` when present), falling back to raw text
+  for older movelite builds. New guide at `guides/traces.mdx`. Closes #318,
+  Closes #324.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Trace renderer: nested struct values in call arguments and return values now
+  render recursively (`{ 0, { 2, 0x… } }`) instead of collapsing to
+  `[object Object]`. The value formatter previously descended only one level, so
+  a struct field that was itself a struct printed as `[object Object]` — visible
+  in the level-4 full tree (framework frames such as `0x1::event::emit_event`)
+  and for any user call taking a nested-struct argument. Verified against a live
+  movelite `-vvvv` trace.
+
 - Restore tracking of `MAINTENANCE.md`, which was inadvertently untracked
   together with the genuinely-internal process docs during the docs cleanup.
   The README (including the npm-published package README) and the docs site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-12
+
 ### Added
 
 - Foundry-style execution traces for `contract.call(...)` on the movelite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The global `-v` / `--verbose` flag is now **counted**: repeat it to raise the
+  verbosity level (`-v` … `-vvvv` → levels 1–4). Level 1 is unchanged — it
+  surfaces subprocess output exactly as before, and `MOVEHAT_VERBOSE=1` remains
+  its shorthand. The higher levels are reserved for the forthcoming movelite
+  transaction-trace renderer (decoded events at 2, the call tree at 3–4). A new
+  `MOVEHAT_VERBOSITY=<0-4>` env var sets the level directly and propagates across
+  the spawned test/script subprocess boundary. `isVerbose()` and its callers are
+  unaffected. Closes #316.
+
 ### Fixed
 
 - Restore tracking of `MAINTENANCE.md`, which was inadvertently untracked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Trace transaction types + HTTP client + `MoveContract` wiring (no renderer
+  yet). `core/trace/{types,client}.ts` model movelite's `/v1/transactions/trace`
+  contract and POST the BCS-signed transaction with `commit=true`. On movelite
+  at verbosity level >= 2, `contract.call(...)` now routes through that endpoint
+  (a single instrumented execution that also commits) instead of the normal
+  submit, preserving the `{hash, success, vm_status}` return shape; on the
+  Movement node and below level 2 the existing submit path is unchanged. The
+  call tree is rendered in a following change. Closes #317.
+
 - Bump the bundled `movelite` optional dependency from `^0.1.0` to `^0.2.0`.
   The 0.2.0 binary adds the `POST /v1/transactions/trace` endpoint that the
   upcoming Foundry-style trace renderer will consume; bumping the dependency

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 - **Hardhat-style Harness API** — `Harness.createLocal`, `createFork`, `createLive` factory methods with explicit lifecycle (`cleanup()`) and use-after-cleanup safety (Proxy poisoning).
 - **Three execution modes** — full local blockchain, read-only fork of a remote network, or live testnet/mainnet binding.
 - **Auto-deploy in tests + auto-detect named addresses** — contracts compile and deploy automatically; no manual address wiring.
+- **Fast local boot with movelite** — on supported platforms an auto-installed [movelite](https://github.com/gilbertsahumada/movelite) binary boots the local test chain in under a second instead of ~15s, with transparent fallback to the full Movement node.
+- **Foundry-style execution traces** — raise verbosity (`-vv` … `-vvvv`) to render an indented call tree for each `contract.call(...)` with decoded arguments, gas, events, and the abort stack (movelite backend).
 - **Native fork system** — local JSON-backed snapshots of Movement L1 state, no BCS compatibility issues.
 - **TypeScript-first** — single `PRIVATE_KEY` across all networks (Hardhat-style); deployments tracked per-network in `deployments/`.
 - **SLSA-provenance releases** — every npm release ships with [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) provenance. Verify with `npm view movehat@<version>`.

--- a/packages/docs/content/docs/cli/global-flags.mdx
+++ b/packages/docs/content/docs/cli/global-flags.mdx
@@ -8,17 +8,27 @@ These flags are available on every `movehat` command. Pass them before or after 
 
 ## `-v`, `--verbose`
 
-Surface subprocess output that Movehat hides by default.
+`-v` is **counted** — repeat it to raise the verbosity level. Each level is additive on top of the previous one.
 
 ```bash
-movehat test --ts          # quiet (default)
-movehat test --ts -v       # surface all subprocess output
-MOVEHAT_VERBOSE=1 movehat test --ts   # equivalent — useful in scripts
+movehat test --ts          # L0 quiet (default)
+movehat test --ts -v       # L1 + subprocess output
+movehat test --ts -vv      # L2 + decoded events per transaction
+movehat test --ts -vvv     # L3 + the call tree of your own modules
+movehat test --ts -vvvv    # L4 + framework frames, natives, storage, return values
 ```
 
-By default Movehat hides routine chatter from the `movement node run-localnet` and `aptos move build / publish` subprocesses to keep the console readable. With `-v` enabled, every line from those processes is printed with a muted gray `›` prefix so you can see exactly what they're doing.
+| Level | Flag | Adds |
+|---|---|---|
+| 0 | _(none)_ | System logs only — the default quiet console. |
+| 1 | `-v` | Subprocess output from `movement node run-localnet` and `aptos move build / publish`, printed with a muted gray `›` prefix. |
+| 2 | `-vv` | A decoded list of the events each `contract.call(...)` emitted. |
+| 3 | `-vvv` | A Foundry-style execution trace showing the call tree of **your** modules (framework `0x1::*` frames filtered out). |
+| 4 | `-vvvv` | The full trace: framework frames, native calls, storage operations, and return values. |
 
-When to reach for `-v`:
+Levels 2–4 render execution traces, which are a **[movelite](/docs/guides/movelite)-only** capability — they require the trace endpoint the lightweight local runtime exposes. On the full Movement node the same flags still raise subprocess verbosity (level 1), but no call tree is rendered. See [Transaction traces](/docs/guides/traces) for the full output format.
+
+When to reach for level 1 (`-v`):
 
 - The local node fails to start and the spinner times out — `-v` reveals what `movement` is saying.
 - `aptos move build` is slow on a fresh clone — `-v` shows the git-dependency download progress.
@@ -51,8 +61,11 @@ Useful when your Move source changed but the local node's deployment cache still
 
 | Variable | Equivalent flag | Purpose |
 |---|---|---|
-| `MOVEHAT_VERBOSE=1` | `-v` / `--verbose` | Surface subprocess output |
+| `MOVEHAT_VERBOSE=1` | `-v` / `--verbose` | Surface subprocess output (level 1) |
+| `MOVEHAT_VERBOSITY=<0-4>` | `-v` … `-vvvv` | Set the exact verbosity level, including the trace levels (2–4) |
 | `MOVEHAT_NETWORK=<name>` | `--network <name>` | Default network for this shell |
 | `NO_COLOR=1` | — | Disable all ANSI colors and spinners |
+
+`MOVEHAT_VERBOSE=1` remains the level-1 shorthand. `MOVEHAT_VERBOSITY` sets the precise level and takes precedence — useful in scripts or CI that want trace output without passing repeated flags.
 
 `NO_COLOR=1` and non-TTY output (pipes, CI) auto-degrade gracefully — spinners disable, no carriage-return rewrites, output stays line-based and grep-friendly.

--- a/packages/docs/content/docs/guides/console-output.mdx
+++ b/packages/docs/content/docs/guides/console-output.mdx
@@ -68,6 +68,20 @@ movehat test --ts
 
 With verbose enabled, subprocess output prints with a muted gray `›` prefix so it visually separates from Movehat's own lines.
 
+### Verbosity levels
+
+`-v` is counted — repeating it raises the level, and each level is additive:
+
+| Level | Flag | Adds |
+|---|---|---|
+| 0 | _(none)_ | System logs only (the default). |
+| 1 | `-v` | Subprocess output (gray `›` prefix). |
+| 2 | `-vv` | A decoded list of the events each `contract.call(...)` emitted. |
+| 3 | `-vvv` | A Foundry-style call tree of your own modules. |
+| 4 | `-vvvv` | The full trace — framework frames, natives, storage, return values. |
+
+Levels 2–4 render execution traces and only do so on the [movelite](/docs/guides/movelite) backend; see [Transaction traces](/docs/guides/traces). `MOVEHAT_VERBOSITY=<0-4>` sets the level directly without repeating flags.
+
 ## Critical signals always surface
 
 Movehat never silences a real failure. Lines matching these patterns reach your terminal regardless of verbosity:

--- a/packages/docs/content/docs/guides/meta.json
+++ b/packages/docs/content/docs/guides/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Guides",
-  "pages": ["compilation", "testing", "movelite", "networks-and-modes", "multi-contract", "tutorial-fork-testing", "tutorial-deploy-live", "tutorial-ci", "deployment", "fork", "scripts", "console-output"]
+  "pages": ["compilation", "testing", "movelite", "traces", "networks-and-modes", "multi-contract", "tutorial-fork-testing", "tutorial-deploy-live", "tutorial-ci", "deployment", "fork", "scripts", "console-output"]
 }

--- a/packages/docs/content/docs/guides/movelite.mdx
+++ b/packages/docs/content/docs/guides/movelite.mdx
@@ -113,6 +113,15 @@ If you expected movelite but see the Movement-node line, the binary was not
 found for your platform — movehat fell back. That is expected on unsupported
 platforms and harmless; your tests still pass, just slower.
 
+## Transaction traces
+
+Because movelite runs an instrumented VM, it can return a Foundry-style execution
+trace for every `contract.call(...)` — the call tree, decoded arguments, gas,
+events, and abort stack. Raise verbosity with `-vv` … `-vvvv` to see it. This is a
+movelite-only capability; the full Movement node does not expose the trace
+endpoint. See [Transaction traces](/docs/guides/traces) for the output format and
+verbosity levels.
+
 ## When to reach for the Movement node
 
 movelite is built for the fast local-test loop. Prefer the full Movement node

--- a/packages/docs/content/docs/guides/traces.mdx
+++ b/packages/docs/content/docs/guides/traces.mdx
@@ -1,0 +1,88 @@
+---
+title: Transaction traces
+description: Foundry-style execution traces for contract.call(...) on the movelite backend, shown at raised verbosity
+icon: ListTree
+---
+
+When you raise verbosity with `-vv`, `-vvv`, or `-vvvv`, Movehat renders a
+Foundry-style execution trace for every `contract.call(...)` — an indented call
+tree with per-frame `module::function`, decoded arguments, gas, return values,
+events, and (on failure) the abort stack.
+
+> Traces are a **[movelite](/docs/guides/movelite)-only** capability. They come
+> from an instrumented VM endpoint that the lightweight local runtime exposes;
+> the full Movement node's REST API does not expose internal call frames. On the
+> Movement node the same flags still raise subprocess verbosity, but no call
+> tree is rendered.
+
+## Enabling traces
+
+Traces escalate with the counted `-v` flag (see [Global flags](/docs/cli/global-flags)):
+
+```bash
+movehat test --ts -vv      # decoded events per call
+movehat test --ts -vvv     # the call tree of your own modules
+movehat test --ts -vvvv    # the full tree: framework frames, natives, storage, returns
+```
+
+| Level | Flag | What it renders |
+|---|---|---|
+| 2 | `-vv` | A flat, decoded list of the events each call emitted. |
+| 3 | `-vvv` | The call tree of **your** modules. Framework (`0x1::*`) frames and native calls are filtered out; events they emit bubble up to your nearest frame. |
+| 4 | `-vvvv` | The complete tree — framework frames, native calls, storage operations, and return values. |
+
+Traces fire only at level 2 and above, so the default test loop stays fast — the
+trace endpoint is opt-in per call and the normal path pays no tracing cost.
+
+## What a trace looks like
+
+A `counter::increment()` call at `-vvvv`:
+
+```text
+Trace
+0xe10b..fe37::counter::increment() [327179]
+  load_resource 0xe10b..fe37::counter::Counter @0xe10b..fe37
+  move_to 0xe10b..fe37::counter::Counter
+  borrow_global_mut 0xe10b..fe37::counter::Counter
+  0x1::signer::address_of({ 0, 0xe10b..fe37 }) [6799]
+    ← 0xe10b..fe37
+    0x1::signer::borrow_address({ 0, 0xe10b..fe37 }) [735]
+      ← 0xe10b..fe37
+
+✔ Executed successfully · gas_used: 440 octas · traced in 13ms
+```
+
+Each line is an entry function or one of the calls it makes, indented by depth.
+Your own modules render in bold cyan; framework frames, native calls, and gas
+figures are dimmed; events are yellow; storage operations are magenta; return
+values (`←`) are green. At `-vvv` the framework helpers above would be hidden,
+leaving just your `increment()` frame and any events it produced.
+
+### A note on gas
+
+The bracketed number after each frame — `[327179]` — is that frame's self gas in
+**internal VM units**. The `gas_used` in the footer — `440 octas` — is the
+transaction's gas in **octas**, the external unit you actually pay. The two
+scales are not comparable; never add a frame's internal gas to the octa total.
+
+## Aborts
+
+When a call aborts, the trace shows the full tree (so the failing frame is
+visible even at `-vvv`), followed by the abort code and the stack from the
+innermost frame outward:
+
+```text
+✖ Aborted: code 1 in 0xe10b..fe37::counter
+  at 0xe10b..fe37::counter::increment @14
+
+✖ Aborted · gas_used: 7 octas · traced in 9ms
+```
+
+The returned result still reports `success: false` and the `vm_status` — the
+trace is additional detail, it does not change what `contract.call(...)` returns.
+
+## Scope
+
+Only `contract.call(...)` (state-changing transactions) is traced. `view(...)`
+is a read-only query and is never traced. Traces require the movelite backend;
+on the Movement node, `createLive`, or a fork, calls run normally with no tree.

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -111,8 +111,10 @@ await harness.cleanup();
 |----------------------------|----------------------|--------------------|--------------------|
 | **Language**               | Move + TypeScript    | Solidity + TS/JS   | Solidity           |
 | **Local blockchain**       | Built-in             | Built-in           | Built-in (anvil)   |
+| **Fast local boot**        | movelite (sub-second)| Built-in           | Built-in (anvil)   |
 | **Fork system**            | Built-in JSON        | External           | Built-in           |
 | **Auto-detected addresses**| Yes                  | N/A                | Manual             |
+| **Execution traces**       | `-vvvv` (movelite)   | Plugin             | `-vvvv` built-in   |
 
 ## What's next?
 

--- a/packages/movehat/README.md
+++ b/packages/movehat/README.md
@@ -21,6 +21,8 @@
 - **Hardhat-style Harness API** — `Harness.createLocal`, `createFork`, `createLive` factory methods with explicit lifecycle (`cleanup()`) and use-after-cleanup safety (Proxy poisoning).
 - **Three execution modes** — full local blockchain, read-only fork of a remote network, or live testnet/mainnet binding.
 - **Auto-deploy in tests + auto-detect named addresses** — contracts compile and deploy automatically; no manual address wiring.
+- **Fast local boot with movelite** — on supported platforms an auto-installed [movelite](https://github.com/gilbertsahumada/movelite) binary boots the local test chain in under a second instead of ~15s, with transparent fallback to the full Movement node.
+- **Foundry-style execution traces** — raise verbosity (`-vv` … `-vvvv`) to render an indented call tree for each `contract.call(...)` with decoded arguments, gas, events, and the abort stack (movelite backend).
 - **Native fork system** — local JSON-backed snapshots of Movement L1 state, no BCS compatibility issues.
 - **TypeScript-first** — single `PRIVATE_KEY` across all networks (Hardhat-style); deployments tracked per-network in `deployments/`.
 - **SLSA-provenance releases** — every npm release ships with [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) provenance. Verify with `npm view movehat@<version>`.

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -71,7 +71,7 @@
     "tsx": "^4.7.0"
   },
   "optionalDependencies": {
-    "movelite": "^0.2.0"
+    "movelite": "^0.2.1"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/movehat/src/cli.ts
+++ b/packages/movehat/src/cli.ts
@@ -50,7 +50,12 @@ program
   .version(version)
   .option('--network <name>', 'Network to use (testnet, mainnet, local, etc.)')
   .option('--redeploy', 'Force redeploy even if already deployed')
-  .option('-v, --verbose', 'Show subprocess output (movement node, aptos move) for debugging')
+  .option(
+    '-v, --verbose',
+    'Increase output verbosity (repeatable: -v subprocess output, -vv..-vvvv transaction traces on movelite)',
+    (_value: string, previous: number) => previous + 1,
+    0
+  )
   .hook('preAction', (thisCommand) => {
     // Store network option in environment for commands to access
     const options = thisCommand.opts();
@@ -60,8 +65,13 @@ program
     if (options.redeploy) {
       process.env.MH_CLI_REDEPLOY = 'true';
     }
-    if (options.verbose) {
+    // `-v` is counted (0..4). Level >= 1 keeps the legacy MOVEHAT_VERBOSE=1
+    // contract (isVerbose + its callers); MOVEHAT_VERBOSITY carries the
+    // numeric level across the spawned test/script subprocess boundary.
+    const level: number = options.verbose ?? 0;
+    if (level >= 1) {
       process.env.MOVEHAT_VERBOSE = '1';
+      process.env.MOVEHAT_VERBOSITY = String(level);
     }
   });
 

--- a/packages/movehat/src/core/contract.ts
+++ b/packages/movehat/src/core/contract.ts
@@ -5,6 +5,7 @@ import {
   type MoveFunctionId,
 } from "@aptos-labs/ts-sdk";
 import { logger } from "../ui/index.js";
+import { traceTransaction } from "./trace/client.js";
 
 export interface TransactionResult {
   hash: string;
@@ -16,7 +17,11 @@ export class MoveContract {
   constructor(
     private aptos: Aptos,
     private moduleAddress: string,
-    private moduleName: string
+    private moduleName: string,
+    // movelite RPC base (ending in `/v1`). Presence enables Foundry-style
+    // execution traces at verbosity level >= 2. Undefined on the Movement node
+    // (no trace endpoint) — calls use the normal submit path.
+    private traceRpcUrl?: string
   ) {}
 
   async call(
@@ -47,6 +52,30 @@ export class MoveContract {
       signer,
       transaction,
     });
+
+    // Trace path: on movelite at raised verbosity, route through the
+    // instrumented `/transactions/trace?commit=true` endpoint, which executes
+    // AND commits in one pass (so we must NOT also submit). PR1c renders the
+    // returned call tree here; for now it maps straight to the result.
+    if (this.traceRpcUrl && logger.getVerbosityLevel() >= 2) {
+      const { response, elapsedMs } = await traceTransaction({
+        rpcUrl: this.traceRpcUrl,
+        transaction,
+        senderAuthenticator: signature,
+      });
+      void elapsedMs; // consumed by the renderer in PR1c
+
+      logger.success(
+        `Transaction ${response.txn_hash} committed with status: ${response.vm_status}`
+      );
+      logger.newline();
+
+      return {
+        hash: response.txn_hash,
+        success: response.success,
+        vm_status: response.vm_status,
+      };
+    }
 
     const committedTxn = await this.aptos.transaction.submit.simple({
       transaction,
@@ -97,7 +126,8 @@ export class MoveContract {
 export function getContract(
     aptos: Aptos,
     moduleAddress: string,
-    moduleName: string
+    moduleName: string,
+    traceRpcUrl?: string
 ): MoveContract {
-    return new MoveContract(aptos, moduleAddress, moduleName);
+    return new MoveContract(aptos, moduleAddress, moduleName, traceRpcUrl);
 }

--- a/packages/movehat/src/core/contract.ts
+++ b/packages/movehat/src/core/contract.ts
@@ -6,6 +6,7 @@ import {
 } from "@aptos-labs/ts-sdk";
 import { logger } from "../ui/index.js";
 import { traceTransaction } from "./trace/client.js";
+import { renderTrace } from "./trace/renderer.js";
 
 export interface TransactionResult {
   hash: string;
@@ -55,15 +56,24 @@ export class MoveContract {
 
     // Trace path: on movelite at raised verbosity, route through the
     // instrumented `/transactions/trace?commit=true` endpoint, which executes
-    // AND commits in one pass (so we must NOT also submit). PR1c renders the
-    // returned call tree here; for now it maps straight to the result.
-    if (this.traceRpcUrl && logger.getVerbosityLevel() >= 2) {
+    // AND commits in one pass (so we must NOT also submit), then render the
+    // returned call tree.
+    const traceLevel = logger.getVerbosityLevel();
+    if (this.traceRpcUrl && traceLevel >= 2) {
       const { response, elapsedMs } = await traceTransaction({
         rpcUrl: this.traceRpcUrl,
         transaction,
         senderAuthenticator: signature,
       });
-      void elapsedMs; // consumed by the renderer in PR1c
+
+      // A render failure must never fail a transaction that already committed.
+      try {
+        renderTrace(response, { level: traceLevel, elapsedMs });
+      } catch (renderError) {
+        const msg =
+          renderError instanceof Error ? renderError.message : String(renderError);
+        logger.warning(`Failed to render trace: ${msg}`);
+      }
 
       logger.success(
         `Transaction ${response.txn_hash} committed with status: ${response.vm_status}`

--- a/packages/movehat/src/core/trace/__tests__/client.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/client.test.ts
@@ -71,6 +71,41 @@ describe("traceTransaction", () => {
       })
     ).rejects.toThrow(/400.*bad transaction/s);
   });
+
+  it("surfaces the `message` from a movelite JSON error body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: "transaction aborted",
+          error_code: "vm_error",
+          vm_error_code: 4004,
+        }),
+        { status: 400, statusText: "Bad Request" }
+      )
+    );
+
+    await expect(
+      traceTransaction({
+        rpcUrl: "http://127.0.0.1:8090/v1",
+        transaction: fakeTxn,
+        senderAuthenticator: fakeAuth,
+      })
+    ).rejects.toThrow(/transaction aborted \(vm_error, 4004\)/);
+  });
+
+  it("falls back to raw text when the error body is not JSON", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("plain text failure", { status: 500, statusText: "Error" })
+    );
+
+    await expect(
+      traceTransaction({
+        rpcUrl: "http://127.0.0.1:8090/v1",
+        transaction: fakeTxn,
+        senderAuthenticator: fakeAuth,
+      })
+    ).rejects.toThrow(/500.*plain text failure/s);
+  });
 });
 
 describe("trace JSON contract (counter-increment fixture)", () => {

--- a/packages/movehat/src/core/trace/__tests__/client.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/client.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AccountAuthenticator, AnyRawTransaction } from "@aptos-labs/ts-sdk";
+
+import { traceTransaction } from "../client.js";
+import type { TraceResponse } from "../types.js";
+import sample from "./fixtures/counter-increment.json" with { type: "json" };
+
+// Stub the only SDK runtime symbol the client uses, so the test needs no real
+// signing material.
+vi.mock("@aptos-labs/ts-sdk", () => ({
+  generateSignedTransaction: vi.fn(() => new Uint8Array([1, 2, 3, 4])),
+}));
+
+const fakeTxn = {} as AnyRawTransaction;
+const fakeAuth = {} as AccountAuthenticator;
+
+describe("traceTransaction", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("POSTs the signed bytes to /transactions/trace?commit=true with the BCS content type", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(sample), { status: 200 })
+    );
+
+    const { response, elapsedMs } = await traceTransaction({
+      rpcUrl: "http://127.0.0.1:8090/v1",
+      transaction: fakeTxn,
+      senderAuthenticator: fakeAuth,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "http://127.0.0.1:8090/v1/transactions/trace?commit=true"
+    );
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/x.aptos.signed_transaction+bcs"
+    );
+    // No Accept header is sent (response must be JSON, not BCS).
+    expect((init.headers as Record<string, string>)["Accept"]).toBeUndefined();
+    expect(init.body).toBeInstanceOf(Uint8Array);
+
+    expect(response.txn_hash).toBe(sample.txn_hash);
+    expect(response.success).toBe(true);
+    expect(typeof elapsedMs).toBe("number");
+    expect(elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("throws on a non-2xx response, surfacing status and body", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("bad transaction", { status: 400, statusText: "Bad Request" })
+    );
+
+    await expect(
+      traceTransaction({
+        rpcUrl: "http://127.0.0.1:8090/v1",
+        transaction: fakeTxn,
+        senderAuthenticator: fakeAuth,
+      })
+    ).rejects.toThrow(/400.*bad transaction/s);
+  });
+});
+
+describe("trace JSON contract (counter-increment fixture)", () => {
+  const trace = sample as unknown as TraceResponse;
+
+  it("carries the response-level fields", () => {
+    expect(trace.success).toBe(true);
+    expect(trace.abort).toBeNull();
+    expect(trace.vm_status).toBe("Executed successfully");
+    // gas_used is octas (small); root.gas is internal VM units (large) — distinct.
+    expect(trace.gas_used).toBeLessThan(trace.root.gas);
+  });
+
+  it("decodes the user entry frame and its args", () => {
+    expect(trace.root.kind).toBe("function");
+    expect(trace.root.module).toContain("::counter");
+    expect(trace.root.function).toBe("increment");
+    // u64 args arrive as strings.
+    expect(trace.root.args[0]).toEqual({ type: "u64", value: "5" });
+  });
+
+  it("models storage ops with the address-nullability quirk", () => {
+    const ops = trace.root.storage;
+    // load_resource carries the resolved address; mutating ops
+    // (borrow_global_mut / move_to) carry a null address.
+    const load = ops.find((o) => o.op === "load_resource");
+    const nullAddrOp = ops.find((o) => o.address === null);
+    expect(load?.address).toBeTypeOf("string");
+    expect(nullAddrOp).toBeDefined();
+    expect(nullAddrOp?.address).toBeNull();
+  });
+});

--- a/packages/movehat/src/core/trace/__tests__/fixtures/counter-increment.json
+++ b/packages/movehat/src/core/trace/__tests__/fixtures/counter-increment.json
@@ -1,0 +1,147 @@
+{
+  "txn_hash": "0xa5c7180f93dae13c9c91cdb104a8cbea3747201253f4fb99c0973e213834fe1f",
+  "success": true,
+  "gas_used": 4,
+  "vm_status": "Executed successfully",
+  "abort": null,
+  "root": {
+    "kind": "function",
+    "module": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter",
+    "function": "increment",
+    "type_args": [],
+    "args": [
+      {
+        "type": "u64",
+        "value": "5"
+      }
+    ],
+    "return": [
+      {
+        "type": "()",
+        "value": null
+      }
+    ],
+    "gas": 949862,
+    "events": [
+      {
+        "type": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter::Incremented",
+        "data": {
+          "value": "13"
+        }
+      }
+    ],
+    "storage": [
+      {
+        "op": "load_resource",
+        "type": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter::Counter",
+        "address": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16"
+      },
+      {
+        "op": "borrow_global_mut",
+        "type": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter::Counter",
+        "address": null
+      }
+    ],
+    "children": [
+      {
+        "kind": "function",
+        "module": "0x1::signer",
+        "function": "address_of",
+        "type_args": [],
+        "args": [
+          {
+            "type": "struct",
+            "value": {
+              "0": "0",
+              "1": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16"
+            }
+          }
+        ],
+        "return": [
+          {
+            "type": "address",
+            "value": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16"
+          }
+        ],
+        "gas": 6799,
+        "events": [],
+        "storage": [],
+        "children": [
+          {
+            "kind": "native",
+            "module": "0x1::signer",
+            "function": "borrow_address",
+            "type_args": [],
+            "args": [
+              {
+                "type": "struct",
+                "value": {
+                  "0": "0",
+                  "1": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16"
+                }
+              }
+            ],
+            "return": [
+              {
+                "type": "address",
+                "value": "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16"
+              }
+            ],
+            "gas": 735,
+            "events": [],
+            "storage": [],
+            "children": []
+          }
+        ]
+      },
+      {
+        "kind": "function",
+        "module": "0x1::event",
+        "function": "emit",
+        "type_args": [
+          "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter::Incremented"
+        ],
+        "args": [
+          {
+            "type": "struct",
+            "value": {
+              "0": "13"
+            }
+          }
+        ],
+        "return": [
+          {
+            "type": "()",
+            "value": null
+          }
+        ],
+        "gas": 5871,
+        "events": [],
+        "storage": [],
+        "children": [
+          {
+            "kind": "native",
+            "module": "0x1::event",
+            "function": "write_module_event_to_store",
+            "type_args": [
+              "0xf90391c81027f03cdea491ed8b36ffaced26b6df208a9b569e5baf2590eb9b16::counter::Incremented"
+            ],
+            "args": [
+              {
+                "type": "struct",
+                "value": {
+                  "0": "13"
+                }
+              }
+            ],
+            "return": [],
+            "gas": 24886,
+            "events": [],
+            "storage": [],
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/movehat/src/core/trace/__tests__/renderer.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/renderer.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import { formatTraceLines } from "../renderer.js";
+import type { CallNode, TraceResponse } from "../types.js";
+import sample from "./fixtures/counter-increment.json" with { type: "json" };
+
+const real = sample as unknown as TraceResponse;
+const text = (lines: string[]) => lines.join("\n");
+
+// Minimal CallNode factory for crafted fixtures.
+const node = (over: Partial<CallNode>): CallNode => ({
+  kind: "function",
+  module: "0xabc::user",
+  function: "f",
+  type_args: [],
+  args: [],
+  return: [],
+  gas: 100,
+  events: [],
+  storage: [],
+  children: [],
+  ...over,
+});
+
+describe("formatTraceLines — real counter-increment fixture", () => {
+  it("level 2: flat event list + footer, no call tree", () => {
+    const out = text(formatTraceLines(real, 2, 5));
+    expect(out).toContain("Events");
+    expect(out).toMatch(/emit .*::counter::Incremented/);
+    // No tree frame label for the entry function at level 2.
+    expect(out).not.toContain("increment(");
+    expect(out).toMatch(/gas_used: \d+ octas/);
+    expect(out).toContain("traced in 5ms");
+  });
+
+  it("level 3: shows the user frame, filters 0x1:: framework frames", () => {
+    const out = text(formatTraceLines(real, 3, 5));
+    expect(out).toContain("::counter::increment(");
+    // Framework helpers are hidden at level 3.
+    expect(out).not.toContain("0x1::signer");
+    expect(out).not.toContain("0x1::event");
+  });
+
+  it("level 4: shows framework frames, natives, storage, and returns", () => {
+    const out = text(formatTraceLines(real, 4, 5));
+    expect(out).toContain("0x1::signer::address_of");
+    expect(out).toContain("0x1::event::emit");
+    expect(out).toContain("load_resource");
+    expect(out).toContain("←"); // a return value from a framework helper
+  });
+
+  it("never emits raw ANSI escape codes (color is gated)", () => {
+    for (const lvl of [2, 3, 4]) {
+      expect(text(formatTraceLines(real, lvl, 5))).not.toContain("\x1b[");
+    }
+  });
+
+  it("shortens long addresses in frame paths", () => {
+    const out = text(formatTraceLines(real, 3, 5));
+    expect(out).toMatch(/0x[0-9a-f]{4}\.\.[0-9a-f]{4}::counter/);
+  });
+});
+
+describe("formatTraceLines — level 3 event bubbling", () => {
+  it("surfaces an event emitted by a hidden framework frame under the user ancestor", () => {
+    const trace: TraceResponse = {
+      txn_hash: "0x1",
+      success: true,
+      gas_used: 10,
+      vm_status: "Executed successfully",
+      abort: null,
+      root: node({
+        module: "0xabc::user",
+        function: "do_thing",
+        children: [
+          node({
+            kind: "function",
+            module: "0x1::event",
+            function: "emit",
+            events: [{ type: "0xabc::user::Did", data: { ok: true } }],
+            children: [
+              node({
+                kind: "native",
+                module: "0x1::event",
+                function: "write_module_event_to_store",
+              }),
+            ],
+          }),
+        ],
+      }),
+    };
+
+    const out = text(formatTraceLines(trace, 3, 1));
+    // The user frame shows...
+    expect(out).toContain("0xabc::user::do_thing");
+    // ...the event bubbles up even though its emitting frame is hidden...
+    expect(out).toContain("emit 0xabc::user::Did");
+    // ...and the framework frame itself stays hidden at level 3.
+    expect(out).not.toContain("0x1::event::emit");
+  });
+});
+
+describe("formatTraceLines — abort", () => {
+  const aborted: TraceResponse = {
+    txn_hash: "0x9",
+    success: false,
+    gas_used: 7,
+    vm_status: "Move abort",
+    abort: {
+      code: 1,
+      sub_status: null,
+      module: "0xabc::user",
+      stack: [
+        { module: "0xabc::user", function: "guard", offset: 14 },
+        { module: null, function: null, offset: null },
+      ],
+    },
+    root: node({
+      module: "0xabc::user",
+      function: "do_thing",
+      children: [
+        node({ kind: "native", module: "0x1::vector", function: "borrow" }),
+      ],
+    }),
+  };
+
+  it("renders the abort header, stack, and a failed footer", () => {
+    const out = text(formatTraceLines(aborted, 3, 2));
+    expect(out).toMatch(/Aborted: code 1/);
+    expect(out).toContain("at 0xabc::user::guard @14");
+    expect(out).toContain("at <unknown>::<unknown>"); // null module/function/offset
+    expect(out).not.toContain("@null"); // null offset omitted, not printed
+  });
+
+  it("forces the full tree on abort even at level 3 (native frame visible)", () => {
+    const out = text(formatTraceLines(aborted, 3, 2));
+    expect(out).toContain("0x1::vector::borrow");
+  });
+});

--- a/packages/movehat/src/core/trace/__tests__/renderer.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/renderer.test.ts
@@ -137,3 +137,34 @@ describe("formatTraceLines — abort", () => {
     expect(out).toContain("0x1::vector::borrow");
   });
 });
+
+describe("formatTraceLines — nested struct values", () => {
+  // A struct arg whose field is itself a struct: movelite decodes these as
+  // nested objects. The formatter must recurse, not render "[object Object]".
+  const nested: TraceResponse = {
+    txn_hash: "0xa",
+    success: true,
+    gas_used: 10,
+    vm_status: "Executed successfully",
+    abort: null,
+    root: node({
+      module: "0xabc::user",
+      function: "wrap",
+      args: [
+        {
+          type: "struct",
+          value: { "0": 7, "1": { "0": "0xabc", "1": 42 } },
+        },
+      ],
+      return: [{ type: "struct", value: { "0": { "0": 1 } } }],
+    }),
+  };
+
+  it("recurses into nested struct args and returns (no [object Object])", () => {
+    const out = text(formatTraceLines(nested, 4, 1));
+    expect(out).not.toContain("[object Object]");
+    // Inner struct rendered with its own braces.
+    expect(out).toContain("{ 7, { 0xabc, 42 } }");
+    expect(out).toContain("{ { 1 } }");
+  });
+});

--- a/packages/movehat/src/core/trace/client.ts
+++ b/packages/movehat/src/core/trace/client.ts
@@ -1,0 +1,52 @@
+import {
+  generateSignedTransaction,
+  type AccountAuthenticator,
+  type AnyRawTransaction,
+} from "@aptos-labs/ts-sdk";
+
+import type { TraceResponse } from "./types.js";
+
+/** Content type movelite requires for BCS-signed transaction bodies. */
+const BCS_SIGNED_TXN_CONTENT_TYPE = "application/x.aptos.signed_transaction+bcs";
+
+/**
+ * Execute a signed transaction through movelite's instrumented VM and return
+ * the Foundry-style call tree. `commit=true` runs the trace AND commits in a
+ * single pass, so this is the sole execution — the caller must NOT also submit.
+ *
+ * @param rpcUrl movelite RPC base, already ending in `/v1`.
+ * @throws if the endpoint returns a non-2xx status (a submission failure).
+ */
+export async function traceTransaction(args: {
+  rpcUrl: string;
+  transaction: AnyRawTransaction;
+  senderAuthenticator: AccountAuthenticator;
+}): Promise<{ response: TraceResponse; elapsedMs: number }> {
+  const { rpcUrl, transaction, senderAuthenticator } = args;
+
+  const bytes = generateSignedTransaction({ transaction, senderAuthenticator });
+  const url = `${rpcUrl}/transactions/trace?commit=true`;
+
+  const start = performance.now();
+  const res = await fetch(url, {
+    method: "POST",
+    // No Accept header (response is JSON); no auth header (movelite runs --no-auth).
+    // Copy into a fresh ArrayBuffer-backed Uint8Array: the SDK returns
+    // `Uint8Array<ArrayBufferLike>`, which the fetch `BodyInit` type rejects
+    // under this TS lib config (the ArrayBuffer / SharedArrayBuffer split).
+    headers: { "Content-Type": BCS_SIGNED_TXN_CONTENT_TYPE },
+    body: new Uint8Array(bytes),
+  });
+  const elapsedMs = performance.now() - start;
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `movelite trace request failed (${res.status} ${res.statusText})` +
+        (body ? `: ${body}` : "")
+    );
+  }
+
+  const response = (await res.json()) as TraceResponse;
+  return { response, elapsedMs };
+}

--- a/packages/movehat/src/core/trace/client.ts
+++ b/packages/movehat/src/core/trace/client.ts
@@ -10,6 +10,34 @@ import type { TraceResponse } from "./types.js";
 const BCS_SIGNED_TXN_CONTENT_TYPE = "application/x.aptos.signed_transaction+bcs";
 
 /**
+ * Pull a readable detail out of a movelite error body. movelite (>= 0.2.1)
+ * returns structured JSON errors (`{ message, error_code, vm_error_code }`);
+ * older versions return plain text. Returns the `message` plus any codes when
+ * the body is JSON, otherwise the raw text unchanged.
+ */
+function extractErrorDetail(body: string): string {
+  if (!body) return "";
+  try {
+    const parsed = JSON.parse(body) as {
+      message?: unknown;
+      error_code?: unknown;
+      vm_error_code?: unknown;
+    };
+    if (parsed && typeof parsed.message === "string") {
+      const codes = [parsed.error_code, parsed.vm_error_code].filter(
+        (c) => c !== undefined && c !== null
+      );
+      return codes.length > 0
+        ? `${parsed.message} (${codes.join(", ")})`
+        : parsed.message;
+    }
+  } catch {
+    // Not JSON (e.g. older movelite plain-text errors) — fall through.
+  }
+  return body;
+}
+
+/**
  * Execute a signed transaction through movelite's instrumented VM and return
  * the Foundry-style call tree. `commit=true` runs the trace AND commits in a
  * single pass, so this is the sole execution — the caller must NOT also submit.
@@ -41,9 +69,10 @@ export async function traceTransaction(args: {
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
+    const detail = extractErrorDetail(body);
     throw new Error(
       `movelite trace request failed (${res.status} ${res.statusText})` +
-        (body ? `: ${body}` : "")
+        (detail ? `: ${detail}` : "")
     );
   }
 

--- a/packages/movehat/src/core/trace/renderer.ts
+++ b/packages/movehat/src/core/trace/renderer.ts
@@ -49,14 +49,21 @@ const leafValue = (value: unknown): string => {
   return s;
 };
 
-const formatArgValue = (arg: TracedArg): string => {
-  if (arg.value === null) return "()";
-  if (arg.type === "struct" && typeof arg.value === "object") {
-    return `{ ${Object.values(arg.value as Record<string, unknown>)
-      .map(leafValue)
+/** Format a decoded value. Struct (and vector) values arrive as objects with
+ *  by-index keys; their fields can themselves be structs, so recurse rather
+ *  than `String()`-ing a nested object into `[object Object]`. */
+const formatValue = (value: unknown): string => {
+  if (value !== null && typeof value === "object") {
+    return `{ ${Object.values(value as Record<string, unknown>)
+      .map(formatValue)
       .join(", ")} }`;
   }
-  return leafValue(arg.value);
+  return leafValue(value);
+};
+
+const formatArgValue = (arg: TracedArg): string => {
+  if (arg.value === null) return "()";
+  return formatValue(arg.value);
 };
 
 const formatArgs = (args: TracedArg[]): string =>

--- a/packages/movehat/src/core/trace/renderer.ts
+++ b/packages/movehat/src/core/trace/renderer.ts
@@ -1,0 +1,239 @@
+import { logger } from "../../ui/index.js";
+import { colors, rgbToAnsi, shouldUseColor } from "../../ui/colors.js";
+import { symbols } from "../../ui/symbols.js";
+
+import type {
+  AbortInfo,
+  CallNode,
+  TracedArg,
+  TracedEvent,
+  TraceResponse,
+} from "./types.js";
+
+// rgbToAnsi emits raw escapes unconditionally, so guard these two ourselves
+// (unlike colors.*, which already no-op when color is disabled).
+const orange = (s: string): string =>
+  shouldUseColor() ? `${rgbToAnsi(255, 165, 0)}${s}\x1b[0m` : s;
+const brightBlue = (s: string): string =>
+  shouldUseColor() ? `${rgbToAnsi(90, 170, 255)}${s}\x1b[0m` : s;
+
+const indent = (depth: number): string => "  ".repeat(depth);
+
+/** Shorten a 0x-prefixed address for display (`0xf903..9b16`); leave short
+ *  framework addresses like `0x1` untouched. */
+const shortAddr = (addr: string): string =>
+  addr.startsWith("0x") && addr.length > 12
+    ? `${addr.slice(0, 6)}..${addr.slice(-4)}`
+    : addr;
+
+/** Shorten the address part of a `address::module[::Name]` path. */
+const shortenPath = (path: string): string => {
+  const [addr, ...rest] = path.split("::");
+  if (addr === undefined || rest.length === 0) return path;
+  return [shortAddr(addr), ...rest].join("::");
+};
+
+const isFramework = (module: string | null): boolean =>
+  module !== null && module.startsWith("0x1::");
+
+/** Visible at level 3 (user-module tree): not a framework frame, not a native. */
+const isUserFrame = (node: CallNode): boolean =>
+  !isFramework(node.module) && node.kind !== "native";
+
+const NUMERIC = /^\d+$/;
+
+const leafValue = (value: unknown): string => {
+  const s = String(value);
+  if (NUMERIC.test(s)) return orange(s);
+  if (s.startsWith("0x") && s.length > 12) return shortAddr(s);
+  return s;
+};
+
+const formatArgValue = (arg: TracedArg): string => {
+  if (arg.value === null) return "()";
+  if (arg.type === "struct" && typeof arg.value === "object") {
+    return `{ ${Object.values(arg.value as Record<string, unknown>)
+      .map(leafValue)
+      .join(", ")} }`;
+  }
+  return leafValue(arg.value);
+};
+
+const formatArgs = (args: TracedArg[]): string =>
+  args.map(formatArgValue).join(", ");
+
+const frameName = (node: CallNode): string => {
+  const base = node.module
+    ? `${shortenPath(node.module)}::${node.function ?? "?"}`
+    : node.function ?? `<${node.kind}>`;
+  return base;
+};
+
+const frameLabel = (node: CallNode): string => {
+  const name = frameName(node);
+  const colored =
+    isFramework(node.module) || node.kind === "native"
+      ? colors.dim(name)
+      : colors.bold(colors.info(name));
+  const gas = colors.dim(` [${node.gas}]`);
+  return `${colored}(${formatArgs(node.args)})${gas}`;
+};
+
+const formatData = (data: unknown): string => {
+  if (data === null || data === undefined) return "";
+  try {
+    return colors.dim(JSON.stringify(data));
+  } catch {
+    return colors.dim(String(data));
+  }
+};
+
+const eventLine = (event: TracedEvent): string =>
+  `${colors.warning(`emit ${shortenPath(event.type)}`)} ${formatData(event.data)}`.trimEnd();
+
+const storageLine = (op: { op: string; type: string; address: string | null }): string =>
+  `${colors.primary(`${op.op} ${shortenPath(op.type)}`)}${
+    op.address ? colors.dim(` @${shortAddr(op.address)}`) : ""
+  }`;
+
+/** Non-unit return values only; null when nothing to show. */
+const returnLine = (ret: TracedArg[]): string | null => {
+  const meaningful = ret.filter((r) => r.type !== "()" && r.value !== null);
+  if (meaningful.length === 0) return null;
+  return colors.success(`← ${meaningful.map(formatArgValue).join(", ")}`);
+};
+
+/** Collect every event in the tree with its emitting module — for the flat
+ *  level-2 view. */
+const collectEvents = (
+  node: CallNode,
+  out: { module: string | null; event: TracedEvent }[]
+): void => {
+  for (const e of node.events) out.push({ module: node.module, event: e });
+  for (const c of node.children) collectEvents(c, out);
+};
+
+/** Level 3: descend through hidden (framework / native) frames, bubbling their
+ *  events up and surfacing the nearest visible frames as children. */
+const gatherHidden = (
+  children: CallNode[],
+  bubbled: TracedEvent[],
+  visible: CallNode[]
+): void => {
+  for (const child of children) {
+    if (isUserFrame(child)) {
+      visible.push(child);
+    } else {
+      bubbled.push(...child.events);
+      gatherHidden(child.children, bubbled, visible);
+    }
+  }
+};
+
+const renderNode = (
+  node: CallNode,
+  depth: number,
+  showFull: boolean,
+  lines: string[]
+): void => {
+  lines.push(indent(depth) + frameLabel(node));
+  const childDepth = depth + 1;
+
+  if (showFull) {
+    for (const e of node.events) lines.push(indent(childDepth) + eventLine(e));
+    for (const s of node.storage) lines.push(indent(childDepth) + storageLine(s));
+    const ret = returnLine(node.return);
+    if (ret) lines.push(indent(childDepth) + ret);
+    for (const c of node.children) renderNode(c, childDepth, showFull, lines);
+    return;
+  }
+
+  // Level 3: own events + events bubbled from hidden descendants, then the
+  // nearest visible child frames.
+  const bubbled: TracedEvent[] = [];
+  const visibleChildren: CallNode[] = [];
+  gatherHidden(node.children, bubbled, visibleChildren);
+  for (const e of [...node.events, ...bubbled]) {
+    lines.push(indent(childDepth) + eventLine(e));
+  }
+  for (const c of visibleChildren) renderNode(c, childDepth, showFull, lines);
+};
+
+const formatAbort = (abort: AbortInfo): string[] => {
+  const lines: string[] = [];
+  let header = colors.error(`${symbols.error} Aborted: code ${abort.code}`);
+  if (abort.sub_status !== null) {
+    header += colors.error(` (sub_status ${abort.sub_status})`);
+  }
+  if (abort.module !== null) {
+    header += colors.dim(` in ${shortenPath(abort.module)}`);
+  }
+  lines.push(header);
+  for (const entry of abort.stack) {
+    const mod = entry.module !== null ? shortenPath(entry.module) : "<unknown>";
+    const fn = entry.function ?? "<unknown>";
+    const off = entry.offset !== null ? ` @${entry.offset}` : "";
+    lines.push("  " + colors.error(`at ${mod}::${fn}${off}`));
+  }
+  return lines;
+};
+
+const formatFooter = (response: TraceResponse, elapsedMs: number): string => {
+  const status = response.success
+    ? colors.success(`${symbols.success} Executed successfully`)
+    : colors.error(`${symbols.error} Aborted`);
+  const sep = colors.dim(" · ");
+  const gas = colors.dim(`gas_used: ${response.gas_used} octas`);
+  const timed = brightBlue(`traced in ${Math.round(elapsedMs)}ms`);
+  return `${status}${sep}${gas}${sep}${timed}`;
+};
+
+/**
+ * Pure formatter — turns a trace into display lines. Snapshot-testable without
+ * touching stdout. `level` is the verbosity level (2..4); per-frame `gas` is in
+ * internal VM units while the footer `gas_used` is in octas (never mixed).
+ */
+export function formatTraceLines(
+  response: TraceResponse,
+  level: number,
+  elapsedMs: number
+): string[] {
+  const lines: string[] = [];
+
+  if (level <= 2) {
+    const events: { module: string | null; event: TracedEvent }[] = [];
+    collectEvents(response.root, events);
+    if (events.length === 0) {
+      lines.push(colors.dim("(no events emitted)"));
+    } else {
+      lines.push(colors.bold("Events"));
+      for (const { event } of events) lines.push("  " + eventLine(event));
+    }
+  } else {
+    // Aborts always show the full tree so the failing frame is visible.
+    const showFull = level >= 4 || !response.success;
+    lines.push(colors.bold("Trace"));
+    renderNode(response.root, 0, showFull, lines);
+  }
+
+  if (!response.success && response.abort) {
+    lines.push("");
+    lines.push(...formatAbort(response.abort));
+  }
+
+  lines.push("");
+  lines.push(formatFooter(response, elapsedMs));
+  return lines;
+}
+
+/** Render a trace to the terminal. Wraps {@link formatTraceLines}. */
+export function renderTrace(
+  response: TraceResponse,
+  opts: { level: number; elapsedMs: number }
+): void {
+  logger.newline();
+  for (const line of formatTraceLines(response, opts.level, opts.elapsedMs)) {
+    logger.plain(line);
+  }
+  logger.newline();
+}

--- a/packages/movehat/src/core/trace/types.ts
+++ b/packages/movehat/src/core/trace/types.ts
@@ -1,0 +1,75 @@
+/**
+ * TypeScript mirror of the JSON contract movelite's `/v1/transactions/trace`
+ * endpoint serializes. Field names and shapes match the Rust structs exactly;
+ * do not rename keys (`return` is keyed literally, `address` is nullable, etc.).
+ */
+
+/** A decoded argument or return value. `value` shape depends on `type`:
+ *  primitives like `u64` arrive as strings (`"5"`); a `struct` arrives as an
+ *  object keyed by field index (`{ "0": .., "1": .. }`); the unit type `()` has
+ *  `value: null`. */
+export interface TracedArg {
+  type: string;
+  value: unknown;
+}
+
+/** An event emitted within a frame. `data` is the decoded event payload. */
+export interface TracedEvent {
+  type: string;
+  data: unknown;
+}
+
+/** A storage access. `address` is populated for `load_resource` and null for
+ *  `move_to` / `borrow_global_mut`. */
+export interface StorageOp {
+  op: string;
+  type: string;
+  address: string | null;
+}
+
+/** One frame of the abort stack, innermost first. Any field may be null when
+ *  the VM could not resolve it. */
+export interface AbortStackEntry {
+  module: string | null;
+  function: string | null;
+  offset: number | null;
+}
+
+/** Abort details, present only when `TraceResponse.success` is false. */
+export interface AbortInfo {
+  code: number;
+  sub_status: number | null;
+  module: string | null;
+  stack: AbortStackEntry[];
+}
+
+/** A single call frame in the execution tree. */
+export interface CallNode {
+  kind: "function" | "native" | "script";
+  module: string | null;
+  function: string | null;
+  type_args: string[];
+  args: TracedArg[];
+  /** Keyed literally as `return` to match the wire format. */
+  return: TracedArg[];
+  /**
+   * Self gas of this frame in **internal** VM gas units. These are much larger
+   * than, and NOT comparable to, the external octa `gas_used` on the response —
+   * never mix the two when rendering.
+   */
+  gas: number;
+  events: TracedEvent[];
+  storage: StorageOp[];
+  children: CallNode[];
+}
+
+/** The full trace response. */
+export interface TraceResponse {
+  txn_hash: string;
+  success: boolean;
+  /** Transaction-level gas in octas (the external unit). */
+  gas_used: number;
+  vm_status: string;
+  abort: AbortInfo | null;
+  root: CallNode;
+}

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -226,9 +226,15 @@ async function setupWithLocalNode(
       throw new Error("Failed to get deployer private key");
     }
 
+    // movelite exposes the /transactions/trace endpoint that powers
+    // Foundry-style execution traces; a real Movement node does not. Compute
+    // this once and reuse it for both the trace wiring and SDK publish below.
+    const isMovelite = localNode instanceof MoveliteManager;
+
     const runtime = await initRuntime({
       network: "local",
       accountManager,
+      ...(isMovelite ? { traceRpcUrl: `${nodeInfo.rpcUrl}/v1` } : {}),
       configOverride: {
         networks: {
           local: {
@@ -251,7 +257,7 @@ async function setupWithLocalNode(
 
       // movelite's REST responses can't drive the Movement CLI publish flow,
       // so deploy through the TypeScript SDK when it is the spawned backend.
-      const sdkPublish = localNode instanceof MoveliteManager;
+      const sdkPublish = isMovelite;
 
       try {
         for (const moduleName of options.autoDeploy) {

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -35,6 +35,14 @@ export interface InitRuntimeOptions {
    * key it extracts ends up on the same manager the runtime exposes.
    */
   accountManager?: AccountManager;
+  /**
+   * movelite RPC base URL (already ending in `/v1`) enabling Foundry-style
+   * execution traces on `contract.call(...)` at verbosity level >= 2. Set only
+   * when the active backend is movelite (its `/transactions/trace` endpoint
+   * does not exist on a real Movement node). When omitted, contracts use the
+   * normal submit path and never trace.
+   */
+  traceRpcUrl?: string;
 }
 
 /**
@@ -98,7 +106,7 @@ export async function initRuntime(
 
   // Helper functions
   const getContractHelper = (address: string, moduleName: string): MoveContract => {
-    return getContract(aptos, address, moduleName);
+    return getContract(aptos, address, moduleName, options.traceRpcUrl);
   };
 
   const deployContract = async (

--- a/packages/movehat/src/ui/__tests__/logger.test.ts
+++ b/packages/movehat/src/ui/__tests__/logger.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { configureLogger, isVerbose, divider, phase } from "../logger.js";
+import {
+  configureLogger,
+  isVerbose,
+  getVerbosityLevel,
+  divider,
+  phase,
+} from "../logger.js";
 
 describe("logger — verbosity", () => {
   let originalEnv: string | undefined;
@@ -46,6 +52,62 @@ describe("logger — verbosity", () => {
     expect(isVerbose()).toBe(false);
     process.env.MOVEHAT_VERBOSE = "0";
     expect(isVerbose()).toBe(false);
+  });
+});
+
+describe("logger — getVerbosityLevel", () => {
+  let origLevel: string | undefined;
+  let origVerbose: string | undefined;
+
+  beforeEach(() => {
+    origLevel = process.env.MOVEHAT_VERBOSITY;
+    origVerbose = process.env.MOVEHAT_VERBOSE;
+    delete process.env.MOVEHAT_VERBOSITY;
+    delete process.env.MOVEHAT_VERBOSE;
+  });
+
+  afterEach(() => {
+    if (origLevel === undefined) delete process.env.MOVEHAT_VERBOSITY;
+    else process.env.MOVEHAT_VERBOSITY = origLevel;
+    if (origVerbose === undefined) delete process.env.MOVEHAT_VERBOSE;
+    else process.env.MOVEHAT_VERBOSE = origVerbose;
+  });
+
+  it("defaults to 0 when neither env var is set", () => {
+    expect(getVerbosityLevel()).toBe(0);
+  });
+
+  it("reads the numeric level from MOVEHAT_VERBOSITY", () => {
+    for (const n of [0, 1, 2, 3, 4]) {
+      process.env.MOVEHAT_VERBOSITY = String(n);
+      expect(getVerbosityLevel()).toBe(n);
+    }
+  });
+
+  it("clamps out-of-range values into 0..4", () => {
+    process.env.MOVEHAT_VERBOSITY = "9";
+    expect(getVerbosityLevel()).toBe(4);
+    process.env.MOVEHAT_VERBOSITY = "-3";
+    expect(getVerbosityLevel()).toBe(0);
+  });
+
+  it("ignores a non-numeric MOVEHAT_VERBOSITY and falls through", () => {
+    process.env.MOVEHAT_VERBOSITY = "loud";
+    expect(getVerbosityLevel()).toBe(0);
+    process.env.MOVEHAT_VERBOSITY = "loud";
+    process.env.MOVEHAT_VERBOSE = "1";
+    expect(getVerbosityLevel()).toBe(1);
+  });
+
+  it("falls back to level 1 for the legacy MOVEHAT_VERBOSE=1 when MOVEHAT_VERBOSITY is unset", () => {
+    process.env.MOVEHAT_VERBOSE = "1";
+    expect(getVerbosityLevel()).toBe(1);
+  });
+
+  it("MOVEHAT_VERBOSITY takes precedence over the legacy MOVEHAT_VERBOSE", () => {
+    process.env.MOVEHAT_VERBOSE = "1";
+    process.env.MOVEHAT_VERBOSITY = "3";
+    expect(getVerbosityLevel()).toBe(3);
   });
 });
 

--- a/packages/movehat/src/ui/logger.ts
+++ b/packages/movehat/src/ui/logger.ts
@@ -48,6 +48,29 @@ export const isVerbose = (): boolean =>
   config.verbosity === 'verbose' || process.env.MOVEHAT_VERBOSE === '1';
 
 /**
+ * Numeric verbosity level (0..4) for level-gated output such as the
+ * transaction-trace renderer. Driven by the counted `-v` CLI flag via the
+ * `MOVEHAT_VERBOSITY` env var, so it survives the spawned test/script
+ * subprocess boundary the same way {@link isVerbose} reads `MOVEHAT_VERBOSE`.
+ * Falls back to the legacy boolean `MOVEHAT_VERBOSE=1` (level 1) for callers
+ * that set only that.
+ *
+ * - 0 default — system logs only
+ * - 1 `-v`    — + subprocess stdout (see {@link isVerbose})
+ * - 2 `-vv`   — + decoded events per call
+ * - 3 `-vvv`  — + user-module call tree
+ * - 4 `-vvvv` — + framework frames, natives, storage, return values
+ */
+export const getVerbosityLevel = (): number => {
+  const raw = process.env.MOVEHAT_VERBOSITY;
+  if (raw !== undefined) {
+    const n = parseInt(raw, 10);
+    if (!Number.isNaN(n)) return Math.max(0, Math.min(4, n));
+  }
+  return process.env.MOVEHAT_VERBOSE === '1' ? 1 : 0;
+};
+
+/**
  * Configure logger globally
  *
  * @param newConfig - Partial configuration to merge with current config
@@ -295,6 +318,7 @@ export const item = (text: string, indent: number = 0): void => {
 export const logger = {
   configure: configureLogger,
   isVerbose,
+  getVerbosityLevel,
   info,
   success,
   error,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.0.0
-        version: 21.0.0(@types/node@24.12.4)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+        version: 21.0.0(@types/node@24.13.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
       '@commitlint/config-conventional':
         specifier: ^21.0.0
         version: 21.0.0
@@ -62,7 +62,7 @@ importers:
         version: 15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-mdx:
         specifier: ^14.2.5
-        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
+        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.13.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0))
       fumadocs-ui:
         specifier: ^15.6.12
         version: 15.8.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
@@ -129,8 +129,8 @@ importers:
         version: 4.21.0
     optionalDependencies:
       movelite:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -1582,11 +1582,11 @@ packages:
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
-  '@types/node@24.12.4':
-    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
-
   '@types/node@24.13.1':
     resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
+
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
@@ -2684,28 +2684,28 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
-  movelite-darwin-arm64@0.2.0:
-    resolution: {integrity: sha512-kAwcGbl0UA8WOX8YkftDEDFub599qLknRAX64AQT8xA+Gp3gUtWhAKktc9q+oGV3ZhYEl562JN9QxqEhspokAA==}
+  movelite-darwin-arm64@0.2.1:
+    resolution: {integrity: sha512-dnJn4jur0Cc9poxKxiqdOhDPANhSdE8BEZ4oX/eocATTJ+ismy8YdVCUnUQL5c/zaM927AyQTWxZ/ZsApkfLQA==}
     cpu: [arm64]
     os: [darwin]
 
-  movelite-darwin-x64@0.2.0:
-    resolution: {integrity: sha512-TXYAZcm2N/IE+ZdMh3vNg/1oAgTAW6UTql9TVc3PNBeZGRambi1OTpd3Id0kTINvq16T7bacwbpwmgzOHpWwPw==}
+  movelite-darwin-x64@0.2.1:
+    resolution: {integrity: sha512-v9IXQPXYidB2j0JMjuZ/KA9k2YARULNqKrCS8jrBKPCdsNXQx1+BzZNm45YhwU35dARO2aw3W+LHXPQ2jQBiSw==}
     cpu: [x64]
     os: [darwin]
 
-  movelite-linux-arm64@0.2.0:
-    resolution: {integrity: sha512-xE0ZLR9vaB6eyvzHsSVA6+oRIyjCYGys/OryNMXV1lR9gix6THVdcoW8qsHrjfj+ndPC+T55ZuQsFA/csjmMgA==}
+  movelite-linux-arm64@0.2.1:
+    resolution: {integrity: sha512-jDzs1WNUjYmiAAolsShmwW2tsf58OdVsOCkfhsQWslbTJMJIBriwLPdwm0EDnhskluVR6p+8y2iALXBPTz7LoA==}
     cpu: [arm64]
     os: [linux]
 
-  movelite-linux-x64@0.2.0:
-    resolution: {integrity: sha512-BvI+Zs6yw5iZwK+FEZVX6JBziQhwHcb4Pxs0kOXXdSj2D8tRzZVQuKkc3VLLzNDr6akzW4+6JcEo6ZEHt0UL4g==}
+  movelite-linux-x64@0.2.1:
+    resolution: {integrity: sha512-jj8D/IiHuzi0rl5J/SGB7dIkbWAE4c7jcVUkXq28Yvrc2RTAfEX3ZbXfQ+k+93S5wppaIqqIq/nRH1LtAWnp8g==}
     cpu: [x64]
     os: [linux]
 
-  movelite@0.2.0:
-    resolution: {integrity: sha512-AEc6EfM1B66wNMJmizqVs91HP2X14DZQ1o/VzqHzJK8dF9KX/GvYG04lDqVtTrSLL4dngJnxHfz8X0Hwjae0jQ==}
+  movelite@0.2.1:
+    resolution: {integrity: sha512-NdPthoiMFwYJpVVHGSwUDm/rqwkJOGX1QP9W6lQMO/eZe4YGxTL+6oqtXY+c0c0GB82VQh4G98AhbNf954+CUw==}
     hasBin: true
 
   ms@2.1.3:
@@ -3441,11 +3441,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@21.0.0(@types/node@24.12.4)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+  '@commitlint/cli@21.0.0(@types/node@24.13.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 21.0.0
       '@commitlint/lint': 21.0.0
-      '@commitlint/load': 21.0.0(@types/node@24.12.4)(typescript@5.9.3)
+      '@commitlint/load': 21.0.0(@types/node@24.13.1)(typescript@5.9.3)
       '@commitlint/read': 21.0.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 21.0.0
       tinyexec: 1.0.2
@@ -3490,14 +3490,14 @@ snapshots:
       '@commitlint/rules': 21.0.0
       '@commitlint/types': 21.0.0
 
-  '@commitlint/load@21.0.0(@types/node@24.12.4)(typescript@5.9.3)':
+  '@commitlint/load@21.0.0(@types/node@24.13.1)(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 21.0.0
       '@commitlint/execute-rule': 21.0.0
       '@commitlint/resolve-extends': 21.0.0
       '@commitlint/types': 21.0.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.12.4)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.13.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
       es-toolkit: 1.46.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -4575,7 +4575,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 24.13.1
+      '@types/node': 24.13.2
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -4605,7 +4605,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 24.13.1
+      '@types/node': 24.13.2
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -4621,11 +4621,11 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@24.12.4':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@24.13.1':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
 
@@ -4644,7 +4644,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 24.13.1
+      '@types/node': 24.13.2
 
   '@types/unist@2.0.11': {}
 
@@ -4880,9 +4880,9 @@ snapshots:
       '@simple-libs/stream-utils': 1.2.0
       meow: 13.2.0
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@24.12.4)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@24.13.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
@@ -5148,7 +5148,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
+  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.14.0(react@19.2.4))(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(mdast-util-mdx-jsx@3.2.0)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.13.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -5175,7 +5175,7 @@ snapshots:
       mdast-util-mdx-jsx: 3.2.0
       next: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-      vite: 7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@24.13.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6040,24 +6040,24 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
-  movelite-darwin-arm64@0.2.0:
+  movelite-darwin-arm64@0.2.1:
     optional: true
 
-  movelite-darwin-x64@0.2.0:
+  movelite-darwin-x64@0.2.1:
     optional: true
 
-  movelite-linux-arm64@0.2.0:
+  movelite-linux-arm64@0.2.1:
     optional: true
 
-  movelite-linux-x64@0.2.0:
+  movelite-linux-x64@0.2.1:
     optional: true
 
-  movelite@0.2.0:
+  movelite@0.2.1:
     optionalDependencies:
-      movelite-darwin-arm64: 0.2.0
-      movelite-darwin-x64: 0.2.0
-      movelite-linux-arm64: 0.2.0
-      movelite-linux-x64: 0.2.0
+      movelite-darwin-arm64: 0.2.1
+      movelite-darwin-x64: 0.2.1
+      movelite-linux-arm64: 0.2.1
+      movelite-linux-x64: 0.2.1
     optional: true
 
   ms@2.1.3: {}
@@ -6693,7 +6693,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0):
+  vite@7.3.1(@types/node@24.13.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.0
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6702,7 +6702,7 @@ snapshots:
       rollup: 4.55.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2


### PR DESCRIPTION
Milestone batch: ships the **movelite-only Foundry-style execution-trace renderer** and bumps **movehat to 0.3.0**.

## What ships

**Feature — execution traces (`-vv` … `-vvvv`)**
- `core/trace/types.ts` — TS model of movelite's `/v1/transactions/trace` response.
- `core/trace/client.ts` — POSTs the BCS-signed txn with `commit=true` (single instrumented execution that also commits); parses movelite 0.2.1's JSON error bodies with plain-text fallback.
- `core/trace/renderer.ts` — L2 flat events / L3 user-module tree (framework frames filtered, their events bubbled up) / L4 full tree; abort header + stack; gas in internal units vs the octa `gas_used` footer. Color is gated for non-TTY/`NO_COLOR`.
- Wiring: counted `-v` + `MOVEHAT_VERBOSITY` (crosses the subprocess boundary), `MoveContract.call()` routes through the trace endpoint on movelite at level >= 2 and preserves `{hash, success, vm_status}`. Render failure degrades to a warning, never fails a committed tx.
- Docs: new `guides/traces.mdx`, updated global-flags / console-output / movelite guides, feature lists in both READMEs + the docs index.

**Dependency — movelite 0.2.1**
- Spec `^0.2.0` -> `^0.2.1`; lockfile pins the 0.2.1 shim + all four platform binaries.

**Fix — nested struct rendering**
- Recursive value formatter; nested struct args/returns render as `{ 0, { 2, 0x… } }` instead of `[object Object]`.

**Release**
- `0.2.9` -> `0.3.0`; CHANGELOG `[Unreleased]` finalized as `[0.3.0] - 2026-06-12`.

## Verification (integrated develop HEAD)
- `pnpm install --frozen-lockfile`: up to date
- `pnpm --filter movehat build`: clean (tsc exit 0)
- **585/585** unit tests green
- **Live movelite 0.2.1 e2e at `-vvvv`**:
  - `counter.increment()` — renders the call tree, commits, follow-up `view -> 1`
  - `registry.register` twice — **real abort** returns HTTP 200 + `success:false` + populated `abort`; renders `✘ Aborted: code 524289 in …::registry` + stack; client does **not** throw, returns `{success:false}`
  - piped + `NO_COLOR`: zero raw ANSI escapes
  - abort JSON shape matches the committed fixture/types exactly (`code`, `sub_status`, `module`, `stack[]{module,function,offset}`)

## npm publish
The publish workflow is **not** triggered by this merge (`publish.yml` runs on `release: published` / `workflow_dispatch` only). After merge, the 0.3.0 npm publish is a separate manual step (with OTP).

Closes #315
Closes #316
Closes #317
Closes #318
Closes #322
Closes #324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Foundry-style execution traces showing call trees, decoded arguments, gas, and abort stacks on the movelite backend.
  * Replaced boolean `-v/--verbose` flag with counted verbosity levels (0-4) and added `MOVEHAT_VERBOSITY` environment variable for fine-grained control.
  * Faster local development with auto-installed movelite binary and fallback to full Movement node.

* **Documentation**
  * Added transaction trace guide and updated global flags documentation to explain verbosity levels and trace capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->