### PR TITLE
fix: harden MoveliteManager lifecycle for long-lived nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `MoveliteManager` process lifecycle is now safe for long-lived use.
+  Interrupting a test run with Ctrl+C no longer leaves an orphaned movelite
+  holding port 8090 (a sync kill hook now runs on process exit and on
+  SIGINT/SIGTERM), an unstopped node no longer keeps the mocha event loop
+  alive (the child and its stdio pipes are unref'd once ready), a chatty
+  node can no longer block on the undrained 64KB pipe buffer (output is
+  drained through the standard verbosity filter — critical signals always
+  surface, chatter only with `-v`), and a node that dies during boot now
+  fails immediately with its exit code and recent stderr instead of burning
+  the full 15s readiness timeout on a generic message. A stopped manager
+  can also be started again (the internal killed flag was never reset).
+  Closes #353.
+
 ### Internal
 
 - The pre-publish gate (`scripts/pre-publish.sh`) no longer aborts on the

--- a/packages/movehat/src/node/LocalNodeManager.ts
+++ b/packages/movehat/src/node/LocalNodeManager.ts
@@ -11,12 +11,12 @@ import { logger, isVerbose, colors, symbols } from "../ui/index.js";
 import { withTimedSpinner, withSpinner } from "../ui/spinner.js";
 
 /**
- * Substrings that always surface from the movement subprocess regardless
- * of verbosity. These are signals the user must see to debug a stuck
+ * Substrings that always surface from a node subprocess regardless of
+ * verbosity. These are signals the user must see to debug a stuck
  * startup (panic, fatal, address-in-use). Tested in
  * __tests__/LocalNodeManager.test.ts to guard against silent regressions.
  */
-const CRITICAL_NODE_OUTPUT = /panic|fatal|address already in use|EADDRINUSE/i;
+export const CRITICAL_NODE_OUTPUT = /panic|fatal|address already in use|EADDRINUSE/i;
 
 export interface LocalNodeOptions {
   testDir?: string;           // Directory for node data (default: .movehat/local-node)

--- a/packages/movehat/src/node/MoveliteManager.ts
+++ b/packages/movehat/src/node/MoveliteManager.ts
@@ -15,6 +15,7 @@ import { logger, isVerbose, colors, symbols } from "../ui/index.js";
 
 const READY_TIMEOUT_MS = 15_000;
 const READY_POLL_INTERVAL_MS = 200;
+const READY_PROBE_TIMEOUT_MS = 2_000;
 const SIGKILL_GRACE_MS = 5_000;
 const MAX_STDERR_TAIL_LINES = 20;
 const MAX_STDERR_TAIL_LINE_LENGTH = 500;
@@ -167,7 +168,12 @@ export class MoveliteManager implements NodeProvider {
       // not mask a child that already died.
       if (exitInfo) throw this.buildBootFailure(exitInfo);
       try {
-        const res = await fetch(url);
+        // Per-probe timeout: without it, a wedged listener that accepts
+        // TCP but never responds would stall the loop far past the 15s
+        // deadline, which is only checked between iterations.
+        const res = await fetch(url, {
+          signal: AbortSignal.timeout(READY_PROBE_TIMEOUT_MS),
+        });
         if (res.ok && !exitInfo) return;
       } catch {
         // not ready yet

--- a/packages/movehat/src/node/MoveliteManager.ts
+++ b/packages/movehat/src/node/MoveliteManager.ts
@@ -1,20 +1,41 @@
-import { execSync, spawn, type ChildProcess } from "child_process";
+import { execSync } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
 import { createRequire } from "module";
 import type { Account } from "@aptos-labs/ts-sdk";
-import type { LocalNodeInfo } from "./LocalNodeManager.js";
-import { logger } from "../ui/index.js";
+import { CRITICAL_NODE_OUTPUT, type LocalNodeInfo } from "./LocalNodeManager.js";
+import type { NodeProvider } from "./NodeProvider.js";
+import {
+  defaultChildProcessAdapter,
+  type ChildProcessAdapter,
+  type SpawnedProcess,
+} from "../utils/childProcessAdapter.js";
+import { cleanupCallbacks, ensureSignalHandler } from "../core/movementProfile.js";
+import { logger, isVerbose, colors, symbols } from "../ui/index.js";
 
-export class MoveliteManager {
-  private process: ChildProcess | null = null;
+const READY_TIMEOUT_MS = 15_000;
+const READY_POLL_INTERVAL_MS = 200;
+const SIGKILL_GRACE_MS = 5_000;
+const MAX_STDERR_TAIL_LINES = 20;
+const MAX_STDERR_TAIL_LINE_LENGTH = 500;
+
+export class MoveliteManager implements NodeProvider {
+  private spawned: SpawnedProcess | null = null;
   private port: number;
   private killed = false;
   private readonly binaryPath: string;
+  private readonly adapter: ChildProcessAdapter;
+  private readonly stderrTail: string[] = [];
+  private exitHook: (() => void) | null = null;
 
-  constructor(binaryPath: string, port = 8090) {
+  constructor(
+    binaryPath: string,
+    port = 8090,
+    adapter: ChildProcessAdapter = defaultChildProcessAdapter,
+  ) {
     this.binaryPath = binaryPath;
     this.port = port;
+    this.adapter = adapter;
   }
 
   async start(): Promise<LocalNodeInfo> {
@@ -32,41 +53,153 @@ export class MoveliteManager {
 
     logger.step("Starting movelite...");
 
-    this.process = spawn(
-      binary,
-      ["start", "--port", String(this.port), "--no-auth"],
-      {
-        stdio: "pipe",
-        detached: false,
-      },
-    );
+    this.killed = false;
+    this.stderrTail.length = 0;
 
-    this.process.on("exit", () => {
-      this.process = null;
+    const spawned = this.adapter.spawn({
+      command: binary,
+      args: ["start", "--port", String(this.port), "--no-auth"],
+      stdio: "pipe",
+    });
+    this.spawned = spawned;
+
+    // An undrained pipe fills its 64KB buffer and blocks the node's
+    // writes, so stdout/stderr must always be consumed.
+    spawned.stdout?.on("data", (data: Buffer) => {
+      const output = data.toString().trim();
+      if (!output) return;
+      if (CRITICAL_NODE_OUTPUT.test(output)) {
+        logger.warning(output);
+        return;
+      }
+      if (isVerbose()) {
+        for (const line of output.split("\n")) {
+          if (line) console.log(`  ${colors.muted(symbols.pointer + " " + line)}`);
+        }
+      }
     });
 
-    await this.waitForReady();
+    spawned.stderr?.on("data", (data: Buffer) => {
+      const output = data.toString().trim();
+      if (!output) return;
+      for (const line of output.split("\n")) {
+        if (!line) continue;
+        this.stderrTail.push(line.slice(0, MAX_STDERR_TAIL_LINE_LENGTH));
+        if (this.stderrTail.length > MAX_STDERR_TAIL_LINES) {
+          this.stderrTail.shift();
+        }
+      }
+      if (CRITICAL_NODE_OUTPUT.test(output)) {
+        logger.error(output);
+        return;
+      }
+      if (isVerbose()) {
+        for (const line of output.split("\n")) {
+          if (line) console.error(`  ${colors.muted(symbols.pointer + " " + line)}`);
+        }
+      }
+    });
+
+    // The 'exit' handler gets one synchronous turn and no supervisor
+    // remains to escalate afterwards, so the reap must be SIGKILL. The
+    // guard covers the double invocation on signals (cleanupCallbacks
+    // runs first, then process.exit fires 'exit').
+    let hookFired = false;
+    const exitHook = () => {
+      if (hookFired) return;
+      hookFired = true;
+      spawned.kill("SIGKILL");
+    };
+    this.exitHook = exitHook;
+    ensureSignalHandler();
+    cleanupCallbacks.add(exitHook);
+    process.on("exit", exitHook);
+
+    void spawned.exited.then(({ code }) => {
+      if (code !== null && code !== 0 && !this.killed) {
+        logger.error(`movelite exited with code ${code}`);
+      }
+      this.deregisterExitHook(exitHook);
+      if (this.spawned === spawned) {
+        this.spawned = null;
+      }
+    });
+
+    try {
+      await this.waitForReady(spawned);
+    } catch (err) {
+      spawned.kill("SIGKILL");
+      this.deregisterExitHook(exitHook);
+      if (this.spawned === spawned) {
+        this.spawned = null;
+      }
+      throw err;
+    }
+
+    // Unref only after readiness so an unstopped node can't keep the
+    // parent's event loop alive.
+    spawned.unref();
+
     logger.success(`movelite ready on port ${this.port}`);
 
     return this.getNodeInfo();
   }
 
-  private async waitForReady(): Promise<void> {
-    const url = `http://127.0.0.1:${this.port}/v1`;
-    const timeout = 15_000;
-    const start = Date.now();
+  private deregisterExitHook(hook: () => void): void {
+    cleanupCallbacks.delete(hook);
+    process.removeListener("exit", hook);
+    if (this.exitHook === hook) {
+      this.exitHook = null;
+    }
+  }
 
-    while (Date.now() - start < timeout) {
+  private async waitForReady(spawned: SpawnedProcess): Promise<void> {
+    const url = `http://127.0.0.1:${this.port}/v1`;
+
+    let exitInfo: { code: number | null; signal: NodeJS.Signals | null } | null = null;
+    void spawned.exited.then((info) => {
+      exitInfo = info;
+    });
+
+    const deadline = Date.now() + READY_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      // Liveness first: a foreign node answering on the same port must
+      // not mask a child that already died.
+      if (exitInfo) throw this.buildBootFailure(exitInfo);
       try {
         const res = await fetch(url);
-        if (res.ok) return;
+        if (res.ok && !exitInfo) return;
       } catch {
         // not ready yet
       }
-      await new Promise((r) => setTimeout(r, 200));
+      await new Promise((r) => setTimeout(r, READY_POLL_INTERVAL_MS));
     }
 
-    throw new Error(`movelite did not become ready within ${timeout}ms`);
+    if (exitInfo) throw this.buildBootFailure(exitInfo);
+    throw new Error(
+      `movelite did not become ready within ${READY_TIMEOUT_MS}ms on port ${this.port}` +
+        this.stderrTailSuffix(),
+    );
+  }
+
+  private buildBootFailure(exitInfo: {
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }): Error {
+    let reason: string;
+    if (exitInfo.code === null && exitInfo.signal === null) {
+      reason = `movelite failed to start — check that ${this.binaryPath} exists and is executable`;
+    } else if (exitInfo.signal !== null) {
+      reason = `movelite was killed by ${exitInfo.signal} before becoming ready`;
+    } else {
+      reason = `movelite exited with code ${exitInfo.code} before becoming ready`;
+    }
+    return new Error(reason + this.stderrTailSuffix());
+  }
+
+  private stderrTailSuffix(): string {
+    if (this.stderrTail.length === 0) return "";
+    return `\nRecent stderr:\n  ${this.stderrTail.join("\n  ")}`;
   }
 
   async fundAccount(address: string, amount: number): Promise<void> {
@@ -86,27 +219,31 @@ export class MoveliteManager {
   }
 
   async stop(): Promise<void> {
-    if (!this.process || this.killed) return;
+    const spawned = this.spawned;
+    if (!spawned || this.killed) return;
+    const hook = this.exitHook;
     this.killed = true;
-    this.process.kill("SIGTERM");
+    spawned.kill("SIGTERM");
 
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        if (this.process) this.process.kill("SIGKILL");
-        resolve();
-      }, 5_000);
-      if (this.process) {
-        this.process.on("exit", () => {
-          clearTimeout(timer);
-          resolve();
-        });
-      } else {
-        clearTimeout(timer);
-        resolve();
+    // The exited continuation nulls this.spawned — exactly the condition
+    // under which skipping the SIGKILL is correct.
+    const forceTimer = setTimeout(() => {
+      if (this.spawned === spawned) {
+        spawned.kill("SIGKILL");
       }
-    });
+    }, SIGKILL_GRACE_MS);
 
-    this.process = null;
+    try {
+      await spawned.exited;
+    } finally {
+      clearTimeout(forceTimer);
+      // The hook stays armed through the grace window in case the parent
+      // dies before the child does.
+      if (hook) this.deregisterExitHook(hook);
+      if (this.spawned === spawned) {
+        this.spawned = null;
+      }
+    }
   }
 
   private async isPortInUse(port: number): Promise<boolean> {
@@ -119,7 +256,7 @@ export class MoveliteManager {
   }
 
   isRunning(): boolean {
-    return this.process !== null && !this.killed;
+    return this.spawned !== null && !this.killed;
   }
 
   getNodeInfo(): LocalNodeInfo {

--- a/packages/movehat/src/node/__tests__/LocalNodeManager.test.ts
+++ b/packages/movehat/src/node/__tests__/LocalNodeManager.test.ts
@@ -58,6 +58,7 @@ function buildFakeSpawned(): FakeSpawnedProcess {
       setImmediate(() => exitResolve({ code: null, signal: _signal ?? "SIGTERM" }));
       return true;
     },
+    unref: vi.fn(),
     exited,
     __exit: (code, signal) => exitResolve({ code, signal }),
   };

--- a/packages/movehat/src/node/__tests__/MoveliteManager.test.ts
+++ b/packages/movehat/src/node/__tests__/MoveliteManager.test.ts
@@ -136,7 +136,7 @@ describe("MoveliteManager — start / stop / lifecycle", () => {
   });
 
   it("start spawns 'movelite start --port 8090 --no-auth' via the adapter", async () => {
-    const { adapter, calls } = buildFakeAdapter();
+    const { adapter, calls, spawned } = buildFakeAdapter();
     stubFetchPortFreeThenReady();
     const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
     const info = await mgr.start();
@@ -144,6 +144,10 @@ describe("MoveliteManager — start / stop / lifecycle", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]!.command).toBe("/bin/movelite");
     expect(calls[0]!.args).toEqual(["start", "--port", "8090", "--no-auth"]);
+    expect(calls[0]!.stdio).toBe("pipe");
+    // Both pipes must have consumers or the child blocks on a full buffer.
+    expect(spawned[0]!.stdout!.listenerCount("data")).toBeGreaterThan(0);
+    expect(spawned[0]!.stderr!.listenerCount("data")).toBeGreaterThan(0);
     expect(info.rpcUrl).toBe("http://127.0.0.1:8090");
     expect(mgr.isRunning()).toBe(true);
     await mgr.stop();
@@ -264,15 +268,45 @@ describe("MoveliteManager — subprocess output filtering (§9 console UX)", () 
     await mgr.stop();
   });
 
+  it("hides routine stderr chatter in quiet mode", async () => {
+    const { mgr, proc } = await startedManager();
+    errSpy.mockClear();
+
+    proc.stderr!.emit("data", Buffer.from("applying genesis state"));
+    proc.stderr!.emit("data", Buffer.from("[WARN] deprecated config field"));
+
+    const errCalls = errSpy.mock.calls.flat().join(" ");
+    expect(errCalls).not.toContain("applying genesis state");
+    expect(errCalls).not.toContain("deprecated config field");
+    await mgr.stop();
+  });
+
   it("surfaces stdout chatter with the muted prefix in verbose mode", async () => {
     process.env.MOVEHAT_VERBOSE = "1";
     const { mgr, proc } = await startedManager();
     logSpy.mockClear();
 
+    // Two chunks: the handler must stay attached across emissions.
     proc.stdout!.emit("data", Buffer.from("block committed height=42"));
+    proc.stdout!.emit("data", Buffer.from("tx executed gas_used=7"));
 
     const stdoutCalls = logSpy.mock.calls.flat().join(" ");
     expect(stdoutCalls).toContain("block committed height=42");
+    expect(stdoutCalls).toContain("tx executed gas_used=7");
+    await mgr.stop();
+  });
+
+  it("surfaces stderr chatter via console.error in verbose mode", async () => {
+    process.env.MOVEHAT_VERBOSE = "1";
+    const { mgr, proc } = await startedManager();
+    errSpy.mockClear();
+
+    proc.stderr!.emit("data", Buffer.from("applying genesis state"));
+    proc.stderr!.emit("data", Buffer.from("opening state db"));
+
+    const errCalls = errSpy.mock.calls.flat().join(" ");
+    expect(errCalls).toContain("applying genesis state");
+    expect(errCalls).toContain("opening state db");
     await mgr.stop();
   });
 });
@@ -285,6 +319,8 @@ describe("MoveliteManager — boot failure and liveness", () => {
   });
 
   afterEach(() => {
+    // A failed assertion must not leak fake timers into later tests.
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -365,6 +401,63 @@ describe("MoveliteManager — boot failure and liveness", () => {
     // Trailing \n distinguishes boot-line-1 from boot-line-1x matches.
     expect(message).not.toContain("boot-line-1\n");
     expect(message).not.toContain("boot-line-5\n");
+    vi.useRealTimers();
+  });
+
+  it("rejects a ready response that arrives after the child died (foreign node on the same port)", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    // Port probe rejects; the first readiness fetch is a deferred promise
+    // we resolve ok only AFTER the child has died, emulating a foreign
+    // node answering on the port.
+    let resolveReady!: (v: { ok: boolean }) => void;
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      .mockImplementationOnce(
+        () => new Promise((resolve) => (resolveReady = resolve)),
+      )
+      .mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.stubGlobal("fetch", fetchFn);
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    let captured: unknown;
+    const startPromise = mgr.start().catch((e) => {
+      captured = e;
+    });
+    await flushMicrotasks();
+
+    spawned[0]!.__exit(1, null);
+    await flushMicrotasks();
+    resolveReady({ ok: true });
+    await startPromise;
+
+    expect(captured).toBeInstanceOf(Error);
+    expect((captured as Error).message).toMatch(/exited with code 1/);
+    expect(mgr.isRunning()).toBe(false);
+  });
+
+  it("truncates oversized stderr lines in the tail", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchNeverReady();
+    vi.useFakeTimers();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    let captured: unknown;
+    const startPromise = mgr.start().catch((e) => {
+      captured = e;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const proc = spawned[0]!;
+    proc.stderr!.emit("data", Buffer.from("x".repeat(600)));
+    proc.__exit(1, null);
+
+    await vi.advanceTimersByTimeAsync(600);
+    await startPromise;
+
+    const message = (captured as Error).message;
+    expect(message).toContain("x".repeat(500));
+    expect(message).not.toContain("x".repeat(501));
     vi.useRealTimers();
   });
 
@@ -473,6 +566,7 @@ describe("MoveliteManager — stop", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });

--- a/packages/movehat/src/node/__tests__/MoveliteManager.test.ts
+++ b/packages/movehat/src/node/__tests__/MoveliteManager.test.ts
@@ -1,0 +1,592 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PassThrough } from "node:stream";
+import { writeFileSync, rmSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { MoveliteManager, findMoveliteBinary } from "../MoveliteManager.js";
+import { cleanupCallbacks } from "../../core/movementProfile.js";
+import type {
+  ChildProcessAdapter,
+  SpawnInput,
+  SpawnedProcess,
+} from "../../utils/childProcessAdapter.js";
+
+/**
+ * Strategy mirrors LocalNodeManager.test.ts: inject a fake
+ * `ChildProcessAdapter` for full control over the spawn handle, stub
+ * global `fetch` for the port probe / readiness / faucet endpoints.
+ *
+ * Fetch contract every start() test must honor: the FIRST fetch is the
+ * port-in-use probe — it must REJECT for the port to be considered
+ * free. An always-ok fetch makes both port probes "succeed" and
+ * start() throws "Ports ... in use" before ever spawning.
+ */
+
+interface FakeSpawnedProcess extends SpawnedProcess {
+  /** Test helper — manually trigger the "exited" promise resolution. */
+  __exit: (code: number | null, signal: NodeJS.Signals | null) => void;
+  killSignals: NodeJS.Signals[];
+}
+
+function buildFakeSpawned(opts: { ignoreSigterm?: boolean } = {}): FakeSpawnedProcess {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough();
+  let exitResolve!: (v: { code: number | null; signal: NodeJS.Signals | null }) => void;
+  const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve) => {
+      exitResolve = resolve;
+    }
+  );
+  let dead = false;
+  const killSignals: NodeJS.Signals[] = [];
+  const proc: FakeSpawnedProcess = {
+    pid: 4242,
+    stdout,
+    stderr,
+    stdin,
+    kill: (signal?: NodeJS.Signals) => {
+      if (dead) return false;
+      const sig = signal ?? "SIGTERM";
+      killSignals.push(sig);
+      if (opts.ignoreSigterm && sig === "SIGTERM") return true;
+      dead = true;
+      setImmediate(() => exitResolve({ code: null, signal: sig }));
+      return true;
+    },
+    unref: vi.fn(),
+    exited,
+    __exit: (code, signal) => {
+      if (dead) return;
+      dead = true;
+      exitResolve({ code, signal });
+    },
+    killSignals,
+  };
+  return proc;
+}
+
+function buildFakeAdapter(spawnOpts: { ignoreSigterm?: boolean } = {}): {
+  adapter: ChildProcessAdapter;
+  calls: SpawnInput[];
+  spawned: FakeSpawnedProcess[];
+} {
+  const calls: SpawnInput[] = [];
+  const spawned: FakeSpawnedProcess[] = [];
+  const adapter: ChildProcessAdapter = {
+    run: vi.fn(),
+    spawn: (input) => {
+      calls.push(input);
+      const proc = buildFakeSpawned(spawnOpts);
+      spawned.push(proc);
+      return proc;
+    },
+  };
+  return { adapter, calls, spawned };
+}
+
+/** Port probe rejects (port free), every later poll resolves ready. */
+function stubFetchPortFreeThenReady() {
+  const fn = vi
+    .fn()
+    .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+    .mockResolvedValue({ ok: true });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+/** Port probe rejects (port free), the node never becomes ready. */
+function stubFetchNeverReady() {
+  const fn = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+async function flushMicrotasks() {
+  await new Promise((r) => setImmediate(r));
+}
+
+describe("MoveliteManager — start / stop / lifecycle", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("getNodeInfo defaults to port 8090 with a /v1 ready url", () => {
+    const { adapter } = buildFakeAdapter();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+    const info = mgr.getNodeInfo();
+    expect(info.rpcUrl).toBe("http://127.0.0.1:8090");
+    expect(info.faucetUrl).toBe("http://127.0.0.1:8090");
+    expect(info.readyUrl).toBe("http://127.0.0.1:8090/v1");
+    expect(info.testDir).toBe("");
+  });
+
+  it("isRunning reports false before start", () => {
+    const { adapter } = buildFakeAdapter();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+    expect(mgr.isRunning()).toBe(false);
+  });
+
+  it("start spawns 'movelite start --port 8090 --no-auth' via the adapter", async () => {
+    const { adapter, calls } = buildFakeAdapter();
+    stubFetchPortFreeThenReady();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+    const info = await mgr.start();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.command).toBe("/bin/movelite");
+    expect(calls[0]!.args).toEqual(["start", "--port", "8090", "--no-auth"]);
+    expect(info.rpcUrl).toBe("http://127.0.0.1:8090");
+    expect(mgr.isRunning()).toBe(true);
+    await mgr.stop();
+  });
+
+  it("bumps to port 8091 when 8090 is busy", async () => {
+    const { adapter, calls } = buildFakeAdapter();
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true }) // 8090 probe: busy
+      .mockRejectedValueOnce(new Error("ECONNREFUSED")) // 8091 probe: free
+      .mockResolvedValue({ ok: true }); // ready
+    vi.stubGlobal("fetch", fetchFn);
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+    const info = await mgr.start();
+
+    expect(calls[0]!.args).toContain("8091");
+    expect(info.rpcUrl).toBe("http://127.0.0.1:8091");
+    await mgr.stop();
+  });
+
+  it("throws without spawning when both ports are busy", async () => {
+    const { adapter, calls } = buildFakeAdapter();
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchFn);
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    await expect(mgr.start()).rejects.toThrow(/Ports 8090 and 8091 are in use/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws when constructed with an empty binary path", async () => {
+    const { adapter } = buildFakeAdapter();
+    const mgr = new MoveliteManager("", 8090, adapter);
+    await expect(mgr.start()).rejects.toThrow(/movelite binary not found/);
+  });
+
+  it("can start again after stop (killed flag resets)", async () => {
+    const { adapter, calls } = buildFakeAdapter();
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNREFUSED")) // probe, first start
+      .mockResolvedValueOnce({ ok: true }) // ready, first start
+      .mockRejectedValueOnce(new Error("ECONNREFUSED")) // probe, second start
+      .mockResolvedValue({ ok: true }); // ready, second start
+    vi.stubGlobal("fetch", fetchFn);
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    await mgr.start();
+    await mgr.stop();
+    expect(mgr.isRunning()).toBe(false);
+
+    await mgr.start();
+    expect(calls).toHaveLength(2);
+    expect(mgr.isRunning()).toBe(true);
+    await mgr.stop();
+  });
+});
+
+describe("MoveliteManager — subprocess output filtering (§9 console UX)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    delete process.env.MOVEHAT_VERBOSE;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.MOVEHAT_VERBOSE;
+  });
+
+  async function startedManager() {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchPortFreeThenReady();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+    await mgr.start();
+    return { mgr, proc: spawned[0]! };
+  }
+
+  it("hides routine stdout chatter in quiet mode", async () => {
+    const { mgr, proc } = await startedManager();
+    logSpy.mockClear();
+
+    proc.stdout!.emit("data", Buffer.from("block committed height=42"));
+    proc.stdout!.emit("data", Buffer.from("tx executed gas_used=7"));
+
+    const stdoutCalls = logSpy.mock.calls.flat().join(" ");
+    expect(stdoutCalls).not.toContain("block committed");
+    expect(stdoutCalls).not.toContain("tx executed");
+    await mgr.stop();
+  });
+
+  it("always surfaces panic lines as warnings, even in quiet mode", async () => {
+    const { mgr, proc } = await startedManager();
+    warnSpy.mockClear();
+
+    proc.stdout!.emit("data", Buffer.from("thread 'main' panicked at 'state corrupted'"));
+
+    const warnCalls = warnSpy.mock.calls.flat().join(" ");
+    expect(warnCalls).toContain("panicked");
+    await mgr.stop();
+  });
+
+  it("always surfaces critical stderr (EADDRINUSE) via logger.error", async () => {
+    const { mgr, proc } = await startedManager();
+    errSpy.mockClear();
+
+    proc.stderr!.emit("data", Buffer.from("Error: listen EADDRINUSE 127.0.0.1:8090"));
+
+    const errCalls = errSpy.mock.calls.flat().join(" ");
+    expect(errCalls).toContain("EADDRINUSE");
+    await mgr.stop();
+  });
+
+  it("surfaces stdout chatter with the muted prefix in verbose mode", async () => {
+    process.env.MOVEHAT_VERBOSE = "1";
+    const { mgr, proc } = await startedManager();
+    logSpy.mockClear();
+
+    proc.stdout!.emit("data", Buffer.from("block committed height=42"));
+
+    const stdoutCalls = logSpy.mock.calls.flat().join(" ");
+    expect(stdoutCalls).toContain("block committed height=42");
+    await mgr.stop();
+  });
+});
+
+describe("MoveliteManager — boot failure and liveness", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("fails fast with exit code and stderr tail when the child dies during boot", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchNeverReady();
+    vi.useFakeTimers();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    let captured: unknown;
+    const startPromise = mgr.start().catch((e) => {
+      captured = e;
+    });
+    await vi.advanceTimersByTimeAsync(0); // let the port probe settle and spawn happen
+
+    const proc = spawned[0]!;
+    proc.stderr!.emit("data", Buffer.from("failed to open genesis blob\nmigration mismatch"));
+    proc.__exit(1, null);
+
+    // Well under the 15s ready timeout — the liveness check must trip first.
+    await vi.advanceTimersByTimeAsync(600);
+    await startPromise;
+
+    expect(captured).toBeInstanceOf(Error);
+    const message = (captured as Error).message;
+    expect(message).toMatch(/exited with code 1 before becoming ready/);
+    expect(message).toContain("failed to open genesis blob");
+    expect(mgr.isRunning()).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("reports a spawn error (no exit code) as a failure to start", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchNeverReady();
+    vi.useFakeTimers();
+    const mgr = new MoveliteManager("/opt/missing/movelite", 8090, adapter);
+
+    let captured: unknown;
+    const startPromise = mgr.start().catch((e) => {
+      captured = e;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    spawned[0]!.__exit(null, null); // the adapter maps spawn 'error' to this shape
+    await vi.advanceTimersByTimeAsync(600);
+    await startPromise;
+
+    const message = (captured as Error).message;
+    expect(message).toMatch(/failed to start/);
+    expect(message).toContain("/opt/missing/movelite");
+    expect(message).not.toContain("code null");
+    vi.useRealTimers();
+  });
+
+  it("bounds the stderr tail to the most recent lines", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchNeverReady();
+    vi.useFakeTimers();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    let captured: unknown;
+    const startPromise = mgr.start().catch((e) => {
+      captured = e;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const proc = spawned[0]!;
+    const lines = Array.from({ length: 30 }, (_, i) => `boot-line-${i + 1}`);
+    proc.stderr!.emit("data", Buffer.from(lines.join("\n")));
+    proc.__exit(1, null);
+
+    await vi.advanceTimersByTimeAsync(600);
+    await startPromise;
+
+    const message = (captured as Error).message;
+    expect(message).toContain("boot-line-30");
+    // Trailing \n distinguishes boot-line-1 from boot-line-1x matches.
+    expect(message).not.toContain("boot-line-1\n");
+    expect(message).not.toContain("boot-line-5\n");
+    vi.useRealTimers();
+  });
+
+  it("ready timeout with a live child kills it and reports the port", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchNeverReady();
+    vi.useFakeTimers();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    let captured: unknown;
+    const startPromise = mgr.start().catch((e) => {
+      captured = e;
+    });
+
+    await vi.advanceTimersByTimeAsync(15_500);
+    await startPromise;
+
+    expect((captured as Error).message).toMatch(/did not become ready within/);
+    expect(spawned[0]!.killSignals).toContain("SIGKILL");
+    expect(spawned[0]!.unref).not.toHaveBeenCalled();
+    expect(mgr.isRunning()).toBe(false);
+    vi.useRealTimers();
+  });
+});
+
+describe("MoveliteManager — unref and exit hooks", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("unrefs the spawn handle exactly once after successful start", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchPortFreeThenReady();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+    await mgr.start();
+
+    expect(spawned[0]!.unref).toHaveBeenCalledTimes(1);
+    await mgr.stop();
+  });
+
+  it("registers exit hooks on start and removes them on stop", async () => {
+    const { adapter } = buildFakeAdapter();
+    stubFetchPortFreeThenReady();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    const exitListenersBefore = process.listenerCount("exit");
+    const cleanupSizeBefore = cleanupCallbacks.size;
+
+    await mgr.start();
+    expect(process.listenerCount("exit")).toBe(exitListenersBefore + 1);
+    expect(cleanupCallbacks.size).toBe(cleanupSizeBefore + 1);
+
+    await mgr.stop();
+    expect(process.listenerCount("exit")).toBe(exitListenersBefore);
+    expect(cleanupCallbacks.size).toBe(cleanupSizeBefore);
+  });
+
+  it("the registered exit hook SIGKILLs the child", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchPortFreeThenReady();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    const listenersBefore = new Set(process.listeners("exit"));
+    await mgr.start();
+    const hook = process
+      .listeners("exit")
+      .find((listener) => !listenersBefore.has(listener));
+    expect(hook).toBeDefined();
+
+    (hook as () => void)();
+    expect(spawned[0]!.killSignals).toContain("SIGKILL");
+
+    await mgr.stop();
+  });
+
+  it("deregisters hooks when the child exits on its own", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchPortFreeThenReady();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    const exitListenersBefore = process.listenerCount("exit");
+    const cleanupSizeBefore = cleanupCallbacks.size;
+
+    await mgr.start();
+    spawned[0]!.__exit(0, null);
+    await flushMicrotasks();
+
+    expect(process.listenerCount("exit")).toBe(exitListenersBefore);
+    expect(cleanupCallbacks.size).toBe(cleanupSizeBefore);
+    expect(mgr.isRunning()).toBe(false);
+  });
+});
+
+describe("MoveliteManager — stop", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("sends SIGTERM, awaits exit, and reports not running; second stop is a no-op", async () => {
+    const { adapter, spawned } = buildFakeAdapter();
+    stubFetchPortFreeThenReady();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+    await mgr.start();
+
+    await mgr.stop();
+    expect(spawned[0]!.killSignals).toEqual(["SIGTERM"]);
+    expect(mgr.isRunning()).toBe(false);
+
+    await mgr.stop();
+    expect(spawned[0]!.killSignals).toEqual(["SIGTERM"]);
+  });
+
+  it("escalates to SIGKILL when the child ignores SIGTERM", async () => {
+    const { adapter, spawned } = buildFakeAdapter({ ignoreSigterm: true });
+    stubFetchPortFreeThenReady();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+    await mgr.start();
+
+    vi.useFakeTimers();
+    const stopPromise = mgr.stop();
+    await vi.advanceTimersByTimeAsync(5_100);
+    await stopPromise;
+    vi.useRealTimers();
+
+    expect(spawned[0]!.killSignals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(mgr.isRunning()).toBe(false);
+  });
+});
+
+describe("MoveliteManager — fundAccount", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("posts to the mint endpoint with address and amount", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchFn);
+    const { adapter } = buildFakeAdapter();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    await mgr.fundAccount("0xabc", 500);
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "http://127.0.0.1:8090/mint?address=0xabc&amount=500",
+      { method: "POST" },
+    );
+  });
+
+  it("throws with the status code when the mint fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    const { adapter } = buildFakeAdapter();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    await expect(mgr.fundAccount("0xabc", 500)).rejects.toThrow(
+      /Failed to fund account: 500/,
+    );
+  });
+
+  it("fundAccounts funds each account in turn", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchFn);
+    const { adapter } = buildFakeAdapter();
+    const mgr = new MoveliteManager("/bin/movelite", 8090, adapter);
+
+    const accounts = [
+      { accountAddress: { toString: () => "0xaaa" } },
+      { accountAddress: { toString: () => "0xbbb" } },
+    ] as never[];
+    await mgr.fundAccounts(accounts, 100);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(fetchFn.mock.calls[0]![0]).toContain("address=0xaaa");
+    expect(fetchFn.mock.calls[1]![0]).toContain("address=0xbbb");
+  });
+});
+
+describe("findMoveliteBinary — MOVELITE_PATH override", () => {
+  let tmpDir: string;
+  const savedEnv = process.env.MOVELITE_PATH;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "movehat-movelite-"));
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.MOVELITE_PATH;
+    } else {
+      process.env.MOVELITE_PATH = savedEnv;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the env path when it points at an existing file", () => {
+    const bin = join(tmpDir, "movelite");
+    writeFileSync(bin, "#!/bin/sh\n");
+    process.env.MOVELITE_PATH = bin;
+    expect(findMoveliteBinary()).toBe(bin);
+  });
+
+  it("returns null when the env path does not exist", () => {
+    process.env.MOVELITE_PATH = join(tmpDir, "nope");
+    expect(findMoveliteBinary()).toBeNull();
+  });
+});

--- a/packages/movehat/src/utils/childProcessAdapter.ts
+++ b/packages/movehat/src/utils/childProcessAdapter.ts
@@ -96,6 +96,13 @@ export interface SpawnedProcess {
   stdin: Writable | null;
   kill(signal?: NodeJS.Signals): boolean;
   /**
+   * Detaches the child AND its stdio pipes from the event-loop ref count
+   * so a long-lived child no longer keeps the parent process alive. Each
+   * stdio socket is a separately ref'd handle, so unref'ing only the
+   * child would leave the pipes holding the loop open.
+   */
+  unref(): void;
+  /**
    * Resolves once when the child exits, regardless of how the caller
    * triggered it (natural exit, `kill`, or process death). Safe to await
    * multiple times.
@@ -265,6 +272,13 @@ class DefaultChildProcessAdapter implements ChildProcessAdapter {
       stderr: child.stderr,
       stdin: child.stdin,
       kill: (signal?: NodeJS.Signals) => child.kill(signal),
+      unref: () => {
+        child.unref();
+        // Typed as Readable/Writable but net.Socket at runtime.
+        for (const stream of [child.stdout, child.stderr, child.stdin]) {
+          (stream as unknown as { unref?: () => void } | null)?.unref?.();
+        }
+      },
       exited,
     };
   }

--- a/packages/movehat/vitest.config.ts
+++ b/packages/movehat/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
         // lifecycle managers
         "src/fork/manager.ts":          { lines: 80, statements: 80, functions: 75, branches: 60 },
         "src/node/LocalNodeManager.ts": { lines: 80, statements: 80, functions: 75, branches: 60 },
+        "src/node/MoveliteManager.ts":  { lines: 80, statements: 80, functions: 75, branches: 60 },
         // top-level commands
         // run.ts threshold intentionally below 80: the orchestrator's
         // "tsx-not-found" branch (lines 80-101) requires patching


### PR DESCRIPTION
## Summary

Sub-PR 1 of 3 for the implicit shared movelite node (#341): makes `MoveliteManager` safe to become a process-lifetime singleton. Two commits:

1. **Enabler** — `SpawnedProcess.unref()` on the child-process adapter (unrefs the child AND each stdio pipe: they are separately ref'd handles, so unref'ing only the child leaves the sockets holding the event loop open); exports `CRITICAL_NODE_OUTPUT` so both node managers share one critical-signal filter.
2. **Hardening** — `MoveliteManager` migrates to the injectable `ChildProcessAdapter` (raw `child_process.spawn` gone; only `execSync` remains, in `findMoveliteBinary`) and closes the lifecycle gaps:
   - **Undrained pipes**: stdout/stderr now flow through the section-9 verbosity filter (critical signals always surface; chatter behind `-v`), so a chatty node can no longer block on the 64KB pipe buffer. The stderr handler also keeps a bounded tail (20 lines x 500 chars) for boot-failure messages.
   - **No unref**: the spawn handle is unref'd once ready — an unstopped node no longer keeps the mocha event loop alive.
   - **No exit hooks**: a sync SIGKILL hook (registered via `process.on("exit")` plus the existing `cleanupCallbacks`/`ensureSignalHandler` registry) reaps the child on parent exit and SIGINT/SIGTERM. SIGKILL because the exit handler gets one synchronous turn with no supervisor left to escalate, and movelite is in-memory with nothing to flush; an orphan would keep port 8090 bound and break the next run's 8090 -> 8091 -> throw probe. Hooks deregister on `stop()` (only after `exited` resolves, so they stay armed through the SIGTERM grace window) and when the child exits on its own.
   - **No liveness check in `waitForReady`**: the loop now checks child exit before each probe and before honoring a ready response (a foreign node on the same port cannot mask a dead child). A boot failure reports immediately with exit code / signal / spawn-error detail plus the stderr tail instead of burning the 15s timeout.
   - **`stop()` on the captured handle**: kills the pre-existing bug where the exit listener nulling the instance field could skip the SIGKILL escalation; also idempotent, and `start()` now resets the killed flag so a stopped manager can restart (required for the future singleton).

No public-surface changes: constructor stays backward compatible (`new MoveliteManager(binary)` unchanged; adapter is an optional third parameter), `NodeProvider` contract unchanged (now declared explicitly via `implements`).

New 26-test unit suite (`src/node/__tests__/MoveliteManager.test.ts`) mirroring the LocalNodeManager fake-adapter patterns, plus a per-file coverage threshold in vitest.config.ts.

## Tier 2 gates (MoveliteManager is on the backend-selection list, §6.2)

- `pnpm vitest run --coverage` — **pass** (617 tests, 54 files; new per-file threshold enforced by the run's exit code).
- `MOVEHAT_EXPECT_BACKEND=movelite pnpm assert-backend` — **pass** (backend=movelite, boot 5511ms <= 20000ms).
- `MOVEHAT_EXPECT_BACKEND=movement-node pnpm assert-backend` — **pass** (backend=movement-node, boot 25440ms <= 90000ms; scope guard falls through correctly).
- `pnpm test:example` — **pass** (9 passing, 12s).
- `pnpm test:smoke` — **pass**.

## Empirical lifecycle verification (issue #353 DoD)

- **No-stop exit**: a script that `start()`s movelite and returns without `stop()` exits in ~1s total (no event-loop hang) and leaves `pgrep -f movelite` empty with port 8090 refusing connections — unref + exit hook both verified.
- **SIGINT mid-suite**: interrupted `pnpm test:example` 12s in (tests running); `pgrep -f movelite` empty and port 8090 free afterwards.

## Tier 3

N/A for this sub-PR (no template or packaging changes); rides the batch e2e per §6.3.

Closes #353
Tracks #341