### PR TITLE
chore: address CodeRabbit nits on the 0.4.0 batch

### DIFF
--- a/packages/docs/content/docs/guides/traces.mdx
+++ b/packages/docs/content/docs/guides/traces.mdx
@@ -89,7 +89,9 @@ The full Movement node does not expose internal call frames, so the call tree is
 movelite-only. But the node's transaction response already carries the events,
 the write-set (state changes), and the gas — so on the node, a fork, or
 `createLive`, the same verbosity flags render a **flat, degraded trace** of that
-data:
+data.
+
+A `registry::register()` call at `-vvvv`:
 
 ```text
 Events

--- a/packages/movehat/src/core/contract.ts
+++ b/packages/movehat/src/core/contract.ts
@@ -101,6 +101,10 @@ export class MoveContract {
     // but the REST response already carries the events, write-set, and gas.
     // At raised verbosity render that flat view (a render failure must never
     // fail a transaction that already committed).
+    //
+    // waitForTransaction returns the CommittedTransactionResponse union; the
+    // `in` guards narrow it to the user-transaction shape that carries events
+    // and changes, so renderNodeTrace receives a typed value without a cast.
     const nodeLevel = logger.getVerbosityLevel();
     if (nodeLevel >= 2 && "events" in response && "changes" in response) {
       try {

--- a/packages/movehat/src/core/trace/__tests__/nodeRenderer.test.ts
+++ b/packages/movehat/src/core/trace/__tests__/nodeRenderer.test.ts
@@ -22,6 +22,8 @@ const success: NodeTxView = {
     { type: "delete_resource", address: longAddr, resource: "0x1::old::Thing" },
     { type: "write_table_item", handle: longAddr },
     { type: "write_module", address: longAddr },
+    { type: "delete_table_item", handle: longAddr },
+    { type: "delete_module", address: longAddr },
   ],
 };
 
@@ -46,6 +48,10 @@ describe("formatNodeTraceLines — node degraded trace", () => {
     expect(out).toMatch(/write_table_item table_item @0xfd1c\.\.2c54/);
     // Module changes render with a generic "module" type.
     expect(out).toMatch(/write_module module/);
+    // delete_* variants fall through to the same handling as their write_
+    // counterparts: table items still key off the handle, modules stay generic.
+    expect(out).toMatch(/delete_table_item table_item @0xfd1c\.\.2c54/);
+    expect(out).toMatch(/delete_module module/);
     // Raw resource data is withheld until level 4.
     expect(out).not.toContain('"count":"99"');
   });


### PR DESCRIPTION
Triage + fixes for the 3 CodeRabbit nitpicks raised on the develop -> main batch (#333). All were CHILL-profile nitpicks; none were bugs.

- **nodeRenderer.test.ts** (real, low value): add explicit `delete_table_item` / `delete_module` fixtures + L3 assertions. They fall through to the same switch branches as their `write_` counterparts, so behavior was already covered — the assertions guard against future divergence.
- **contract.ts** (by-design): keep the `"events"/"changes" in response` guards — `waitForTransaction` returns the `CommittedTransactionResponse` union, so the `in` checks narrow it to the user-transaction shape without a cast (keeps `tsc` clean). Added a comment explaining the rationale, per CR's own alternative.
- **traces.mdx** (real, consistency): label the node example as a `-vvvv` run, matching the movelite section's phrasing.

Verified: `tsc` clean, 591 unit tests pass, docs build green.

Tracks #330

develop-targeted -> CodeRabbit skip.