### PR TITLE
fix: pre-publish gate no longer aborts on the happy path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- The pre-publish gate (`scripts/pre-publish.sh`) no longer aborts on the
+  happy path. Its `check()` helper inspected `$?`, which at else-branch call
+  sites is the exit status of the just-failed `if` condition — so a clean
+  tree, an absent version tag, or a reasonable package size each printed a
+  false failure and killed the script under `set -e` precisely when
+  everything was fine (0.5.0 ran the gate's substance manually because of
+  this). Checks now use explicit `check_ok`/`check_fail` markers that
+  accumulate to the summary. Also adds `--non-interactive` (honors `CI=true`)
+  for automation, and treats missing local npm credentials as informational
+  since the publish path is OIDC via `publish.yml`. Closes #348.
+
 ## [0.5.0] - 2026-07-07
 
 ### Fixed

--- a/scripts/pre-publish.sh
+++ b/scripts/pre-publish.sh
@@ -3,10 +3,19 @@ set -e
 
 # Pre-Publish Checklist Script
 # We Run this before publishing to npm
+#
+# Usage: bash scripts/pre-publish.sh [--non-interactive]
+#   --non-interactive (or CI=true): never prompt; any condition that would
+#   have asked "Continue anyway?" fails immediately instead.
 
 # Detect project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+NON_INTERACTIVE=0
+if [[ "${1:-}" == "--non-interactive" ]] || [[ "${CI:-}" == "true" ]]; then
+    NON_INTERACTIVE=1
+fi
 
 echo "=========================================="
 echo "MoveHat Pre-Publish Checklist"
@@ -23,16 +32,19 @@ NC='\033[0m'
 CHECKS_PASSED=0
 CHECKS_FAILED=0
 
-check() {
-    if [ $? -eq 0 ]; then
-        echo -e "${GREEN}✓${NC} $1"
-        CHECKS_PASSED=$((CHECKS_PASSED + 1))
-        return 0
-    else
-        echo -e "${RED}✗${NC} $1"
-        CHECKS_FAILED=$((CHECKS_FAILED + 1))
-        return 1
-    fi
+# Explicit pass/fail markers. Never inspect $? here: at else-branch call
+# sites $? is the exit status of the just-failed `if` condition, which made
+# the old check() print a false ✗ and abort under `set -e` on the exact
+# path where everything was fine. Both helpers return 0 so failures
+# accumulate to the summary, which exits 1 when any check failed.
+check_ok() {
+    echo -e "${GREEN}✓${NC} $1"
+    CHECKS_PASSED=$((CHECKS_PASSED + 1))
+}
+
+check_fail() {
+    echo -e "${RED}✗${NC} $1"
+    CHECKS_FAILED=$((CHECKS_FAILED + 1))
 }
 
 echo -e "${BLUE}1. Checking Git Status${NC}"
@@ -43,13 +55,17 @@ if [[ -n $(git status -s) ]]; then
     echo -e "${YELLOW}⚠${NC}  You have uncommitted changes"
     git status -s
     echo ""
+    if [[ $NON_INTERACTIVE -eq 1 ]]; then
+        echo -e "${RED}✗${NC} Uncommitted changes (non-interactive mode refuses to continue)"
+        exit 1
+    fi
     read -p "Continue anyway? (y/N) " -n 1 -r
     echo ""
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         exit 1
     fi
 else
-    check "No uncommitted changes"
+    check_ok "No uncommitted changes"
 fi
 
 # Check current branch
@@ -58,6 +74,10 @@ echo "Current branch: $CURRENT_BRANCH"
 
 if [[ "$CURRENT_BRANCH" != "main" ]] && [[ "$CURRENT_BRANCH" != "master" ]]; then
     echo -e "${YELLOW}⚠${NC}  Not on main/master branch"
+    if [[ $NON_INTERACTIVE -eq 1 ]]; then
+        echo -e "${RED}✗${NC} Not on main/master (non-interactive mode refuses to continue)"
+        exit 1
+    fi
     read -p "Continue anyway? (y/N) " -n 1 -r
     echo ""
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
@@ -78,7 +98,7 @@ if git rev-parse "v$PACKAGE_VERSION" >/dev/null 2>&1; then
     echo "   Please bump version in package.json"
     exit 1
 else
-    check "Version tag v$PACKAGE_VERSION does not exist (good)"
+    check_ok "Version tag v$PACKAGE_VERSION does not exist (good)"
 fi
 
 echo ""
@@ -87,7 +107,7 @@ echo "----------------------------------------"
 
 cd packages/movehat
 pnpm tsc --noEmit
-check "TypeScript types are valid"
+check_ok "TypeScript types are valid"
 
 echo ""
 echo -e "${BLUE}4. Building Package${NC}"
@@ -95,14 +115,14 @@ echo "----------------------------------------"
 
 cd "$PROJECT_ROOT"
 pnpm build:movehat
-check "Build successful"
+check_ok "Build successful"
 
 echo ""
 echo -e "${BLUE}5. Running Smoke Tests${NC}"
 echo "----------------------------------------"
 
 bash scripts/smoke-test.sh
-check "Smoke tests passed"
+check_ok "Smoke tests passed"
 
 echo ""
 echo -e "${BLUE}5b. Running Tier 3 Install-Experience E2E${NC}"
@@ -113,7 +133,7 @@ echo "----------------------------------------"
 # to catch packaging regressions (missing dist files, broken exports,
 # stale templates) before the artifact reaches npm users.
 bash scripts/e2e-local.sh
-check "Install-experience E2E passed"
+check_ok "Install-experience E2E passed"
 
 echo ""
 echo -e "${BLUE}6. Checking Package Size${NC}"
@@ -129,7 +149,7 @@ if (( $(echo "$SIZE_BYTES > 10" | bc -l) )); then
     echo -e "${YELLOW}⚠${NC}  Package size is large (>10MB)"
     echo "   Consider excluding unnecessary files"
 else
-    check "Package size is reasonable"
+    check_ok "Package size is reasonable"
 fi
 
 echo ""
@@ -141,11 +161,9 @@ REQUIRED_FIELDS=("name" "version" "description" "author" "license" "repository" 
 for field in "${REQUIRED_FIELDS[@]}"; do
     VALUE=$(node -p "require('./package.json').$field || 'MISSING'")
     if [[ "$VALUE" == "MISSING" ]] || [[ "$VALUE" == "undefined" ]]; then
-        echo -e "${RED}✗${NC} Missing required field: $field"
-        CHECKS_FAILED=$((CHECKS_FAILED + 1))
+        check_fail "Missing required field: $field"
     else
-        echo -e "${GREEN}✓${NC} $field: $VALUE"
-        CHECKS_PASSED=$((CHECKS_PASSED + 1))
+        check_ok "$field: $VALUE"
     fi
 done
 
@@ -167,36 +185,36 @@ echo -e "${BLUE}9. Testing README${NC}"
 echo "----------------------------------------"
 
 if [ -f "README.md" ]; then
-    check "README.md exists"
+    check_ok "README.md exists"
 
     # Check for required sections
     if grep -q "## Installation" README.md; then
-        check "README has Installation section"
+        check_ok "README has Installation section"
     else
         echo -e "${YELLOW}⚠${NC}  README missing Installation section"
     fi
 
     if grep -q "## Usage" README.md || grep -q "## Quick Start" README.md; then
-        check "README has Usage/Quick Start section"
+        check_ok "README has Usage/Quick Start section"
     else
         echo -e "${YELLOW}⚠${NC}  README missing Usage section"
     fi
 else
-    echo -e "${RED}✗${NC} README.md is missing"
-    CHECKS_FAILED=$((CHECKS_FAILED + 1))
+    check_fail "README.md is missing"
 fi
 
 echo ""
 echo -e "${BLUE}10. Checking npm credentials${NC}"
 echo "----------------------------------------"
 
+# Informational only: the real publish runs in CI (publish.yml, triggered by
+# a GitHub Release) via OIDC/Trusted Publishers and needs no local login.
+# Local credentials matter only for a manual `npm publish` fallback.
 if npm whoami > /dev/null 2>&1; then
     NPM_USER=$(npm whoami)
-    check "Logged into npm as: $NPM_USER"
+    check_ok "Logged into npm as: $NPM_USER"
 else
-    echo -e "${RED}✗${NC} Not logged into npm"
-    echo "   Run: npm login"
-    CHECKS_FAILED=$((CHECKS_FAILED + 1))
+    echo -e "${YELLOW}⚠${NC}  Not logged into npm (fine: publish runs via OIDC in CI; needed only for manual npm publish)"
 fi
 
 echo ""
@@ -210,12 +228,11 @@ echo ""
 if [ $CHECKS_FAILED -eq 0 ]; then
     echo -e "${GREEN}✓ All checks passed!${NC}"
     echo ""
-    echo "Ready to publish? Run:"
-    echo -e "${BLUE}  cd packages/movehat${NC}"
-    echo -e "${BLUE}  npm publish${NC}"
+    echo "Ready to publish? Create the GitHub Release (publish.yml pushes to npm via OIDC):"
+    echo -e "${BLUE}  gh release create v$PACKAGE_VERSION --target main --title \"v$PACKAGE_VERSION\"${NC}"
     echo ""
-    echo "Or for a dry run:"
-    echo -e "${BLUE}  npm publish --dry-run${NC}"
+    echo "Or publish manually (requires npm login):"
+    echo -e "${BLUE}  cd packages/movehat && npm publish${NC}"
     exit 0
 else
     echo -e "${RED}✗ Some checks failed. Please fix before publishing.${NC}"


### PR DESCRIPTION
## Summary

`scripts/pre-publish.sh` killed itself on a clean tree: `check()` inspected `$?`, which at else-branch call sites is the exit status of the just-failed `if` condition — so a clean tree, an absent version tag, or a reasonable package size each printed a false ✗ and `set -e` aborted precisely when everything was fine (0.5.0's gate ran manually because of this). One commit:

- `check()` replaced with explicit `check_ok` / `check_fail` markers (no `$?` reliance anywhere; both return 0 so failures accumulate to the existing summary, which already exits 1 when any check failed — the original design intent, restored).
- New `--non-interactive` flag (also honors `CI=true`): the two "Continue anyway?" prompts become immediate failures for automation.
- Local npm-credentials check downgraded to informational: the publish path is OIDC via `publish.yml` on GitHub Release; local login only matters for a manual `npm publish` fallback. The closing hint now names the real path (`gh release create vX.Y.Z`).

Out of scope (pre-existing, warning-only): the package-size parser assumes MB units; a kB-sized tarball would mis-warn.

## Verification (§6.2)

- **Happy path (the bug)**: full run to completion through all 10 sections — typecheck, build, smoke, install-E2E — summary `Passed: 17 / Failed: 0`, exit 0. (Run from this branch with a temporary uncommitted version bump so the version-tag check has an untagged version to validate, answering both prompts; count reconciles exactly — the 18th check is the clean-tree ✓ that a dirty run correctly skips.)
- **Non-interactive, clean tree, feature branch**: exits 1 citing the branch; the formerly-fatal `No uncommitted changes` line now prints as ✓ first.
- **Non-interactive, dirty tree**: exits 1 immediately citing uncommitted changes; `CI=true` triggers the same guard.
- Tier 2 (`test:example` / `test:smoke`): N/A as a gate for this diff — maintainer script, not in `packages/movehat/src/**` nor the published tarball — but `test:smoke` and the install-E2E ran anyway inside the happy-path verification above, both green.
- shellcheck: not installed locally, skipped (best-effort item).

Closes #348