### PR TITLE
chore: release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-07
+
 ### Fixed
 
 - The example suite and the `movehat init` scaffold silently disabled movelite

--- a/packages/movehat/package.json
+++ b/packages/movehat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movehat",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "Hardhat-like development framework for Movement L1 smart contracts",
   "bin": {


### PR DESCRIPTION
## Summary

Mechanical release PR: `[Unreleased]` → `[0.5.0] - 2026-07-07` in CHANGELOG.md and `package.json` 0.4.1 → 0.5.0. No prose written — entries were accumulated per-PR under §11.

**Minor bump per MAINTENANCE.md** ("new features, new exports"): this release adds the `NodeProvider` export and widens `LocalTestOptions.localNode`, alongside the movelite-preferring scaffold fix (traces in `movehat test` out of the box). Content shipped to main in batch #344 (sub-PRs #340, #343, #346, #347; issues #339, #342, #345).

## Pre-publish gate (§6.3)

- `pnpm test:e2e` on this branch: **pass — 34/34 in 53s**.
- `scripts/pre-publish.sh` could not run: it aborts on the happy path (clean-tree check reads stale `$?` under `set -e`) — bug filed as #348 with the gate's substance (test:e2e) run manually instead. CI on this PR re-runs unit + E2E + audit as belt-and-suspenders.
- After merge: GitHub Release `v0.5.0` triggers `publish.yml` (OIDC/Trusted Publishers, provenance).