### PR TITLE
release: movehat 0.4.0 — degraded execution traces on the Movement node backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Degraded execution traces on the Movement node backend. The full call tree is
+  movelite-only (the node's REST API does not expose internal call frames), but
+  the committed-transaction response already carries the events, the write-set,
+  and the gas — so on the Movement node, a fork, or `createLive`, the same
+  verbosity flags now render a flat trace of that data instead of nothing. `-vv`
+  shows the decoded events; `-vvv` adds the write-set summary (which resources
+  were written/deleted, by `address::Module::Resource`); `-vvvv` adds each
+  change's full decoded data. The footer carries the status and the octa
+  `gas_used`. Render-only and opt-in by verbosity — `contract.call(...)` returns
+  the same `{hash, success, vm_status}`, and a render failure degrades to a
+  warning without failing a committed transaction. The generic trace formatters
+  are now shared between the movelite and node renderers (`core/trace/format.ts`).
+
 ## [0.3.0] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-14
+
 ### Added
 
 - Degraded execution traces on the Movement node backend. The full call tree is

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - **Three execution modes** — full local blockchain, read-only fork of a remote network, or live testnet/mainnet binding.
 - **Auto-deploy in tests + auto-detect named addresses** — contracts compile and deploy automatically; no manual address wiring.
 - **Fast local boot with movelite** — on supported platforms an auto-installed [movelite](https://github.com/gilbertsahumada/movelite) binary boots the local test chain in under a second instead of ~15s, with transparent fallback to the full Movement node.
-- **Foundry-style execution traces** — raise verbosity (`-vv` … `-vvvv`) to render an indented call tree for each `contract.call(...)` with decoded arguments, gas, events, and the abort stack (movelite backend).
+- **Foundry-style execution traces** — raise verbosity (`-vv` … `-vvvv`) to render an indented call tree for each `contract.call(...)` with decoded arguments, gas, events, and the abort stack (full tree on the movelite backend; the Movement node renders a degraded flat trace — events, state changes, and gas).
 - **Native fork system** — local JSON-backed snapshots of Movement L1 state, no BCS compatibility issues.
 - **TypeScript-first** — single `PRIVATE_KEY` across all networks (Hardhat-style); deployments tracked per-network in `deployments/`.
 - **SLSA-provenance releases** — every npm release ships with [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) provenance. Verify with `npm view movehat@<version>`.

--- a/packages/docs/content/docs/cli/global-flags.mdx
+++ b/packages/docs/content/docs/cli/global-flags.mdx
@@ -23,10 +23,10 @@ movehat test --ts -vvvv    # L4 + framework frames, natives, storage, return val
 | 0 | _(none)_ | System logs only — the default quiet console. |
 | 1 | `-v` | Subprocess output from `movement node run-localnet` and `aptos move build / publish`, printed with a muted gray `›` prefix. |
 | 2 | `-vv` | A decoded list of the events each `contract.call(...)` emitted. |
-| 3 | `-vvv` | A Foundry-style execution trace showing the call tree of **your** modules (framework `0x1::*` frames filtered out). |
-| 4 | `-vvvv` | The full trace: framework frames, native calls, storage operations, and return values. |
+| 3 | `-vvv` | The call tree of **your** modules (framework `0x1::*` frames filtered out) on movelite; a flat write-set summary on the Movement node. |
+| 4 | `-vvvv` | Full detail: framework frames, natives, storage, and return values on movelite; each state change's full decoded data on the Movement node. |
 
-Levels 2–4 render execution traces, which are a **[movelite](/docs/guides/movelite)-only** capability — they require the trace endpoint the lightweight local runtime exposes. On the full Movement node the same flags still raise subprocess verbosity (level 1), but no call tree is rendered. See [Transaction traces](/docs/guides/traces) for the full output format.
+Levels 2–4 render execution traces. The full **call tree** is a **[movelite](/docs/guides/movelite)-only** capability — it requires the trace endpoint the lightweight local runtime exposes. On the full Movement node (and forks / `createLive`) the same flags render a **degraded flat trace** instead — the transaction's events, state changes, and gas, which the node's response already carries. See [Transaction traces](/docs/guides/traces) for both output formats.
 
 When to reach for level 1 (`-v`):
 

--- a/packages/docs/content/docs/guides/console-output.mdx
+++ b/packages/docs/content/docs/guides/console-output.mdx
@@ -77,10 +77,10 @@ With verbose enabled, subprocess output prints with a muted gray `›` prefix so
 | 0 | _(none)_ | System logs only (the default). |
 | 1 | `-v` | Subprocess output (gray `›` prefix). |
 | 2 | `-vv` | A decoded list of the events each `contract.call(...)` emitted. |
-| 3 | `-vvv` | A Foundry-style call tree of your own modules. |
-| 4 | `-vvvv` | The full trace — framework frames, natives, storage, return values. |
+| 3 | `-vvv` | A Foundry-style call tree of your own modules (movelite); a flat write-set summary on the Movement node. |
+| 4 | `-vvvv` | Full detail — frames/natives/storage/returns (movelite); each state change's decoded data on the Movement node. |
 
-Levels 2–4 render execution traces and only do so on the [movelite](/docs/guides/movelite) backend; see [Transaction traces](/docs/guides/traces). `MOVEHAT_VERBOSITY=<0-4>` sets the level directly without repeating flags.
+Levels 2–4 render execution traces. The full call **tree** is [movelite](/docs/guides/movelite)-only; on the Movement node (and forks / `createLive`) the same flags render a degraded flat trace — events + state changes + gas. See [Transaction traces](/docs/guides/traces). `MOVEHAT_VERBOSITY=<0-4>` sets the level directly without repeating flags.
 
 ## Critical signals always surface
 

--- a/packages/docs/content/docs/guides/movelite.mdx
+++ b/packages/docs/content/docs/guides/movelite.mdx
@@ -117,10 +117,11 @@ platforms and harmless; your tests still pass, just slower.
 
 Because movelite runs an instrumented VM, it can return a Foundry-style execution
 trace for every `contract.call(...)` — the call tree, decoded arguments, gas,
-events, and abort stack. Raise verbosity with `-vv` … `-vvvv` to see it. This is a
-movelite-only capability; the full Movement node does not expose the trace
-endpoint. See [Transaction traces](/docs/guides/traces) for the output format and
-verbosity levels.
+events, and abort stack. Raise verbosity with `-vv` … `-vvvv` to see it. The full
+**call tree** is movelite-only; the Movement node does not expose the trace
+endpoint, but at the same verbosity it renders a degraded flat trace (events +
+state changes + gas). See [Transaction traces](/docs/guides/traces) for both
+output formats and the verbosity levels.
 
 ## When to reach for the Movement node
 

--- a/packages/docs/content/docs/guides/traces.mdx
+++ b/packages/docs/content/docs/guides/traces.mdx
@@ -109,6 +109,11 @@ footer carries the status and the octa `gas_used` (there is no per-frame timing
 off the node). As with the full tree, this is additional detail only — it never
 changes what `contract.call(...)` returns.
 
+The write-set is the transaction's complete state diff, so it includes framework
+resources the runtime touched for gas and fee accounting (coin stores, account
+state) alongside your own. `-vvv` keeps it to a one-line-per-change summary;
+`-vvvv` prints every change's data, which can be verbose on a busy transaction.
+
 ## Scope
 
 Only `contract.call(...)` (state-changing transactions) is traced. `view(...)`

--- a/packages/docs/content/docs/guides/traces.mdx
+++ b/packages/docs/content/docs/guides/traces.mdx
@@ -9,11 +9,13 @@ Foundry-style execution trace for every `contract.call(...)` — an indented cal
 tree with per-frame `module::function`, decoded arguments, gas, return values,
 events, and (on failure) the abort stack.
 
-> Traces are a **[movelite](/docs/guides/movelite)-only** capability. They come
-> from an instrumented VM endpoint that the lightweight local runtime exposes;
-> the full Movement node's REST API does not expose internal call frames. On the
-> Movement node the same flags still raise subprocess verbosity, but no call
-> tree is rendered.
+> The full **call tree** is a **[movelite](/docs/guides/movelite)-only**
+> capability — it comes from an instrumented VM endpoint that the lightweight
+> local runtime exposes, and the full Movement node's REST API does not expose
+> internal call frames. On the Movement node (and forks / `createLive`) the same
+> flags render a **degraded flat trace** instead: the transaction's events, state
+> changes, and gas, which the node's response already carries. See
+> [On the Movement node](#on-the-movement-node-degraded-trace) below.
 
 ## Enabling traces
 
@@ -81,8 +83,35 @@ innermost frame outward:
 The returned result still reports `success: false` and the `vm_status` — the
 trace is additional detail, it does not change what `contract.call(...)` returns.
 
+## On the Movement node (degraded trace)
+
+The full Movement node does not expose internal call frames, so the call tree is
+movelite-only. But the node's transaction response already carries the events,
+the write-set (state changes), and the gas — so on the node, a fork, or
+`createLive`, the same verbosity flags render a **flat, degraded trace** of that
+data:
+
+```text
+Events
+  emit 0xec8f..f3a4::registry::RegisterEvent {"name":"alice","owner":"0xec8f..."}
+
+State changes
+  write_resource 0xec8f..f3a4::registry::Identity @0xec8f..f3a4
+    {"name":"alice","register_events":{ ... }}
+
+✔ Executed successfully · gas_used: 461 octas
+```
+
+The levels mirror the movelite tiers: `-vv` shows the decoded events; `-vvv`
+adds the write-set summary (which resources were written or deleted, by
+`address::Module::Resource`); `-vvvv` adds each change's full decoded data. The
+footer carries the status and the octa `gas_used` (there is no per-frame timing
+off the node). As with the full tree, this is additional detail only — it never
+changes what `contract.call(...)` returns.
+
 ## Scope
 
 Only `contract.call(...)` (state-changing transactions) is traced. `view(...)`
-is a read-only query and is never traced. Traces require the movelite backend;
-on the Movement node, `createLive`, or a fork, calls run normally with no tree.
+is a read-only query and is never traced. The full call **tree** requires the
+movelite backend; on the Movement node, `createLive`, or a fork, you get the
+degraded flat trace (events + state changes + gas) described above.

--- a/packages/docs/content/docs/guides/traces.mdx
+++ b/packages/docs/content/docs/guides/traces.mdx
@@ -89,7 +89,9 @@ The full Movement node does not expose internal call frames, so the call tree is
 movelite-only. But the node's transaction response already carries the events,
 the write-set (state changes), and the gas — so on the node, a fork, or
 `createLive`, the same verbosity flags render a **flat, degraded trace** of that
-data:
+data.
+
+A `registry::register()` call at `-vvvv`:
 
 ```text
 Events

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -114,7 +114,7 @@ await harness.cleanup();
 | **Fast local boot**        | movelite (sub-second)| Built-in           | Built-in (anvil)   |
 | **Fork system**            | Built-in JSON        | External           | Built-in           |
 | **Auto-detected addresses**| Yes                  | N/A                | Manual             |
-| **Execution traces**       | `-vvvv` (movelite)   | Plugin             | `-vvvv` built-in   |
+| **Execution traces**       | `-vvvv` (full tree on movelite) | Plugin  | `-vvvv` built-in   |
 
 ## What's next?
 

--- a/packages/movehat/README.md
+++ b/packages/movehat/README.md
@@ -22,7 +22,7 @@
 - **Three execution modes** — full local blockchain, read-only fork of a remote network, or live testnet/mainnet binding.
 - **Auto-deploy in tests + auto-detect named addresses** — contracts compile and deploy automatically; no manual address wiring.
 - **Fast local boot with movelite** — on supported platforms an auto-installed [movelite](https://github.com/gilbertsahumada/movelite) binary boots the local test chain in under a second instead of ~15s, with transparent fallback to the full Movement node.
-- **Foundry-style execution traces** — raise verbosity (`-vv` … `-vvvv`) to render an indented call tree for each `contract.call(...)` with decoded arguments, gas, events, and the abort stack (movelite backend).
+- **Foundry-style execution traces** — raise verbosity (`-vv` … `-vvvv`) to render an indented call tree for each `contract.call(...)` with decoded arguments, gas, events, and the abort stack (full tree on the movelite backend; the Movement node renders a degraded flat trace — events, state changes, and gas).
 - **Native fork system** — local JSON-backed snapshots of Movement L1 state, no BCS compatibility issues.
 - **TypeScript-first** — single `PRIVATE_KEY` across all networks (Hardhat-style); deployments tracked per-network in `deployments/`.
 - **SLSA-provenance releases** — every npm release ships with [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) provenance. Verify with `npm view movehat@<version>`.

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {

--- a/packages/movehat/src/core/contract.ts
+++ b/packages/movehat/src/core/contract.ts
@@ -101,6 +101,10 @@ export class MoveContract {
     // but the REST response already carries the events, write-set, and gas.
     // At raised verbosity render that flat view (a render failure must never
     // fail a transaction that already committed).
+    //
+    // waitForTransaction returns the CommittedTransactionResponse union; the
+    // `in` guards narrow it to the user-transaction shape that carries events
+    // and changes, so renderNodeTrace receives a typed value without a cast.
     const nodeLevel = logger.getVerbosityLevel();
     if (nodeLevel >= 2 && "events" in response && "changes" in response) {
       try {

--- a/packages/movehat/src/core/contract.ts
+++ b/packages/movehat/src/core/contract.ts
@@ -7,6 +7,7 @@ import {
 import { logger } from "../ui/index.js";
 import { traceTransaction } from "./trace/client.js";
 import { renderTrace } from "./trace/renderer.js";
+import { renderNodeTrace } from "./trace/nodeRenderer.js";
 
 export interface TransactionResult {
   hash: string;
@@ -95,6 +96,21 @@ export class MoveContract {
     const response = await this.aptos.waitForTransaction({
       transactionHash: committedTxn.hash,
     });
+
+    // Degraded trace: the Movement node does not expose internal call frames,
+    // but the REST response already carries the events, write-set, and gas.
+    // At raised verbosity render that flat view (a render failure must never
+    // fail a transaction that already committed).
+    const nodeLevel = logger.getVerbosityLevel();
+    if (nodeLevel >= 2 && "events" in response && "changes" in response) {
+      try {
+        renderNodeTrace(response, { level: nodeLevel });
+      } catch (renderError) {
+        const msg =
+          renderError instanceof Error ? renderError.message : String(renderError);
+        logger.warning(`Failed to render trace: ${msg}`);
+      }
+    }
 
     logger.success(
       `Transaction ${committedTxn.hash} committed with status: ${response.vm_status}`

--- a/packages/movehat/src/core/trace/__tests__/nodeRenderer.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/nodeRenderer.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { formatNodeTraceLines } from "../nodeRenderer.js";
+import type { NodeTxView } from "../nodeRenderer.js";
+
+const text = (lines: string[]) => lines.join("\n");
+
+const longAddr =
+  "0xfd1c28091511e9285586fa38de58a35fc4f2388724ffbef57b0467cce2882c54";
+
+const success: NodeTxView = {
+  success: true,
+  vm_status: "Executed successfully",
+  gas_used: "440",
+  events: [{ type: `${longAddr}::counter::Incremented`, data: { value: "1" } }],
+  changes: [
+    {
+      type: "write_resource",
+      address: longAddr,
+      data: { type: `${longAddr}::counter::Counter`, data: { count: "99" } },
+    },
+    { type: "delete_resource", address: longAddr, resource: "0x1::old::Thing" },
+    { type: "write_table_item" },
+  ],
+};
+
+describe("formatNodeTraceLines — node degraded trace", () => {
+  it("level 2: events + footer, no state changes", () => {
+    const out = text(formatNodeTraceLines(success, 2));
+    expect(out).toContain("Events");
+    expect(out).toMatch(/emit .*::counter::Incremented/);
+    expect(out).toContain("Executed successfully");
+    expect(out).toContain("gas_used: 440 octas");
+    // State changes appear only from level 3.
+    expect(out).not.toContain("State changes");
+  });
+
+  it("level 3: adds the write-set summary, no raw data payload", () => {
+    const out = text(formatNodeTraceLines(success, 3));
+    expect(out).toContain("State changes");
+    expect(out).toContain("write_resource");
+    expect(out).toContain("delete_resource");
+    expect(out).toContain("write_table_item");
+    // Long resource type/address is shortened.
+    expect(out).toMatch(/write_resource 0xfd1c\.\.2c54::counter::Counter/);
+    // Raw resource data is withheld until level 4.
+    expect(out).not.toContain('"count":"99"');
+  });
+
+  it("level 4: appends each change's decoded data payload", () => {
+    const out = text(formatNodeTraceLines(success, 4));
+    expect(out).toContain('{"count":"99"}');
+  });
+
+  it("renders an abort: failed status carries the vm_status reason", () => {
+    const aborted: NodeTxView = {
+      success: false,
+      vm_status: "Move abort in 0x1::account: ERESOURCE_ALREADY_EXISTS",
+      gas_used: "4",
+      events: [],
+      changes: [],
+    };
+    const out = text(formatNodeTraceLines(aborted, 2));
+    expect(out).toContain("(no events emitted)");
+    expect(out).toContain("Move abort in 0x1::account");
+    expect(out).toContain("gas_used: 4 octas");
+  });
+
+  it("shows a placeholder when there are no events", () => {
+    const noEvents: NodeTxView = { ...success, events: [] };
+    expect(text(formatNodeTraceLines(noEvents, 2))).toContain(
+      "(no events emitted)"
+    );
+  });
+
+  it("never emits raw ANSI escape codes (color is gated)", () => {
+    for (const lvl of [2, 3, 4]) {
+      expect(text(formatNodeTraceLines(success, lvl))).not.toContain("\x1b[");
+    }
+  });
+});

--- a/packages/movehat/src/core/trace/__tests__/nodeRenderer.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/nodeRenderer.test.ts
@@ -22,6 +22,8 @@ const success: NodeTxView = {
     { type: "delete_resource", address: longAddr, resource: "0x1::old::Thing" },
     { type: "write_table_item", handle: longAddr },
     { type: "write_module", address: longAddr },
+    { type: "delete_table_item", handle: longAddr },
+    { type: "delete_module", address: longAddr },
   ],
 };
 
@@ -46,6 +48,10 @@ describe("formatNodeTraceLines — node degraded trace", () => {
     expect(out).toMatch(/write_table_item table_item @0xfd1c\.\.2c54/);
     // Module changes render with a generic "module" type.
     expect(out).toMatch(/write_module module/);
+    // delete_* variants fall through to the same handling as their write_
+    // counterparts: table items still key off the handle, modules stay generic.
+    expect(out).toMatch(/delete_table_item table_item @0xfd1c\.\.2c54/);
+    expect(out).toMatch(/delete_module module/);
     // Raw resource data is withheld until level 4.
     expect(out).not.toContain('"count":"99"');
   });

--- a/packages/movehat/src/core/trace/__tests__/nodeRenderer.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/nodeRenderer.test.ts
@@ -20,7 +20,8 @@ const success: NodeTxView = {
       data: { type: `${longAddr}::counter::Counter`, data: { count: "99" } },
     },
     { type: "delete_resource", address: longAddr, resource: "0x1::old::Thing" },
-    { type: "write_table_item" },
+    { type: "write_table_item", handle: longAddr },
+    { type: "write_module", address: longAddr },
   ],
 };
 
@@ -38,11 +39,13 @@ describe("formatNodeTraceLines — node degraded trace", () => {
   it("level 3: adds the write-set summary, no raw data payload", () => {
     const out = text(formatNodeTraceLines(success, 3));
     expect(out).toContain("State changes");
-    expect(out).toContain("write_resource");
     expect(out).toContain("delete_resource");
-    expect(out).toContain("write_table_item");
     // Long resource type/address is shortened.
     expect(out).toMatch(/write_resource 0xfd1c\.\.2c54::counter::Counter/);
+    // Table items key off the shortened table handle, not a resource type.
+    expect(out).toMatch(/write_table_item table_item @0xfd1c\.\.2c54/);
+    // Module changes render with a generic "module" type.
+    expect(out).toMatch(/write_module module/);
     // Raw resource data is withheld until level 4.
     expect(out).not.toContain('"count":"99"');
   });

--- a/packages/movehat/src/core/trace/format.ts
+++ b/packages/movehat/src/core/trace/format.ts
@@ -4,9 +4,11 @@ import { colors, rgbToAnsi, shouldUseColor } from "../../ui/colors.js";
 // renderer (renderer.ts) and the node degraded-trace renderer (nodeRenderer.ts).
 // None of these are tied to a specific response shape.
 
-// rgbToAnsi emits raw escapes unconditionally, so guard these two ourselves
-// (unlike colors.*, which already no-op when color is disabled).
-export const orange = (s: string): string =>
+// rgbToAnsi emits raw escapes unconditionally, so guard these ourselves
+// (unlike colors.*, which already no-op when color is disabled). `orange` is
+// module-private (only `leafValue` uses it); `brightBlue` is consumed by the
+// movelite renderer's footer.
+const orange = (s: string): string =>
   shouldUseColor() ? `${rgbToAnsi(255, 165, 0)}${s}\x1b[0m` : s;
 export const brightBlue = (s: string): string =>
   shouldUseColor() ? `${rgbToAnsi(90, 170, 255)}${s}\x1b[0m` : s;
@@ -29,7 +31,7 @@ export const shortenPath = (path: string): string => {
 
 const NUMERIC = /^\d+$/;
 
-export const leafValue = (value: unknown): string => {
+const leafValue = (value: unknown): string => {
   const s = String(value);
   if (NUMERIC.test(s)) return orange(s);
   if (s.startsWith("0x") && s.length > 12) return shortAddr(s);

--- a/packages/movehat/src/core/trace/format.ts
+++ b/packages/movehat/src/core/trace/format.ts
@@ -1,0 +1,76 @@
+import { colors, rgbToAnsi, shouldUseColor } from "../../ui/colors.js";
+
+// Generic, stateless formatting helpers shared by the movelite call-tree
+// renderer (renderer.ts) and the node degraded-trace renderer (nodeRenderer.ts).
+// None of these are tied to a specific response shape.
+
+// rgbToAnsi emits raw escapes unconditionally, so guard these two ourselves
+// (unlike colors.*, which already no-op when color is disabled).
+export const orange = (s: string): string =>
+  shouldUseColor() ? `${rgbToAnsi(255, 165, 0)}${s}\x1b[0m` : s;
+export const brightBlue = (s: string): string =>
+  shouldUseColor() ? `${rgbToAnsi(90, 170, 255)}${s}\x1b[0m` : s;
+
+export const indent = (depth: number): string => "  ".repeat(depth);
+
+/** Shorten a 0x-prefixed address for display (`0xf903..9b16`); leave short
+ *  framework addresses like `0x1` untouched. */
+export const shortAddr = (addr: string): string =>
+  addr.startsWith("0x") && addr.length > 12
+    ? `${addr.slice(0, 6)}..${addr.slice(-4)}`
+    : addr;
+
+/** Shorten the address part of a `address::module[::Name]` path. */
+export const shortenPath = (path: string): string => {
+  const [addr, ...rest] = path.split("::");
+  if (addr === undefined || rest.length === 0) return path;
+  return [shortAddr(addr), ...rest].join("::");
+};
+
+const NUMERIC = /^\d+$/;
+
+export const leafValue = (value: unknown): string => {
+  const s = String(value);
+  if (NUMERIC.test(s)) return orange(s);
+  if (s.startsWith("0x") && s.length > 12) return shortAddr(s);
+  return s;
+};
+
+/** Format a decoded value. Struct (and vector) values arrive as objects with
+ *  by-index keys; their fields can themselves be structs, so recurse rather
+ *  than `String()`-ing a nested object into `[object Object]`. */
+export const formatValue = (value: unknown): string => {
+  if (value !== null && typeof value === "object") {
+    return `{ ${Object.values(value as Record<string, unknown>)
+      .map(formatValue)
+      .join(", ")} }`;
+  }
+  return leafValue(value);
+};
+
+export const formatData = (data: unknown): string => {
+  if (data === null || data === undefined) return "";
+  try {
+    return colors.dim(JSON.stringify(data));
+  } catch {
+    return colors.dim(String(data));
+  }
+};
+
+/** One emitted-event line: `emit <module>::<Event> {…data}`. Reads only `type`
+ *  and `data`, so it accepts both the movelite `TracedEvent` and the SDK's
+ *  `Event` shape. */
+export const formatEventLine = (event: { type: string; data: unknown }): string =>
+  `${colors.warning(`emit ${shortenPath(event.type)}`)} ${formatData(event.data)}`.trimEnd();
+
+/** One storage / state-change line: `<op> <module>::<Resource> [@addr]`. The
+ *  `op` object is duck-typed so both movelite storage ops and SDK write-set
+ *  changes (after reshaping) feed it. */
+export const storageLine = (op: {
+  op: string;
+  type: string;
+  address: string | null;
+}): string =>
+  `${colors.primary(`${op.op} ${shortenPath(op.type)}`)}${
+    op.address ? colors.dim(` @${shortAddr(op.address)}`) : ""
+  }`;

--- a/packages/movehat/src/core/trace/nodeRenderer.ts
+++ b/packages/movehat/src/core/trace/nodeRenderer.ts
@@ -1,0 +1,124 @@
+import { logger } from "../../ui/index.js";
+import { colors } from "../../ui/colors.js";
+import { symbols } from "../../ui/symbols.js";
+
+import { formatData, formatEventLine, storageLine } from "./format.js";
+
+/**
+ * Minimal structural view of a committed transaction, as the Aptos SDK's
+ * `waitForTransaction` returns it (`UserTransactionResponse`). Typed loosely so
+ * unit tests can feed plain fixtures and so we never depend on the full SDK
+ * response union. The real Movement node REST API does NOT expose internal call
+ * frames, so this is a flat, degraded trace — events + write-set + gas — rather
+ * than the movelite call tree.
+ */
+export interface NodeTxView {
+  success: boolean;
+  vm_status: string;
+  /** Transaction gas in octas (external unit). */
+  gas_used: string;
+  events: { type: string; data: unknown }[];
+  changes: NodeWriteSetChange[];
+}
+
+/** Loose shape of an SDK `WriteSetChange` — only the fields we render. */
+interface NodeWriteSetChange {
+  type: string;
+  address?: string;
+  /** `write_resource` / `write_module` payload (a `MoveResource` `{type,data}`). */
+  data?: { type?: string; data?: unknown } | unknown;
+  /** `delete_resource` carries the resource type as a string here. */
+  resource?: string;
+}
+
+/** Reshape an SDK write-set change into the shared `storageLine` duck-type. */
+const changeToOp = (
+  c: NodeWriteSetChange
+): { op: string; type: string; address: string | null } => {
+  const address = typeof c.address === "string" ? c.address : null;
+  switch (c.type) {
+    case "write_resource": {
+      const t =
+        c.data && typeof c.data === "object" && "type" in c.data
+          ? String((c.data as { type?: unknown }).type ?? "?")
+          : "?";
+      return { op: c.type, type: t, address };
+    }
+    case "delete_resource":
+      return { op: c.type, type: c.resource ?? "?", address };
+    case "write_module":
+    case "delete_module":
+      return { op: c.type, type: "module", address };
+    case "write_table_item":
+    case "delete_table_item":
+      return { op: c.type, type: "table_item", address: null };
+    default:
+      return { op: c.type, type: "?", address };
+  }
+};
+
+/** Level-4 payload for a change: the resource's decoded fields when present. */
+const changePayload = (c: NodeWriteSetChange): unknown => {
+  if (c.data && typeof c.data === "object" && "data" in c.data) {
+    return (c.data as { data?: unknown }).data;
+  }
+  return c.data;
+};
+
+const nodeFooter = (tx: NodeTxView): string => {
+  const status = tx.success
+    ? colors.success(`${symbols.success} ${tx.vm_status}`)
+    : colors.error(`${symbols.error} ${tx.vm_status}`);
+  const sep = colors.dim(" · ");
+  const gas = colors.dim(`gas_used: ${tx.gas_used} octas`);
+  return `${status}${sep}${gas}`;
+};
+
+/**
+ * Pure formatter for the node degraded trace. Snapshot-testable without
+ * touching stdout. `level` is the verbosity level (2..4): L2 = events, L3 =
+ * + state changes, L4 = + each change's decoded data. The footer carries the
+ * status and the octa `gas_used` (there is no per-frame trace timing off the
+ * node).
+ */
+export function formatNodeTraceLines(tx: NodeTxView, level: number): string[] {
+  const lines: string[] = [];
+
+  // Events (level 2+).
+  if (tx.events.length === 0) {
+    lines.push(colors.dim("(no events emitted)"));
+  } else {
+    lines.push(colors.bold("Events"));
+    for (const e of tx.events) lines.push("  " + formatEventLine(e));
+  }
+
+  // State changes (level 3+).
+  if (level >= 3) {
+    lines.push("");
+    if (tx.changes.length === 0) {
+      lines.push(colors.dim("(no state changes)"));
+    } else {
+      lines.push(colors.bold("State changes"));
+      for (const c of tx.changes) {
+        lines.push("  " + storageLine(changeToOp(c)));
+        if (level >= 4) {
+          const payload = formatData(changePayload(c));
+          if (payload) lines.push("    " + payload);
+        }
+      }
+    }
+  }
+
+  lines.push("");
+  lines.push(nodeFooter(tx));
+  return lines;
+}
+
+/** Render a node degraded trace to the terminal. Wraps {@link formatNodeTraceLines}. */
+export function renderNodeTrace(tx: NodeTxView, opts: { level: number }): void {
+  logger.newline();
+  for (const line of formatNodeTraceLines(tx, opts.level)) {
+    logger.plain(line);
+  }
+  logger.newline();
+}

--- a/packages/movehat/src/core/trace/nodeRenderer.ts
+++ b/packages/movehat/src/core/trace/nodeRenderer.ts
@@ -25,10 +25,13 @@ export interface NodeTxView {
 interface NodeWriteSetChange {
   type: string;
   address?: string;
-  /** `write_resource` / `write_module` payload (a `MoveResource` `{type,data}`). */
-  data?: { type?: string; data?: unknown } | unknown;
+  /** `write_resource` payload (a `MoveResource` `{type,data}`); typed `unknown`
+   *  and narrowed at the use sites since the shape varies by change type. */
+  data?: unknown;
   /** `delete_resource` carries the resource type as a string here. */
   resource?: string;
+  /** Table-item changes carry a `handle` instead of an `address`. */
+  handle?: string;
 }
 
 /** Reshape an SDK write-set change into the shared `storageLine` duck-type. */
@@ -51,7 +54,8 @@ const changeToOp = (
       return { op: c.type, type: "module", address };
     case "write_table_item":
     case "delete_table_item":
-      return { op: c.type, type: "table_item", address: null };
+      // Table items have no resource type; key off the table `handle`.
+      return { op: c.type, type: "table_item", address: c.handle ?? null };
     default:
       return { op: c.type, type: "?", address };
   }

--- a/packages/movehat/src/core/trace/renderer.ts
+++ b/packages/movehat/src/core/trace/renderer.ts
@@ -1,6 +1,15 @@
 import { logger } from "../../ui/index.js";
-import { colors, rgbToAnsi, shouldUseColor } from "../../ui/colors.js";
+import { colors } from "../../ui/colors.js";
 import { symbols } from "../../ui/symbols.js";
+
+import {
+  brightBlue,
+  formatEventLine,
+  formatValue,
+  indent,
+  shortenPath,
+  storageLine,
+} from "./format.js";
 
 import type {
   AbortInfo,
@@ -10,56 +19,12 @@ import type {
   TraceResponse,
 } from "./types.js";
 
-// rgbToAnsi emits raw escapes unconditionally, so guard these two ourselves
-// (unlike colors.*, which already no-op when color is disabled).
-const orange = (s: string): string =>
-  shouldUseColor() ? `${rgbToAnsi(255, 165, 0)}${s}\x1b[0m` : s;
-const brightBlue = (s: string): string =>
-  shouldUseColor() ? `${rgbToAnsi(90, 170, 255)}${s}\x1b[0m` : s;
-
-const indent = (depth: number): string => "  ".repeat(depth);
-
-/** Shorten a 0x-prefixed address for display (`0xf903..9b16`); leave short
- *  framework addresses like `0x1` untouched. */
-const shortAddr = (addr: string): string =>
-  addr.startsWith("0x") && addr.length > 12
-    ? `${addr.slice(0, 6)}..${addr.slice(-4)}`
-    : addr;
-
-/** Shorten the address part of a `address::module[::Name]` path. */
-const shortenPath = (path: string): string => {
-  const [addr, ...rest] = path.split("::");
-  if (addr === undefined || rest.length === 0) return path;
-  return [shortAddr(addr), ...rest].join("::");
-};
-
 const isFramework = (module: string | null): boolean =>
   module !== null && module.startsWith("0x1::");
 
 /** Visible at level 3 (user-module tree): not a framework frame, not a native. */
 const isUserFrame = (node: CallNode): boolean =>
   !isFramework(node.module) && node.kind !== "native";
-
-const NUMERIC = /^\d+$/;
-
-const leafValue = (value: unknown): string => {
-  const s = String(value);
-  if (NUMERIC.test(s)) return orange(s);
-  if (s.startsWith("0x") && s.length > 12) return shortAddr(s);
-  return s;
-};
-
-/** Format a decoded value. Struct (and vector) values arrive as objects with
- *  by-index keys; their fields can themselves be structs, so recurse rather
- *  than `String()`-ing a nested object into `[object Object]`. */
-const formatValue = (value: unknown): string => {
-  if (value !== null && typeof value === "object") {
-    return `{ ${Object.values(value as Record<string, unknown>)
-      .map(formatValue)
-      .join(", ")} }`;
-  }
-  return leafValue(value);
-};
 
 const formatArgValue = (arg: TracedArg): string => {
   if (arg.value === null) return "()";
@@ -85,23 +50,6 @@ const frameLabel = (node: CallNode): string => {
   const gas = colors.dim(` [${node.gas}]`);
   return `${colored}(${formatArgs(node.args)})${gas}`;
 };
-
-const formatData = (data: unknown): string => {
-  if (data === null || data === undefined) return "";
-  try {
-    return colors.dim(JSON.stringify(data));
-  } catch {
-    return colors.dim(String(data));
-  }
-};
-
-const eventLine = (event: TracedEvent): string =>
-  `${colors.warning(`emit ${shortenPath(event.type)}`)} ${formatData(event.data)}`.trimEnd();
-
-const storageLine = (op: { op: string; type: string; address: string | null }): string =>
-  `${colors.primary(`${op.op} ${shortenPath(op.type)}`)}${
-    op.address ? colors.dim(` @${shortAddr(op.address)}`) : ""
-  }`;
 
 /** Non-unit return values only; null when nothing to show. */
 const returnLine = (ret: TracedArg[]): string | null => {
@@ -147,7 +95,7 @@ const renderNode = (
   const childDepth = depth + 1;
 
   if (showFull) {
-    for (const e of node.events) lines.push(indent(childDepth) + eventLine(e));
+    for (const e of node.events) lines.push(indent(childDepth) + formatEventLine(e));
     for (const s of node.storage) lines.push(indent(childDepth) + storageLine(s));
     const ret = returnLine(node.return);
     if (ret) lines.push(indent(childDepth) + ret);
@@ -161,7 +109,7 @@ const renderNode = (
   const visibleChildren: CallNode[] = [];
   gatherHidden(node.children, bubbled, visibleChildren);
   for (const e of [...node.events, ...bubbled]) {
-    lines.push(indent(childDepth) + eventLine(e));
+    lines.push(indent(childDepth) + formatEventLine(e));
   }
   for (const c of visibleChildren) renderNode(c, childDepth, showFull, lines);
 };
@@ -214,7 +162,7 @@ export function formatTraceLines(
       lines.push(colors.dim("(no events emitted)"));
     } else {
       lines.push(colors.bold("Events"));
-      for (const { event } of events) lines.push("  " + eventLine(event));
+      for (const { event } of events) lines.push("  " + formatEventLine(event));
     }
   } else {
     // Aborts always show the full tree so the failing frame is visible.


### PR DESCRIPTION
Milestone batch: develop -> main for movehat 0.4.0.

## Summary
movehat 0.3.0 shipped Foundry-style execution traces, but they are movelite-only (the full call tree comes from movelite's instrumented VM endpoint, which the real Movement node does not expose). This release adds a **degraded flat trace** on the node path: at raised verbosity, `contract.call(...)` now renders the events, state changes (write-set), and gas the SDK's committed-transaction response already carries — instead of nothing.

Level mapping mirrors the movelite tiers:
- `-vv` decoded events
- `-vvv` + write-set summary (`op address::Module::Resource`)
- `-vvvv` + each change's full decoded data

Applies to all node-backed calls: local full node, fork, and `createLive`.

## Backward compatibility
Render-only side effect. `contract.call(...)` returns the same `{hash, success, vm_status}` — events/changes/gas were already discarded before this change. Opt-in by verbosity (default L0/L1 output is byte-identical). A render failure degrades to a warning and never fails a committed transaction. movelite is untouched; the shared `core/trace/format.ts` extraction is proven non-breaking by the unchanged `renderer.test.ts`.

## Changes
- New: `core/trace/format.ts` (shared formatters), `core/trace/nodeRenderer.ts` (flat node renderer) + tests.
- `core/trace/renderer.ts` imports the shared helpers (no behavior change).
- `core/contract.ts` renders the node trace at verbosity >= 2 in the node path.
- Docs: traces / global-flags / console-output / movelite / index + both READMEs.
- Release: package.json 0.3.0 -> 0.4.0, CHANGELOG `[0.4.0] - 2026-06-14`.

## Verified live against real runtimes
- Node full backend at `-vvvv`: 9/9 counter-example tests pass; Events + State changes + `gas_used` footer render correctly.
- movelite at `-vvvv`: full call tree intact.
- 591 unit tests, movehat build, docs build (181 pages) all green.

Closes #330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Execution traces now render on Movement node backend at verbosity levels 2 and above, displaying events, state changes, and gas usage; full call tree rendering remains exclusive to movelite.

* **Documentation**
  * Updated documentation to clarify trace output differences between movelite and Movement node backends.

* **Chores**
  * Bumped version to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->