### PR TITLE
docs: sync quickstart tree and movelite backend diagnosis with scaffold

### DIFF
--- a/packages/docs/content/docs/getting-started/quickstart.mdx
+++ b/packages/docs/content/docs/getting-started/quickstart.mdx
@@ -42,7 +42,8 @@ my-project/
 │   │   └── Counter.move       # Your Move smart contract
 │   └── Move.toml
 ├── tests/
-│   └── Counter.test.ts        # TypeScript tests
+│   ├── Counter.test.ts        # TypeScript tests
+│   └── setup.ts               # Shared local test node (mocha root hooks)
 ├── scripts/
 │   └── deploy-counter.ts      # Deployment script
 ├── movehat.config.ts          # Network configuration

--- a/packages/docs/content/docs/guides/movelite.mdx
+++ b/packages/docs/content/docs/guides/movelite.mdx
@@ -109,9 +109,17 @@ movehat logs the backend as it boots, so you can confirm which one ran:
 - movelite prints `Starting movelite...`
 - the full node prints `Starting local Movement node`
 
-If you expected movelite but see the Movement-node line, the binary was not
-found for your platform — movehat fell back. That is expected on unsupported
-platforms and harmless; your tests still pass, just slower.
+If you expected movelite but see the Movement-node line, there are two causes:
+
+- **The binary was not found for your platform** — movehat fell back. That is
+  expected on unsupported platforms and harmless; your tests still pass, just
+  slower.
+- **Your tests inject a node** — passing `localNode` to `Harness.createLocal`
+  or `setupTestFixture` overrides backend detection entirely; movehat uses
+  whatever node you hand it. Older scaffolds pinned `LocalNodeManager` in
+  `tests/setup.ts` — construct a `MoveliteManager` there instead (see
+  [Sharing one node across
+  specs](./testing#sharing-one-node-across-specs-optional)).
 
 ## Transaction traces
 


### PR DESCRIPTION
## Summary

Two pre-existing docs drifts surfaced by the #339/#340 audit:

- `getting-started/quickstart.mdx` — the Project Structure tree now lists `tests/setup.ts`, scaffolded by `movehat init` since the shared-node optimization and now the file that decides the test backend (and therefore whether traces render).
- `guides/movelite.mdx` — "Which backend started?" now names both causes for seeing the Movement-node line: binary not found (existing) and an injected `localNode` overriding detection (new — this is what older scaffolds hit, with movelite correctly installed), linking to the testing guide's shared-node note.

## Verification (§6.2 / §6.3)

- `pnpm build:docs`: **pass** (183/183 pages, 0 errors)
- Anchor `testing#sharing-one-node-across-specs-optional` verified against built HTML in #340
- `test:example` / `test:smoke` / `test:e2e` / `assert-backend`: **N/A** — docs-site-only, no `packages/movehat/src` or template changes
- CHANGELOG: **skipped per §11** — docs-site content only; nothing ships in the npm package

Closes #342