### PR TITLE
fix: pre-publish gate measures package size, anchors to repo root, rejects unknown args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for automation, and treats missing local npm credentials as informational
   since the publish path is OIDC via `publish.yml`. Closes #348.
 
+- Follow-up robustness fixes for `scripts/pre-publish.sh` from the post-merge
+  review of the #348 fix. The package-size check never actually measured
+  anything (it grepped for `"Unpacked size:"` while npm emits lowercase
+  `unpacked size:`, so the comparison always silently passed); it now parses
+  `npm pack --dry-run --json` and compares the byte-exact `unpackedSize`
+  against 10 MB. The script also anchors itself to the repo root at startup —
+  invoking it from a subdirectory previously died with a raw node
+  MODULE_NOT_FOUND stack — and rejects unknown arguments instead of silently
+  running interactive mode on a mistyped `--non-interactive`. Closes #351.
+
 ## [0.5.0] - 2026-07-07
 
 ### Fixed

--- a/scripts/pre-publish.sh
+++ b/scripts/pre-publish.sh
@@ -154,8 +154,14 @@ echo "----------------------------------------"
 cd packages/movehat
 # --json puts machine-readable output on stdout (notices go to stderr);
 # unpackedSize is in bytes, so no unit parsing is needed.
+# The node validation must fail hard on a missing/non-numeric value: bash
+# arithmetic would silently coerce a stray string to 0 and pass the check.
 UNPACKED_BYTES=$(npm pack --dry-run --json 2>/dev/null \
-    | node -e "const j=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log(j[0].unpackedSize)")
+    | node -e "
+        const v = JSON.parse(require('fs').readFileSync(0, 'utf8'))[0].unpackedSize;
+        if (!Number.isInteger(v)) { console.error('unpackedSize missing from npm pack --json output'); process.exit(1); }
+        console.log(v);
+    ")
 echo "Unpacked size: $((UNPACKED_BYTES / 1024)) kB"
 
 # Warn if package is too large (>10MB)

--- a/scripts/pre-publish.sh
+++ b/scripts/pre-publish.sh
@@ -8,12 +8,24 @@ set -e
 #   --non-interactive (or CI=true): never prompt; any condition that would
 #   have asked "Continue anyway?" fails immediately instead.
 
-# Detect project root
+# Detect project root and anchor there so the script behaves the same
+# regardless of the invocation directory.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
 
 NON_INTERACTIVE=0
-if [[ "${1:-}" == "--non-interactive" ]] || [[ "${CI:-}" == "true" ]]; then
+for arg in "$@"; do
+    case "$arg" in
+        --non-interactive) NON_INTERACTIVE=1 ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            echo "Usage: bash scripts/pre-publish.sh [--non-interactive]" >&2
+            exit 1
+            ;;
+    esac
+done
+if [[ "${CI:-}" == "true" ]]; then
     NON_INTERACTIVE=1
 fi
 
@@ -140,12 +152,14 @@ echo -e "${BLUE}6. Checking Package Size${NC}"
 echo "----------------------------------------"
 
 cd packages/movehat
-PACKAGE_SIZE=$(npm pack --dry-run 2>&1 | grep "Unpacked size:" | awk '{print $3}')
-echo "Package size: $PACKAGE_SIZE"
+# --json puts machine-readable output on stdout (notices go to stderr);
+# unpackedSize is in bytes, so no unit parsing is needed.
+UNPACKED_BYTES=$(npm pack --dry-run --json 2>/dev/null \
+    | node -e "const j=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log(j[0].unpackedSize)")
+echo "Unpacked size: $((UNPACKED_BYTES / 1024)) kB"
 
 # Warn if package is too large (>10MB)
-SIZE_BYTES=$(echo "$PACKAGE_SIZE" | grep -o '[0-9.]*' | head -1)
-if (( $(echo "$SIZE_BYTES > 10" | bc -l) )); then
+if (( UNPACKED_BYTES > 10 * 1024 * 1024 )); then
     echo -e "${YELLOW}⚠${NC}  Package size is large (>10MB)"
     echo "   Consider excluding unnecessary files"
 else


### PR DESCRIPTION
## Summary

Follow-ups from the post-merge adversarial review of PR #350 (issue #351). Three fixes to `scripts/pre-publish.sh`, none affecting the published npm artifact:

1. **Package-size check (section 6) now actually measures.** It grepped `"Unpacked size:"` while npm emits lowercase `unpacked size:`, so `PACKAGE_SIZE` was always empty, `bc` printed a parse error to stderr, and the check passed unconditionally since its introduction. It now parses `npm pack --dry-run --json` (`.[0].unpackedSize`, bytes) and compares against `10 * 1024 * 1024` — no unit ambiguity, no `bc` dependency. Under `set -e`, a failed `npm pack` or JSON parse aborts the script (correct: that is a real failure).
2. **The script anchors itself to the repo root** (`cd "$PROJECT_ROOT"` right after computing it). Invoking it from any subdirectory previously died at section 2 with a raw node MODULE_NOT_FOUND stack because `require('./packages/movehat/package.json')` resolved against the invocation cwd.
3. **Unknown arguments are rejected** with a usage message (exit 1). Previously only an exact `$1 == --non-interactive` was recognized, so a typo silently ran interactive mode. `CI=true` still implies non-interactive.

## Tier 2 / Tier 3

N/A — maintainer-only script; touches neither `packages/movehat/src/**` nor anything shipped in the tarball. The verification below runs the full Tier 3 gate anyway as part of exercising the script itself.

## Verification (maps 1:1 to the #351 DoD)

- **Unknown flag:** `bash scripts/pre-publish.sh --bogus-flag` → exit 1, `Unknown argument: --bogus-flag` + usage. **pass**
- **`--non-interactive` regression:** from this feature branch with the CHANGELOG dirty → exit 1 immediately citing uncommitted changes, no stdin hang. **pass**
- **Full happy-path run from a subdirectory:** with a temporary uncommitted version bump to 0.5.1 (tag v0.5.0 exists), ran `printf 'yy' | bash ../../scripts/pre-publish.sh` from `packages/movehat/`. All 10 sections completed (build, smoke, install-experience E2E 34/34), printed the real size (`Unpacked size: 488 kB` → `✓ Package size is reasonable`), zero `bc` stderr noise, summary `Passed: 17 / Failed: 0`, exit 0. **pass**
- **Counter integrity:** the 17 reachable `check_ok` sites in that run (version tag, tsc, build, smoke, e2e, size, 8 package.json fields, 3 README checks) match `Passed: 17` exactly. **pass**

## CHANGELOG

`[Unreleased] ### Internal` bullet added in this PR.

Closes #351