### PR TITLE
release: movehat 0.4.1 — escape-free spinner output when piped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Spinner success/fail lines no longer leak ANSI color when stdout is piped.
+  The `Building package` / `Publishing to blockchain` (and other) spinners
+  persisted their final `✔` / `✖` through ora's own TTY detection, which still
+  colored the symbol on a non-TTY stream. The symbol now routes through the
+  `shouldUseColor()`-gated `coloredSymbol`, so piped output is escape-free while
+  a real terminal keeps the colored glyph (§9 console-UX convention).
+
 ## [0.4.0] - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-15
+
 ### Fixed
 
 - Spinner success/fail lines no longer leak ANSI color when stdout is piped.

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {

--- a/packages/movehat/src/ui/spinner.ts
+++ b/packages/movehat/src/ui/spinner.ts
@@ -1,5 +1,27 @@
 import ora, { type Ora, type Options as OraOptions } from 'ora';
 import { shouldUseColor } from './colors.js';
+import { coloredSymbol } from './symbols.js';
+
+/**
+ * Persist a spinner's final line with a color-gated status symbol.
+ *
+ * ora's own `.succeed()` / `.fail()` color their log-symbols through ora's
+ * internal TTY detection, which still emits ANSI on the persisted line when
+ * stdout is piped (non-TTY) even though our `shouldUseColor()` says no color.
+ * Routing the symbol through `coloredSymbol` (gated by `shouldUseColor`) keeps
+ * piped output escape-free while preserving the colored glyph in a real TTY.
+ */
+const persist = (
+  spin: Ora,
+  type: 'success' | 'error',
+  text?: string
+): void => {
+  spin.stopAndPersist(
+    text === undefined
+      ? { symbol: coloredSymbol(type) }
+      : { symbol: coloredSymbol(type), text }
+  );
+};
 
 /**
  * Spinner color options
@@ -94,11 +116,11 @@ export const withSpinner = async <T>(
 
   try {
     const result = await task();
-    spin.succeed(successText || startText.replace(/\.\.\.?$/, ''));
+    persist(spin, 'success', successText || startText.replace(/\.\.\.?$/, ''));
     return result;
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
-    spin.fail(errorText || `Failed: ${errMsg}`);
+    persist(spin, 'error', errorText || `Failed: ${errMsg}`);
     throw error;
   }
 };
@@ -139,11 +161,11 @@ export const withTimedSpinner = async <T>(
   }, 500);
   try {
     const result = await task();
-    spin.succeed(`${label} (${((Date.now() - start) / 1000).toFixed(1)}s)`);
+    persist(spin, 'success', `${label} (${((Date.now() - start) / 1000).toFixed(1)}s)`);
     return result;
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
-    spin.fail(errMsg);
+    persist(spin, 'error', errMsg);
     throw error;
   } finally {
     clearInterval(timer);
@@ -201,10 +223,10 @@ export const createSpinnerChain = (): SpinnerChain => {
       currentSpinner = spinner({ text, indent });
       try {
         const result = await task();
-        currentSpinner.succeed();
+        persist(currentSpinner, 'success');
         return result;
       } catch (error) {
-        currentSpinner.fail();
+        persist(currentSpinner, 'error');
         throw error;
       }
     },


### PR DESCRIPTION
Milestone batch: develop -> main for movehat 0.4.1 (patch).

## Summary
Fixes the §9 console-UX gap where the `withSpinner` / `withTimedSpinner` / `createSpinnerChain` helpers persisted their final `✔` / `✖` through ora's own TTY detection, leaking ANSI color on a piped (non-TTY) stdout. The symbol now routes through the `shouldUseColor()`-gated `coloredSymbol` via `stopAndPersist`, so piped output is escape-free while a real terminal keeps the colored glyph.

## Backward compatibility
TTY output is byte-identical (`.succeed(text)` is `stopAndPersist({symbol: logSymbols.success, text})`; only the symbol's color source changes). No API change.

## Changes
- `core` / `ui`: `src/ui/spinner.ts` persists via `coloredSymbol` (gated by `shouldUseColor`).
- Release: package.json 0.4.0 -> 0.4.1, CHANGELOG `[0.4.1] - 2026-06-15`.

## Verified
- Piped: zero `\x1b` escapes across success / fail / timed-spinner paths.
- Simulated TTY: symbol still `\x1b[32m✔\x1b[39m`.
- 591 unit tests green; `tsc --noEmit` clean; movehat build clean.

Closes #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ANSI color code leakage in spinner status output when stdout is redirected to non-TTY streams or piped to other processes. Spinner symbols now display with proper colors in interactive terminals while piped output remains clean and ANSI-escape-free for automated tools, log aggregators, and parsers.

* **Chores**
  * Version bumped to 0.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->