### PR TITLE
fix: batch #344 review findings — scaffold env override, docs wording, NodeProvider caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `LocalTestOptions.localNode` now accepts any `NodeProvider` (previously
-  `LocalNodeManager` only), and the `NodeProvider` interface is exported from
-  `movehat/helpers` — injecting a pre-started `MoveliteManager` into
-  `setupTestFixture` / `Harness.createLocal` is now expressible in user code.
-  Closes #339.
+- `LocalTestOptions.localNode` now accepts either bundled node manager —
+  `LocalNodeManager` or `MoveliteManager` — via the `NodeProvider` interface,
+  which is newly exported from `movehat/helpers` (previously the option was
+  typed `LocalNodeManager` only, so a pre-started `MoveliteManager` could not
+  be injected into `setupTestFixture` / `Harness.createLocal` at all). Note
+  that movelite-specific behavior (the trace endpoint and SDK publish) engages
+  only for an actual `MoveliteManager` instance; other `NodeProvider`
+  implementations run as a plain node. Closes #339.
 
 ## [0.4.1] - 2026-06-15
 

--- a/examples/counter-example/tests/setup.ts
+++ b/examples/counter-example/tests/setup.ts
@@ -18,12 +18,16 @@ let sharedNode: NodeProvider | undefined;
  * When movelite is not installed (e.g. a platform without a published
  * binary) it falls back to the full Movement node, which still runs the
  * tests but renders only the degraded event/state trace.
+ *
+ * `MOVEHAT_USE_MOVELITE=0` forces the Movement-node fallback — the same
+ * contract the framework's own backend auto-selection honors.
  */
 export function getSharedNode(): NodeProvider {
   if (!sharedNode || !sharedNode.isRunning()) {
     throw new Error(
-      "Shared node not available. " +
-        'Ensure tests/setup.ts is listed in .mocharc.json under "require".'
+      "Shared node not available — it either never started (ensure " +
+        'tests/setup.ts is listed in .mocharc.json under "require") ' +
+        "or stopped/crashed mid-run."
     );
   }
   return sharedNode;
@@ -32,7 +36,8 @@ export function getSharedNode(): NodeProvider {
 export const mochaHooks = {
   async beforeAll(this: Mocha.Context) {
     this.timeout(60000);
-    const moveliteBinary = findMoveliteBinary();
+    const moveliteBinary =
+      process.env.MOVEHAT_USE_MOVELITE !== "0" ? findMoveliteBinary() : null;
     sharedNode = moveliteBinary
       ? new MoveliteManager(moveliteBinary)
       : new LocalNodeManager({ forceRestart: true });

--- a/packages/docs/content/docs/guides/networks-and-modes.mdx
+++ b/packages/docs/content/docs/guides/networks-and-modes.mdx
@@ -133,7 +133,7 @@ Fix: keep `deployments/{network}/*.json` files committed (they're tracked by def
 
 ### "My test suite runs slowly because each spec spawns a node"
 
-Symptom: 10 test files = 10 sequential local-node spawns of pure startup overhead before any assertion runs.
+Symptom: 10 test files = 10 sequential local-node spawns — pure startup overhead before any assertion runs.
 
 What happened: each `Harness.createLocal()` call spawns its own local node by default. On the movelite backend that costs under a second per spec, so this usually only hurts when the suite fell back to the full Movement node (~15s per boot).
 

--- a/packages/docs/content/docs/guides/testing.mdx
+++ b/packages/docs/content/docs/guides/testing.mdx
@@ -173,11 +173,12 @@ override, and how to tell which backend started.
 
 ### Sharing one node across specs (optional)
 
-Each spec booting its own local chain is the default and, with movelite,
-costs under a second per file — most projects never need more. To boot the
-chain **once** for the whole `mocha` run, the scaffold that `movehat init`
-generates ships a `tests/setup.ts` root hook that starts one shared node and
-hands it to every fixture via `{ localNode: getSharedNode() }` — see the
+With zero configuration, each spec boots its own local chain — with movelite
+that costs under a second per file, so many projects need nothing more. The
+scaffold that `movehat init` generates goes one step further: it ships a
+`tests/setup.ts` root hook that boots one shared node for the whole `mocha`
+run and hands it to every fixture via `{ localNode: getSharedNode() }` — see
+the
 [counter example](https://github.com/gilbertsahumada/movehat/blob/main/examples/counter-example/tests/setup.ts)
 for the full file.
 

--- a/packages/movehat/src/templates/tests/setup.ts
+++ b/packages/movehat/src/templates/tests/setup.ts
@@ -12,16 +12,22 @@ let sharedNode;
  * Pass the result as `{ localNode: getSharedNode() }` to
  * Harness.createLocal() or setupTestFixture().
  *
- * Prefers movelite when its binary is available: only the movelite
- * backend powers the Foundry-style execution traces shown at raised
- * verbosity (`movehat test --ts -vvvv`). Falls back to the full
- * Movement node on platforms without a movelite binary.
+ * Prefers movelite when its binary is available: only the movelite backend
+ * exposes the /transactions/trace endpoint that powers the Foundry-style
+ * execution traces you see at raised verbosity (`movehat test --ts -vvvv`).
+ * When movelite is not installed (e.g. a platform without a published
+ * binary) it falls back to the full Movement node, which still runs the
+ * tests but renders only the degraded event/state trace.
+ *
+ * `MOVEHAT_USE_MOVELITE=0` forces the Movement-node fallback — the same
+ * contract the framework's own backend auto-selection honors.
  */
 export function getSharedNode() {
   if (!sharedNode || !sharedNode.isRunning()) {
     throw new Error(
-      "Shared node not available. " +
-        'Ensure tests/setup.ts is listed in .mocharc.json under "require".'
+      "Shared node not available — it either never started (ensure " +
+        'tests/setup.ts is listed in .mocharc.json under "require") ' +
+        "or stopped/crashed mid-run."
     );
   }
   return sharedNode;
@@ -30,7 +36,8 @@ export function getSharedNode() {
 export const mochaHooks = {
   async beforeAll() {
     this.timeout(60000);
-    const moveliteBinary = findMoveliteBinary();
+    const moveliteBinary =
+      process.env.MOVEHAT_USE_MOVELITE !== "0" ? findMoveliteBinary() : null;
     sharedNode = moveliteBinary
       ? new MoveliteManager(moveliteBinary)
       : new LocalNodeManager({ forceRestart: true });

--- a/packages/movehat/src/types/config.ts
+++ b/packages/movehat/src/types/config.ts
@@ -47,7 +47,7 @@ export interface LocalTestOptions {
     mode?: LocalTestingMode;            // Testing mode: 'local-node' (full blockchain) or 'fork' (read-only snapshot) (default: 'local-node')
 
     // Shared node (when mode='local-node')
-    localNode?: import("../node/NodeProvider.js").NodeProvider; // Pre-started node to reuse; skips spawn when provided (LocalNodeManager or MoveliteManager)
+    localNode?: import("../node/NodeProvider.js").NodeProvider; // Pre-started node to reuse; skips spawn when provided. Movelite-specific behavior (trace endpoint, SDK publish) engages only for an actual MoveliteManager instance; other NodeProvider implementations run as a plain node.
     useMovelite?: boolean;              // Try movelite before Movement node (default: true)
 
     // Local Node options (when mode='local-node')


### PR DESCRIPTION
## Summary

Resolves the four yellow findings from the 8-angle review of batch PR #344 (see the review comment there). Three commits, one per functional unit:

- `fix: scaffold shared node honors MOVEHAT_USE_MOVELITE` — the example and init-template root hooks selected purely on `findMoveliteBinary()`, making the documented `MOVEHAT_USE_MOVELITE=0` escape hatch inert in scaffolded projects (an injected `localNode` bypasses the framework's `resolveUseMovelite()` gate). Also reworks `getSharedNode()`'s error so it no longer blames `.mocharc.json` exclusively when the node stopped mid-run, and aligns the two copies' doc comments.
- `docs: fix broken sentence and default-behavior wording from batch review` — repairs the ungrammatical symptom line in networks-and-modes.mdx and disambiguates zero-config behavior vs the scaffold's shared-node default in testing.mdx.
- `docs: caveat that movelite behavior requires a MoveliteManager instance` — the `localNode` option comment and the CHANGELOG `[Unreleased]` bullet now state that trace wiring and SDK publish key off `instanceof MoveliteManager`; custom `NodeProvider` implementations run as a plain node. Capability-based fix deferred to #341.

## Verification (§6.2)

- Tier 1 (`pnpm build:movehat` + `pnpm typecheck:example`): **pass**
- **Env-override proof**: `MOVEHAT_USE_MOVELITE=0` on the example suite now logs `Starting local Movement node` (selection honored; the node backend itself is unavailable on this machine — known local issue — so the assertion is the selection line). Default path logs `Starting movelite...` and the full suite passes **9/9 in 14s**.
- `pnpm test:smoke`: **pass** (template changed)
- `pnpm build:docs`: **pass** (0 errors)
- `pnpm test:e2e`: N/A for this sub-PR — already run on the batch head (34/34); the batch PR #344 picks these commits up automatically and its body records the e2e result.

Closes #345