### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-14
+
 ### Added
 
 - Degraded execution traces on the Movement node backend. The full call tree is

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {


### PR DESCRIPTION
Bump movehat 0.3.0 -> 0.4.0 and finalize the CHANGELOG for the node-backend degraded-trace feature (merged via #331).

## What
- `packages/movehat/package.json`: 0.3.0 -> 0.4.0 (minor: new feature, pre-1.0 SemVer).
- `CHANGELOG.md`: `[Unreleased]` -> `[0.4.0] - 2026-06-14`.

## Why minor
New user-facing feature (degraded flat trace on the Movement node backend); render-only and backward-compatible (`contract.call(...)` still returns `{hash, success, vm_status}`).

## Verified live before this batch
- Node full backend at `-vvvv`: 9/9 counter-example tests pass; Events + State changes + `gas_used` footer render.
- movelite at `-vvvv`: full call tree intact (the shared `format.ts` extraction is non-breaking).
- 591 unit tests, movehat build, and docs build all green.

Tracks #330

develop-targeted -> CodeRabbit skip (the develop -> main batch is the review gate).