### PR TITLE
fix: shared test node prefers movelite so traces work in movehat test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The example suite and the `movehat init` scaffold silently disabled movelite
+  — and with it the Foundry-style execution traces — in `movehat test`. Their
+  shared root-hook node (`tests/setup.ts`) pinned `LocalNodeManager`, and an
+  injected `localNode` takes precedence over movelite auto-selection, so
+  `traceRpcUrl` was never wired and `-vv..-vvvv` rendered no call tree while
+  every run paid the slow Movement-node boot. The shared node now prefers
+  movelite when its binary resolves (Movement node remains the fallback), so
+  scaffolded projects get sub-second boots and full traces out of the box.
+  Closes #339.
+
+### Changed
+
+- `LocalTestOptions.localNode` now accepts any `NodeProvider` (previously
+  `LocalNodeManager` only), and the `NodeProvider` interface is exported from
+  `movehat/helpers` — injecting a pre-started `MoveliteManager` into
+  `setupTestFixture` / `Harness.createLocal` is now expressible in user code.
+  Closes #339.
+
 ## [0.4.1] - 2026-06-15
 
 ### Fixed

--- a/examples/counter-example/tests/setup.ts
+++ b/examples/counter-example/tests/setup.ts
@@ -1,13 +1,25 @@
-import { LocalNodeManager } from "movehat/helpers";
+import {
+  LocalNodeManager,
+  MoveliteManager,
+  findMoveliteBinary,
+  type NodeProvider,
+} from "movehat/helpers";
 
-let sharedNode: LocalNodeManager | undefined;
+let sharedNode: NodeProvider | undefined;
 
 /**
- * Returns the shared local Movement node started by root hooks.
+ * Returns the shared local node started by root hooks.
  * Pass the result as `{ localNode: getSharedNode() }` to
  * Harness.createLocal() or setupTestFixture().
+ *
+ * Prefers movelite when its binary is available: only the movelite backend
+ * exposes the /transactions/trace endpoint that powers the Foundry-style
+ * execution traces you see at raised verbosity (`movehat test --ts -vvvv`).
+ * When movelite is not installed (e.g. a platform without a published
+ * binary) it falls back to the full Movement node, which still runs the
+ * tests but renders only the degraded event/state trace.
  */
-export function getSharedNode(): LocalNodeManager {
+export function getSharedNode(): NodeProvider {
   if (!sharedNode || !sharedNode.isRunning()) {
     throw new Error(
       "Shared node not available. " +
@@ -20,7 +32,10 @@ export function getSharedNode(): LocalNodeManager {
 export const mochaHooks = {
   async beforeAll(this: Mocha.Context) {
     this.timeout(60000);
-    sharedNode = new LocalNodeManager({ forceRestart: true });
+    const moveliteBinary = findMoveliteBinary();
+    sharedNode = moveliteBinary
+      ? new MoveliteManager(moveliteBinary)
+      : new LocalNodeManager({ forceRestart: true });
     await sharedNode.start();
   },
 

--- a/packages/docs/content/docs/guides/networks-and-modes.mdx
+++ b/packages/docs/content/docs/guides/networks-and-modes.mdx
@@ -133,11 +133,11 @@ Fix: keep `deployments/{network}/*.json` files committed (they're tracked by def
 
 ### "My test suite runs slowly because each spec spawns a node"
 
-Symptom: 10 test files = 10 sequential local-node spawns = 2-5 minutes of pure startup overhead before any assertion runs.
+Symptom: 10 test files = 10 sequential local-node spawns of pure startup overhead before any assertion runs.
 
-What happened: each `Harness.createLocal()` call spawns its own Movement local node by default. The current architecture doesn't share a single node across specs.
+What happened: each `Harness.createLocal()` call spawns its own local node by default. On the movelite backend that costs under a second per spec, so this usually only hurts when the suite fell back to the full Movement node (~15s per boot).
 
-Fix: open issue [#235](https://github.com/gilbertsahumada/movehat/issues/235) tracks this; the proposed mocha root-hooks pattern (Option 1) brings N spawns down to 1. Until that ships, the workaround is to keep test spec counts low or split into separate `movehat test --ts` invocations.
+Fix: the scaffold's mocha root-hooks pattern boots one shared node for the whole run — see [Sharing one node across specs](./testing#sharing-one-node-across-specs-optional). If the per-spec boots themselves are slow, first check that movelite is actually the selected backend (see [movelite](./movelite)).
 
 ## Related
 

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -171,6 +171,21 @@ harness = await Harness.createLocal({
 See [movelite](./movelite) for supported platforms, the `MOVEHAT_USE_MOVELITE`
 override, and how to tell which backend started.
 
+### Sharing one node across specs (optional)
+
+Each spec booting its own local chain is the default and, with movelite,
+costs under a second per file — most projects never need more. To boot the
+chain **once** for the whole `mocha` run, the scaffold that `movehat init`
+generates ships a `tests/setup.ts` root hook that starts one shared node and
+hands it to every fixture via `{ localNode: getSharedNode() }` — see the
+[counter example](https://github.com/gilbertsahumada/movehat/tree/main/examples/counter-example/tests/setup.ts)
+for the full file.
+
+> **Passing `localNode` opts out of movelite auto-selection** — movehat uses
+> the node you hand it. To keep the full [execution traces](./traces),
+> construct a `MoveliteManager` (as the scaffold does); a plain
+> `LocalNodeManager` gives only the degraded event/state trace.
+
 ## Running All Tests
 
 Run both Move and TypeScript tests together:

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -178,7 +178,7 @@ costs under a second per file — most projects never need more. To boot the
 chain **once** for the whole `mocha` run, the scaffold that `movehat init`
 generates ships a `tests/setup.ts` root hook that starts one shared node and
 hands it to every fixture via `{ localNode: getSharedNode() }` — see the
-[counter example](https://github.com/gilbertsahumada/movehat/tree/main/examples/counter-example/tests/setup.ts)
+[counter example](https://github.com/gilbertsahumada/movehat/blob/main/examples/counter-example/tests/setup.ts)
 for the full file.
 
 > **Passing `localNode` opts out of movelite auto-selection** — movehat uses

--- a/packages/movehat/src/helpers/index.ts
+++ b/packages/movehat/src/helpers/index.ts
@@ -27,6 +27,7 @@ export type { StoredAccount } from "../core/AccountManager.js";
 export { LocalNodeManager } from "../node/LocalNodeManager.js";
 export type { LocalNodeOptions, LocalNodeInfo } from "../node/LocalNodeManager.js";
 export { MoveliteManager, findMoveliteBinary } from "../node/MoveliteManager.js";
+export type { NodeProvider } from "../node/NodeProvider.js";
 export { setupLocalTesting } from "./setupLocalTesting.js";
 export type { LocalTestingContext } from "./setupLocalTesting.js";
 export {

--- a/packages/movehat/src/templates/tests/setup.ts
+++ b/packages/movehat/src/templates/tests/setup.ts
@@ -1,12 +1,21 @@
 // @ts-nocheck - This is a template file, dependencies are installed in user projects
-import { LocalNodeManager } from "movehat/helpers";
+import {
+  LocalNodeManager,
+  MoveliteManager,
+  findMoveliteBinary,
+} from "movehat/helpers";
 
 let sharedNode;
 
 /**
- * Returns the shared local Movement node started by root hooks.
+ * Returns the shared local node started by root hooks.
  * Pass the result as `{ localNode: getSharedNode() }` to
  * Harness.createLocal() or setupTestFixture().
+ *
+ * Prefers movelite when its binary is available: only the movelite
+ * backend powers the Foundry-style execution traces shown at raised
+ * verbosity (`movehat test --ts -vvvv`). Falls back to the full
+ * Movement node on platforms without a movelite binary.
  */
 export function getSharedNode() {
   if (!sharedNode || !sharedNode.isRunning()) {
@@ -21,7 +30,10 @@ export function getSharedNode() {
 export const mochaHooks = {
   async beforeAll() {
     this.timeout(60000);
-    sharedNode = new LocalNodeManager({ forceRestart: true });
+    const moveliteBinary = findMoveliteBinary();
+    sharedNode = moveliteBinary
+      ? new MoveliteManager(moveliteBinary)
+      : new LocalNodeManager({ forceRestart: true });
     await sharedNode.start();
   },
 

--- a/packages/movehat/src/types/config.ts
+++ b/packages/movehat/src/types/config.ts
@@ -47,7 +47,7 @@ export interface LocalTestOptions {
     mode?: LocalTestingMode;            // Testing mode: 'local-node' (full blockchain) or 'fork' (read-only snapshot) (default: 'local-node')
 
     // Shared node (when mode='local-node')
-    localNode?: import("../node/LocalNodeManager.js").LocalNodeManager; // Pre-started node to reuse; skips spawn when provided
+    localNode?: import("../node/NodeProvider.js").NodeProvider; // Pre-started node to reuse; skips spawn when provided (LocalNodeManager or MoveliteManager)
     useMovelite?: boolean;              // Try movelite before Movement node (default: true)
 
     // Local Node options (when mode='local-node')


### PR DESCRIPTION
## Summary

The example suite and the `movehat init` scaffold pinned `LocalNodeManager` as the shared root-hook test node. An injected `localNode` takes precedence over movelite auto-selection (`setupLocalTesting.ts:163`), so `traceRpcUrl` was never wired: `movehat test --ts -vv..-vvvv` never rendered the Foundry-style call tree, and every run paid the slow Movement-node boot (on this machine the suite timed out entirely: 0 passing / 5 failing at 3min).

This PR makes the shared-node pattern movelite-preferring everywhere it exists today and syncs the docs. One commit per file:

- `fix: widen LocalTestOptions.localNode to NodeProvider` — the public option only accepted `LocalNodeManager`, so a `MoveliteManager` could not be injected at all.
- `feat: export NodeProvider type from movehat/helpers` — lets scaffold code annotate the shared node.
- `fix: example shared test node prefers movelite so traces work` — `findMoveliteBinary()` → `MoveliteManager`, `LocalNodeManager` fallback.
- `fix: init template shared test node prefers movelite` — `movehat init` output now matches the example and the docs.
- `docs: concise shared-node note in testing guide` — documents the scaffold pattern + the "injecting `localNode` opts out of movelite auto-selection" caveat.
- `docs: refresh stale shared-node paragraph in networks-and-modes` — the root-hooks pattern shipped (#235); the paragraph said it hadn't.
- `docs(changelog): movelite-preferring shared node + NodeProvider export`

Follow-up (separate issue, out of scope): implicit movelite-only shared-node singleton inside the framework so user test files carry zero node-lifecycle code (Hardhat/Foundry-parity DX). Requires `MoveliteManager` lifecycle hardening first.

## Verification (§6.2 Tier 2 / §6.3)

- `pnpm build:movehat` + `pnpm typecheck:example` (Tier 1): **pass** (also enforced by pre-push hook)
- `pnpm test:example`: **pass** — 9 passing in 24s on the movelite backend (baseline before this fix: 0 passing, Movement-node timeout). Note: one run executed concurrently with `pnpm build:docs` flaked on the fixture's 60s timeout from CPU contention; a solo re-run passed clean.
- `pnpm test:smoke`: **pass** — pack, global install, CLI commands, `movehat init` (covers the template change)
- `pnpm test:e2e`: **skip** — not a develop→main batch nor a publish; `templates/scripts/**` untouched (only `templates/tests/`), so the §6.2 e2e:quick rule does not apply
- `pnpm assert-backend`: **skip** — backend-selection logic (`setupLocalTesting.ts`, `MoveliteManager.ts`, `Publisher.ts`) untouched
- `pnpm build:docs`: **pass**
- Manual trace check: `MOVEHAT_VERBOSITY=2/3/4` on the example suite renders events / user-module tree / full call tree respectively via movelite's trace endpoint

Closes #339