### PR TITLE
chore: release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-15
+
 ### Fixed
 
 - Spinner success/fail lines no longer leak ANSI color when stdout is piped.

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {


### PR DESCRIPTION
Patch release: bumps movehat 0.4.0 -> 0.4.1 and finalizes the CHANGELOG for the §9 spinner color-leak fix (PR #336).

## What
- `packages/movehat/package.json`: 0.4.0 -> 0.4.1.
- `CHANGELOG.md`: `[Unreleased]` -> `[0.4.1] - 2026-06-15`.

## Why patch
Single bug fix (spinner success/fail symbol leaked ANSI when piped); no API or behavior change in a TTY.

Tracks #335

develop-targeted -> CodeRabbit skip (the develop -> main batch is the review gate).