### PR TITLE
Batch: movelite-preferring scaffold + trace-visibility docs (develop → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `LocalTestOptions.localNode` now accepts any `NodeProvider` (previously
-  `LocalNodeManager` only), and the `NodeProvider` interface is exported from
-  `movehat/helpers` — injecting a pre-started `MoveliteManager` into
-  `setupTestFixture` / `Harness.createLocal` is now expressible in user code.
-  Closes #339.
+- `LocalTestOptions.localNode` now accepts either bundled node manager —
+  `LocalNodeManager` or `MoveliteManager` — via the `NodeProvider` interface,
+  which is newly exported from `movehat/helpers` (previously the option was
+  typed `LocalNodeManager` only, so a pre-started `MoveliteManager` could not
+  be injected into `setupTestFixture` / `Harness.createLocal` at all). Note
+  that movelite-specific behavior (the trace endpoint and SDK publish) engages
+  only for an actual `MoveliteManager` instance; other `NodeProvider`
+  implementations run as a plain node. Closes #339.
 
 ## [0.4.1] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The example suite and the `movehat init` scaffold silently disabled movelite
+  — and with it the Foundry-style execution traces — in `movehat test`. Their
+  shared root-hook node (`tests/setup.ts`) pinned `LocalNodeManager`, and an
+  injected `localNode` takes precedence over movelite auto-selection, so
+  `traceRpcUrl` was never wired and `-vv..-vvvv` rendered no call tree while
+  every run paid the slow Movement-node boot. The shared node now prefers
+  movelite when its binary resolves (Movement node remains the fallback), so
+  scaffolded projects get sub-second boots and full traces out of the box.
+  Closes #339.
+
+### Changed
+
+- `LocalTestOptions.localNode` now accepts any `NodeProvider` (previously
+  `LocalNodeManager` only), and the `NodeProvider` interface is exported from
+  `movehat/helpers` — injecting a pre-started `MoveliteManager` into
+  `setupTestFixture` / `Harness.createLocal` is now expressible in user code.
+  Closes #339.
+
 ## [0.4.1] - 2026-06-15
 
 ### Fixed

--- a/examples/counter-example/tests/setup.ts
+++ b/examples/counter-example/tests/setup.ts
@@ -18,12 +18,16 @@ let sharedNode: NodeProvider | undefined;
  * When movelite is not installed (e.g. a platform without a published
  * binary) it falls back to the full Movement node, which still runs the
  * tests but renders only the degraded event/state trace.
+ *
+ * `MOVEHAT_USE_MOVELITE=0` forces the Movement-node fallback — the same
+ * contract the framework's own backend auto-selection honors.
  */
 export function getSharedNode(): NodeProvider {
   if (!sharedNode || !sharedNode.isRunning()) {
     throw new Error(
-      "Shared node not available. " +
-        'Ensure tests/setup.ts is listed in .mocharc.json under "require".'
+      "Shared node not available — it either never started (ensure " +
+        'tests/setup.ts is listed in .mocharc.json under "require") ' +
+        "or stopped/crashed mid-run."
     );
   }
   return sharedNode;
@@ -32,7 +36,8 @@ export function getSharedNode(): NodeProvider {
 export const mochaHooks = {
   async beforeAll(this: Mocha.Context) {
     this.timeout(60000);
-    const moveliteBinary = findMoveliteBinary();
+    const moveliteBinary =
+      process.env.MOVEHAT_USE_MOVELITE !== "0" ? findMoveliteBinary() : null;
     sharedNode = moveliteBinary
       ? new MoveliteManager(moveliteBinary)
       : new LocalNodeManager({ forceRestart: true });

--- a/examples/counter-example/tests/setup.ts
+++ b/examples/counter-example/tests/setup.ts
@@ -1,13 +1,25 @@
-import { LocalNodeManager } from "movehat/helpers";
+import {
+  LocalNodeManager,
+  MoveliteManager,
+  findMoveliteBinary,
+  type NodeProvider,
+} from "movehat/helpers";
 
-let sharedNode: LocalNodeManager | undefined;
+let sharedNode: NodeProvider | undefined;
 
 /**
- * Returns the shared local Movement node started by root hooks.
+ * Returns the shared local node started by root hooks.
  * Pass the result as `{ localNode: getSharedNode() }` to
  * Harness.createLocal() or setupTestFixture().
+ *
+ * Prefers movelite when its binary is available: only the movelite backend
+ * exposes the /transactions/trace endpoint that powers the Foundry-style
+ * execution traces you see at raised verbosity (`movehat test --ts -vvvv`).
+ * When movelite is not installed (e.g. a platform without a published
+ * binary) it falls back to the full Movement node, which still runs the
+ * tests but renders only the degraded event/state trace.
  */
-export function getSharedNode(): LocalNodeManager {
+export function getSharedNode(): NodeProvider {
   if (!sharedNode || !sharedNode.isRunning()) {
     throw new Error(
       "Shared node not available. " +
@@ -20,7 +32,10 @@ export function getSharedNode(): LocalNodeManager {
 export const mochaHooks = {
   async beforeAll(this: Mocha.Context) {
     this.timeout(60000);
-    sharedNode = new LocalNodeManager({ forceRestart: true });
+    const moveliteBinary = findMoveliteBinary();
+    sharedNode = moveliteBinary
+      ? new MoveliteManager(moveliteBinary)
+      : new LocalNodeManager({ forceRestart: true });
     await sharedNode.start();
   },
 

--- a/packages/docs/content/docs/getting-started/quickstart.mdx
+++ b/packages/docs/content/docs/getting-started/quickstart.mdx
@@ -42,7 +42,8 @@ my-project/
 │   │   └── Counter.move       # Your Move smart contract
 │   └── Move.toml
 ├── tests/
-│   └── Counter.test.ts        # TypeScript tests
+│   ├── Counter.test.ts        # TypeScript tests
+│   └── setup.ts               # Shared local test node (mocha root hooks)
 ├── scripts/
 │   └── deploy-counter.ts      # Deployment script
 ├── movehat.config.ts          # Network configuration

--- a/packages/docs/content/docs/guides/movelite.mdx
+++ b/packages/docs/content/docs/guides/movelite.mdx
@@ -109,9 +109,17 @@ movehat logs the backend as it boots, so you can confirm which one ran:
 - movelite prints `Starting movelite...`
 - the full node prints `Starting local Movement node`
 
-If you expected movelite but see the Movement-node line, the binary was not
-found for your platform — movehat fell back. That is expected on unsupported
-platforms and harmless; your tests still pass, just slower.
+If you expected movelite but see the Movement-node line, there are two causes:
+
+- **The binary was not found for your platform** — movehat fell back. That is
+  expected on unsupported platforms and harmless; your tests still pass, just
+  slower.
+- **Your tests inject a node** — passing `localNode` to `Harness.createLocal`
+  or `setupTestFixture` overrides backend detection entirely; movehat uses
+  whatever node you hand it. Older scaffolds pinned `LocalNodeManager` in
+  `tests/setup.ts` — construct a `MoveliteManager` there instead (see
+  [Sharing one node across
+  specs](./testing#sharing-one-node-across-specs-optional)).
 
 ## Transaction traces
 

--- a/packages/docs/content/docs/guides/networks-and-modes.mdx
+++ b/packages/docs/content/docs/guides/networks-and-modes.mdx
@@ -133,7 +133,7 @@ Fix: keep `deployments/{network}/*.json` files committed (they're tracked by def
 
 ### "My test suite runs slowly because each spec spawns a node"
 
-Symptom: 10 test files = 10 sequential local-node spawns of pure startup overhead before any assertion runs.
+Symptom: 10 test files = 10 sequential local-node spawns — pure startup overhead before any assertion runs.
 
 What happened: each `Harness.createLocal()` call spawns its own local node by default. On the movelite backend that costs under a second per spec, so this usually only hurts when the suite fell back to the full Movement node (~15s per boot).
 

--- a/packages/docs/content/docs/guides/networks-and-modes.mdx
+++ b/packages/docs/content/docs/guides/networks-and-modes.mdx
@@ -133,11 +133,11 @@ Fix: keep `deployments/{network}/*.json` files committed (they're tracked by def
 
 ### "My test suite runs slowly because each spec spawns a node"
 
-Symptom: 10 test files = 10 sequential local-node spawns = 2-5 minutes of pure startup overhead before any assertion runs.
+Symptom: 10 test files = 10 sequential local-node spawns of pure startup overhead before any assertion runs.
 
-What happened: each `Harness.createLocal()` call spawns its own Movement local node by default. The current architecture doesn't share a single node across specs.
+What happened: each `Harness.createLocal()` call spawns its own local node by default. On the movelite backend that costs under a second per spec, so this usually only hurts when the suite fell back to the full Movement node (~15s per boot).
 
-Fix: open issue [#235](https://github.com/gilbertsahumada/movehat/issues/235) tracks this; the proposed mocha root-hooks pattern (Option 1) brings N spawns down to 1. Until that ships, the workaround is to keep test spec counts low or split into separate `movehat test --ts` invocations.
+Fix: the scaffold's mocha root-hooks pattern boots one shared node for the whole run — see [Sharing one node across specs](./testing#sharing-one-node-across-specs-optional). If the per-spec boots themselves are slow, first check that movelite is actually the selected backend (see [movelite](./movelite)).
 
 ## Related
 

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -173,11 +173,12 @@ override, and how to tell which backend started.
 
 ### Sharing one node across specs (optional)
 
-Each spec booting its own local chain is the default and, with movelite,
-costs under a second per file — most projects never need more. To boot the
-chain **once** for the whole `mocha` run, the scaffold that `movehat init`
-generates ships a `tests/setup.ts` root hook that starts one shared node and
-hands it to every fixture via `{ localNode: getSharedNode() }` — see the
+With zero configuration, each spec boots its own local chain — with movelite
+that costs under a second per file, so many projects need nothing more. The
+scaffold that `movehat init` generates goes one step further: it ships a
+`tests/setup.ts` root hook that boots one shared node for the whole `mocha`
+run and hands it to every fixture via `{ localNode: getSharedNode() }` — see
+the
 [counter example](https://github.com/gilbertsahumada/movehat/blob/main/examples/counter-example/tests/setup.ts)
 for the full file.
 

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -171,6 +171,21 @@ harness = await Harness.createLocal({
 See [movelite](./movelite) for supported platforms, the `MOVEHAT_USE_MOVELITE`
 override, and how to tell which backend started.
 
+### Sharing one node across specs (optional)
+
+Each spec booting its own local chain is the default and, with movelite,
+costs under a second per file — most projects never need more. To boot the
+chain **once** for the whole `mocha` run, the scaffold that `movehat init`
+generates ships a `tests/setup.ts` root hook that starts one shared node and
+hands it to every fixture via `{ localNode: getSharedNode() }` — see the
+[counter example](https://github.com/gilbertsahumada/movehat/tree/main/examples/counter-example/tests/setup.ts)
+for the full file.
+
+> **Passing `localNode` opts out of movelite auto-selection** — movehat uses
+> the node you hand it. To keep the full [execution traces](./traces),
+> construct a `MoveliteManager` (as the scaffold does); a plain
+> `LocalNodeManager` gives only the degraded event/state trace.
+
 ## Running All Tests
 
 Run both Move and TypeScript tests together:

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -178,7 +178,7 @@ costs under a second per file — most projects never need more. To boot the
 chain **once** for the whole `mocha` run, the scaffold that `movehat init`
 generates ships a `tests/setup.ts` root hook that starts one shared node and
 hands it to every fixture via `{ localNode: getSharedNode() }` — see the
-[counter example](https://github.com/gilbertsahumada/movehat/tree/main/examples/counter-example/tests/setup.ts)
+[counter example](https://github.com/gilbertsahumada/movehat/blob/main/examples/counter-example/tests/setup.ts)
 for the full file.
 
 > **Passing `localNode` opts out of movelite auto-selection** — movehat uses

--- a/packages/movehat/src/helpers/index.ts
+++ b/packages/movehat/src/helpers/index.ts
@@ -27,6 +27,7 @@ export type { StoredAccount } from "../core/AccountManager.js";
 export { LocalNodeManager } from "../node/LocalNodeManager.js";
 export type { LocalNodeOptions, LocalNodeInfo } from "../node/LocalNodeManager.js";
 export { MoveliteManager, findMoveliteBinary } from "../node/MoveliteManager.js";
+export type { NodeProvider } from "../node/NodeProvider.js";
 export { setupLocalTesting } from "./setupLocalTesting.js";
 export type { LocalTestingContext } from "./setupLocalTesting.js";
 export {

--- a/packages/movehat/src/templates/tests/setup.ts
+++ b/packages/movehat/src/templates/tests/setup.ts
@@ -12,16 +12,22 @@ let sharedNode;
  * Pass the result as `{ localNode: getSharedNode() }` to
  * Harness.createLocal() or setupTestFixture().
  *
- * Prefers movelite when its binary is available: only the movelite
- * backend powers the Foundry-style execution traces shown at raised
- * verbosity (`movehat test --ts -vvvv`). Falls back to the full
- * Movement node on platforms without a movelite binary.
+ * Prefers movelite when its binary is available: only the movelite backend
+ * exposes the /transactions/trace endpoint that powers the Foundry-style
+ * execution traces you see at raised verbosity (`movehat test --ts -vvvv`).
+ * When movelite is not installed (e.g. a platform without a published
+ * binary) it falls back to the full Movement node, which still runs the
+ * tests but renders only the degraded event/state trace.
+ *
+ * `MOVEHAT_USE_MOVELITE=0` forces the Movement-node fallback — the same
+ * contract the framework's own backend auto-selection honors.
  */
 export function getSharedNode() {
   if (!sharedNode || !sharedNode.isRunning()) {
     throw new Error(
-      "Shared node not available. " +
-        'Ensure tests/setup.ts is listed in .mocharc.json under "require".'
+      "Shared node not available — it either never started (ensure " +
+        'tests/setup.ts is listed in .mocharc.json under "require") ' +
+        "or stopped/crashed mid-run."
     );
   }
   return sharedNode;
@@ -30,7 +36,8 @@ export function getSharedNode() {
 export const mochaHooks = {
   async beforeAll() {
     this.timeout(60000);
-    const moveliteBinary = findMoveliteBinary();
+    const moveliteBinary =
+      process.env.MOVEHAT_USE_MOVELITE !== "0" ? findMoveliteBinary() : null;
     sharedNode = moveliteBinary
       ? new MoveliteManager(moveliteBinary)
       : new LocalNodeManager({ forceRestart: true });

--- a/packages/movehat/src/templates/tests/setup.ts
+++ b/packages/movehat/src/templates/tests/setup.ts
@@ -3,9 +3,10 @@ import {
   LocalNodeManager,
   MoveliteManager,
   findMoveliteBinary,
+  type NodeProvider,
 } from "movehat/helpers";
 
-let sharedNode;
+let sharedNode: NodeProvider | undefined;
 
 /**
  * Returns the shared local node started by root hooks.
@@ -22,7 +23,7 @@ let sharedNode;
  * `MOVEHAT_USE_MOVELITE=0` forces the Movement-node fallback — the same
  * contract the framework's own backend auto-selection honors.
  */
-export function getSharedNode() {
+export function getSharedNode(): NodeProvider {
   if (!sharedNode || !sharedNode.isRunning()) {
     throw new Error(
       "Shared node not available — it either never started (ensure " +

--- a/packages/movehat/src/templates/tests/setup.ts
+++ b/packages/movehat/src/templates/tests/setup.ts
@@ -1,12 +1,21 @@
 // @ts-nocheck - This is a template file, dependencies are installed in user projects
-import { LocalNodeManager } from "movehat/helpers";
+import {
+  LocalNodeManager,
+  MoveliteManager,
+  findMoveliteBinary,
+} from "movehat/helpers";
 
 let sharedNode;
 
 /**
- * Returns the shared local Movement node started by root hooks.
+ * Returns the shared local node started by root hooks.
  * Pass the result as `{ localNode: getSharedNode() }` to
  * Harness.createLocal() or setupTestFixture().
+ *
+ * Prefers movelite when its binary is available: only the movelite
+ * backend powers the Foundry-style execution traces shown at raised
+ * verbosity (`movehat test --ts -vvvv`). Falls back to the full
+ * Movement node on platforms without a movelite binary.
  */
 export function getSharedNode() {
   if (!sharedNode || !sharedNode.isRunning()) {
@@ -21,7 +30,10 @@ export function getSharedNode() {
 export const mochaHooks = {
   async beforeAll() {
     this.timeout(60000);
-    sharedNode = new LocalNodeManager({ forceRestart: true });
+    const moveliteBinary = findMoveliteBinary();
+    sharedNode = moveliteBinary
+      ? new MoveliteManager(moveliteBinary)
+      : new LocalNodeManager({ forceRestart: true });
     await sharedNode.start();
   },
 

--- a/packages/movehat/src/types/config.ts
+++ b/packages/movehat/src/types/config.ts
@@ -47,7 +47,7 @@ export interface LocalTestOptions {
     mode?: LocalTestingMode;            // Testing mode: 'local-node' (full blockchain) or 'fork' (read-only snapshot) (default: 'local-node')
 
     // Shared node (when mode='local-node')
-    localNode?: import("../node/LocalNodeManager.js").LocalNodeManager; // Pre-started node to reuse; skips spawn when provided
+    localNode?: import("../node/NodeProvider.js").NodeProvider; // Pre-started node to reuse; skips spawn when provided (LocalNodeManager or MoveliteManager)
     useMovelite?: boolean;              // Try movelite before Movement node (default: true)
 
     // Local Node options (when mode='local-node')

--- a/packages/movehat/src/types/config.ts
+++ b/packages/movehat/src/types/config.ts
@@ -47,7 +47,7 @@ export interface LocalTestOptions {
     mode?: LocalTestingMode;            // Testing mode: 'local-node' (full blockchain) or 'fork' (read-only snapshot) (default: 'local-node')
 
     // Shared node (when mode='local-node')
-    localNode?: import("../node/NodeProvider.js").NodeProvider; // Pre-started node to reuse; skips spawn when provided (LocalNodeManager or MoveliteManager)
+    localNode?: import("../node/NodeProvider.js").NodeProvider; // Pre-started node to reuse; skips spawn when provided. Movelite-specific behavior (trace endpoint, SDK publish) engages only for an actual MoveliteManager instance; other NodeProvider implementations run as a plain node.
     useMovelite?: boolean;              // Try movelite before Movement node (default: true)
 
     // Local Node options (when mode='local-node')


### PR DESCRIPTION
## Summary

Develop→main batch shipping two sub-PRs:

- **#340** — the example suite and the `movehat init` template's shared root-hook test node now prefers movelite (with `LocalNodeManager` fallback), so `movehat test --ts -vv..-vvvv` renders Foundry-style execution traces out of the box; `LocalTestOptions.localNode` widened to `NodeProvider` (newly exported from `movehat/helpers`). Closes #339.
- **#343** — docs drift sync: quickstart project tree lists `tests/setup.ts`; movelite guide's "Which backend started?" documents the injected-`localNode` cause. Closes #342.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Docs / chore / tooling

## Related issues

Closes #339, Closes #342 (sub-PRs merged to develop; keywords repeated here so the batch auto-closes them on main).

## How was this tested?

- `pnpm test:e2e`: **pass — 34/34 in 87s** (pack → global install → init → test --move → fork create/list), run on this batch head per §6.3.
- Tier 2 (from sub-PR #340, re-verified on develop): `pnpm test:example` **pass** (9 passing in 24s on the movelite backend), `pnpm test:smoke` **pass** (covers the changed init template).
- Tier 1: `pnpm build:movehat` + `pnpm typecheck:example` **pass** (pre-push enforced).
- `pnpm build:docs` **pass** (183/183 pages).
- Manual: `MOVEHAT_VERBOSITY=2/3/4` on the example suite renders events / user-module tree / full call tree via movelite's trace endpoint.

## Checklist

- [x] `pnpm test` passes locally (563 unit tests, enforced pre-push)
- [x] **Tier 2 install verification** — `pnpm test:example` pass, `pnpm test:smoke` pass (batch touches `packages/movehat/src/**` and published templates)
- [x] CHANGELOG `[Unreleased]` updated
- [x] Docs updated (testing, movelite, networks-and-modes, quickstart guides)
- [x] ROADMAP — N/A (no ROADMAP.md at repo root; no milestone DoD bullets affected)
- [x] Conventional Commits used in commit messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local test setups can now automatically use a faster backend when available, with seamless fallback to the full node.
  * Test suites can share one node across multiple specs for quicker runs and full tracing support.

* **Bug Fixes**
  * Restored full execution traces in shared test setups.
  * Reduced local node startup time in default test runs.

* **Documentation**
  * Expanded guides and quickstart examples to explain backend selection, shared-node setup, and performance expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->