### PR TITLE
fix: normalize addresses in the module-address assertion; export normalizeAddress from helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `normalizeAddress` is now exported from `movehat/helpers` (lowercase,
-  `0x`-prefixed, left-padded to 64 hex chars). On-chain view results return
+- `normalizeAddress` and `isHexAddress` are now exported from
+  `movehat/helpers` (`normalizeAddress`: lowercase, `0x`-prefixed,
+  left-padded to 64 hex chars; `isHexAddress`: syntactic validation, which
+  `normalizeAddress`'s docs direct callers to). On-chain view results return
   addresses without leading-zero padding while the SDK's
   `accountAddress.toString()` zero-pads them, so comparing the two raw
   strings fails whenever an address happens to start with a zero byte —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `normalizeAddress` is now exported from `movehat/helpers` (lowercase,
+  `0x`-prefixed, left-padded to 64 hex chars). On-chain view results return
+  addresses without leading-zero padding while the SDK's
+  `accountAddress.toString()` zero-pads them, so comparing the two raw
+  strings fails whenever an address happens to start with a zero byte —
+  roughly 1 run in 16 with randomly generated test accounts. The
+  counter-example's `get_module_address` test flaked exactly this way; it
+  now normalizes both sides. New public export, so the next release is a
+  minor bump. Closes #355.
+
 ### Fixed
 
 - `MoveliteManager` process lifecycle is now safe for long-lived use.

--- a/examples/counter-example/tests/greeting.test.ts
+++ b/examples/counter-example/tests/greeting.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, before, after } from "mocha";
 import { expect } from "chai";
-import { setupTestFixture, type TestFixture } from "movehat/helpers";
+import {
+  setupTestFixture,
+  normalizeAddress,
+  type TestFixture,
+} from "movehat/helpers";
 import { getSharedNode } from "./setup.js";
 
 describe("Greeting Contract", () => {
@@ -75,7 +79,11 @@ describe("Greeting Contract", () => {
     const moduleAddress = await greeting.view<string>("get_module_address", []);
     console.log(`   Module address: ${moduleAddress}`);
 
-    expect(moduleAddress).to.equal(fixture.accounts.deployer.accountAddress.toString());
+    // The on-chain view returns the address without leading-zero padding
+    // while the SDK zero-pads to 64 hex chars — normalize both sides.
+    expect(normalizeAddress(moduleAddress)).to.equal(
+      normalizeAddress(fixture.accounts.deployer.accountAddress.toString()),
+    );
   });
 
   after(async () => {

--- a/packages/movehat/src/helpers/index.ts
+++ b/packages/movehat/src/helpers/index.ts
@@ -35,5 +35,6 @@ export {
   setupMinimalFixture,
 } from "./testFixtures.js";
 export type { TestFixture } from "./testFixtures.js";
+export { normalizeAddress } from "../utils/address.js";
 
 export type { MovehatConfig, LocalTestOptions } from "../types/config.js";

--- a/packages/movehat/src/helpers/index.ts
+++ b/packages/movehat/src/helpers/index.ts
@@ -35,6 +35,6 @@ export {
   setupMinimalFixture,
 } from "./testFixtures.js";
 export type { TestFixture } from "./testFixtures.js";
-export { normalizeAddress } from "../utils/address.js";
+export { normalizeAddress, isHexAddress } from "../utils/address.js";
 
 export type { MovehatConfig, LocalTestOptions } from "../types/config.js";


### PR DESCRIPTION
## Summary

Kills the ~1/16 flake in the counter-example (`greeting.test.ts`, "should return correct module address"): the on-chain `get_module_address` view returns the address **without** leading-zero padding (`0xfb52…`) while the SDK's `accountAddress.toString()` zero-pads to 64 hex chars (`0x0fb52…`), so the raw string comparison failed whenever the randomly generated deployer drew a leading-zero byte. Reproduced under both backends; backend-independent by construction.

Fix (option 1 from the issue): re-export the existing `normalizeAddress` helper (`src/utils/address.ts`, already unit-tested) from `movehat/helpers`, and normalize both sides of the assertion. Exporting it is a deliberate DX choice — end users comparing view results against SDK addresses hit the same papercut. **New public export ⇒ the next release is a minor bump** (per MAINTENANCE.md); noted in the CHANGELOG entry.

TypeDoc note: the API reference under `packages/docs/content/docs/api/reference/` is gitignored and regenerated at docs-build time; `pnpm docs:api` was run and picks up the new export automatically (`normalizeAddress.mdx` generated) — nothing to commit.

## Verification

- **Deterministic proof of the flake case**: `normalizeAddress("0xfb52…") === normalizeAddress("0x0fb52…")` → `true` (the exact observed failure shape; padded length 66). The 19 existing `address.test.ts` unit tests pass unchanged.
- **Tier 1** `pnpm check:example` — **pass** (the example, as the strictest consumer, typechecks the new export).
- **Tier 2** — `pnpm test:example` run **10 consecutive times: 10/10 pass** (none of the 10 draws happened to hit a leading-zero deployer, so the deterministic pair check above is the load-bearing evidence for the flake case; the runs prove no regression). `pnpm test:smoke` — **pass**.
- assert-backend N/A (no backend-selection files touched).

## Unblocks

#356 (CI gate for `pnpm test:example`) — this flake was its blocker.

Closes #355