### PR TITLE
chore: align template setup.ts typing with the example (CR triage on #344)

### DIFF
--- a/packages/movehat/src/templates/tests/setup.ts
+++ b/packages/movehat/src/templates/tests/setup.ts
@@ -3,9 +3,10 @@ import {
   LocalNodeManager,
   MoveliteManager,
   findMoveliteBinary,
+  type NodeProvider,
 } from "movehat/helpers";
 
-let sharedNode;
+let sharedNode: NodeProvider | undefined;
 
 /**
  * Returns the shared local node started by root hooks.
@@ -22,7 +23,7 @@ let sharedNode;
  * `MOVEHAT_USE_MOVELITE=0` forces the Movement-node fallback — the same
  * contract the framework's own backend auto-selection honors.
  */
-export function getSharedNode() {
+export function getSharedNode(): NodeProvider {
   if (!sharedNode || !sharedNode.isRunning()) {
     throw new Error(
       "Shared node not available — it either never started (ensure " +


### PR DESCRIPTION
## Summary

Applies the single actionable CodeRabbit finding from the batch #344 review: the init-template `tests/setup.ts` lacked the `NodeProvider` annotations its sibling example carries, so `sharedNode` / `getSharedNode()` inferred `any` in every scaffolded project. Three-line alignment; `@ts-nocheck` still guards repo-side compilation, and scaffolded projects now receive a file identical to the linked canonical example.

## Verification (§6.2)

- Tier 1 (`pnpm build:movehat` + `pnpm typecheck:example`): **pass**
- `pnpm test:smoke`: **pass** (template ships correctly)
- `pnpm test:example`: N/A — example files untouched by this PR (verified 9/9 on this tree in #346 an hour ago)

Refs #344 (CR triage; no standalone issue — three-line scaffold-typing alignment surfaced by the batch review, resolution recorded on #344).