### PR TITLE
fix: spinner symbol color leaks ANSI when piped (§9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Spinner success/fail lines no longer leak ANSI color when stdout is piped.
+  The `Building package` / `Publishing to blockchain` (and other) spinners
+  persisted their final `✔` / `✖` through ora's own TTY detection, which still
+  colored the symbol on a non-TTY stream. The symbol now routes through the
+  `shouldUseColor()`-gated `coloredSymbol`, so piped output is escape-free while
+  a real terminal keeps the colored glyph (§9 console-UX convention).
+
 ## [0.4.0] - 2026-06-14
 
 ### Added

--- a/packages/movehat/src/ui/spinner.ts
+++ b/packages/movehat/src/ui/spinner.ts
@@ -1,5 +1,27 @@
 import ora, { type Ora, type Options as OraOptions } from 'ora';
 import { shouldUseColor } from './colors.js';
+import { coloredSymbol } from './symbols.js';
+
+/**
+ * Persist a spinner's final line with a color-gated status symbol.
+ *
+ * ora's own `.succeed()` / `.fail()` color their log-symbols through ora's
+ * internal TTY detection, which still emits ANSI on the persisted line when
+ * stdout is piped (non-TTY) even though our `shouldUseColor()` says no color.
+ * Routing the symbol through `coloredSymbol` (gated by `shouldUseColor`) keeps
+ * piped output escape-free while preserving the colored glyph in a real TTY.
+ */
+const persist = (
+  spin: Ora,
+  type: 'success' | 'error',
+  text?: string
+): void => {
+  spin.stopAndPersist(
+    text === undefined
+      ? { symbol: coloredSymbol(type) }
+      : { symbol: coloredSymbol(type), text }
+  );
+};
 
 /**
  * Spinner color options
@@ -94,11 +116,11 @@ export const withSpinner = async <T>(
 
   try {
     const result = await task();
-    spin.succeed(successText || startText.replace(/\.\.\.?$/, ''));
+    persist(spin, 'success', successText || startText.replace(/\.\.\.?$/, ''));
     return result;
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
-    spin.fail(errorText || `Failed: ${errMsg}`);
+    persist(spin, 'error', errorText || `Failed: ${errMsg}`);
     throw error;
   }
 };
@@ -139,11 +161,11 @@ export const withTimedSpinner = async <T>(
   }, 500);
   try {
     const result = await task();
-    spin.succeed(`${label} (${((Date.now() - start) / 1000).toFixed(1)}s)`);
+    persist(spin, 'success', `${label} (${((Date.now() - start) / 1000).toFixed(1)}s)`);
     return result;
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
-    spin.fail(errMsg);
+    persist(spin, 'error', errMsg);
     throw error;
   } finally {
     clearInterval(timer);
@@ -201,10 +223,10 @@ export const createSpinnerChain = (): SpinnerChain => {
       currentSpinner = spinner({ text, indent });
       try {
         const result = await task();
-        currentSpinner.succeed();
+        persist(currentSpinner, 'success');
         return result;
       } catch (error) {
-        currentSpinner.fail();
+        persist(currentSpinner, 'error');
         throw error;
       }
     },


### PR DESCRIPTION
Closes the pre-existing §9 console-UX gap noted alongside the trace work.

## Problem
`withSpinner` / `withTimedSpinner` / `createSpinnerChain` persisted their final line via ora's `.succeed()` / `.fail()`, which colors the `✔` / `✖` log-symbol through ora's own TTY detection. On a piped (non-TTY) stdout that still emitted `\x1b[32m…\x1b[39m`, even though `shouldUseColor()` returns false there.

## Fix
Persist via `stopAndPersist({ symbol: coloredSymbol(type), text })`. `coloredSymbol` routes through `colors.*`, which is gated by `shouldUseColor()` — so a real TTY keeps the green/red glyph and piped output is escape-free. Centralized in `spinner.ts`; all persist sites (incl. Publisher `Building package` / `Publishing to blockchain`) route through these three helpers, so no other call sites need touching.

## §8 self-review
- 🔴 none.
- 🟡 none. Behavior in a TTY is unchanged — `.succeed(text)` is literally `stopAndPersist({symbol: logSymbols.success, text})`; only the symbol's color source changes. ora `indent` stays 0 (indent is baked into the start-frame text, not re-applied on persist), so the persisted line's layout is identical.
- 🟢 none.

## Verification
- Piped: `grep -c $'\x1b'` = 0 across success / fail / timed-spinner paths (was non-zero).
- Simulated TTY (`process.stdout.isTTY=true` before import): `coloredSymbol('success')` = `\x1b[32m✔\x1b[39m`.
- 591 unit tests green; `tsc --noEmit` clean; movehat build clean.

Tracks #335 (auto-closes when this lands on `main` via the next develop→main batch).

develop-targeted -> CodeRabbit skip.