### PR TITLE
CI: Example suite gate (Tier 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,8 @@ jobs:
         # movelite (pulled by pnpm install as movehat's optionalDependency)
         # and the Movement CLI installed above compiles the Move packages.
         # The movement-node mode (MOVEHAT_USE_MOVELITE=0) stays deferred to
-        # the Linux MintFunder issue, same as MOVEHAT_SKIP_LOCAL_NODE above.
+        # the Linux MintFunder issue (#149), same as MOVEHAT_SKIP_LOCAL_NODE
+        # above.
         run: pnpm test:example
         env:
           MOVEMENT_RPC_URL: https://testnet.movementnetwork.xyz/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [build, unit-tests]
-    timeout-minutes: 12
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
@@ -271,6 +271,16 @@ jobs:
         # via the SDK path. The Movement CLI installed above provides the
         # `movement move build` compile step.
         run: MOVEHAT_EXPECT_BACKEND=movelite pnpm assert-backend
+        env:
+          MOVEMENT_RPC_URL: https://testnet.movementnetwork.xyz/v1
+
+      - name: Example suite (Tier 2 gate — movelite backend)
+        # The counter-example mocha suite is all-local: the root hook boots
+        # movelite (pulled by pnpm install as movehat's optionalDependency)
+        # and the Movement CLI installed above compiles the Move packages.
+        # The movement-node mode (MOVEHAT_USE_MOVELITE=0) stays deferred to
+        # the Linux MintFunder issue, same as MOVEHAT_SKIP_LOCAL_NODE above.
+        run: pnpm test:example
         env:
           MOVEMENT_RPC_URL: https://testnet.movementnetwork.xyz/v1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   MODULE_NOT_FOUND stack — and rejects unknown arguments instead of silently
   running interactive mode on a mistyped `--non-interactive`. Closes #351.
 
+- CI E2E job gains the example suite gate (Tier 2 from CLAUDE.md §6.2): the
+  counter-example mocha tests now run on every PR to main, in movelite mode
+  (movement-node deferred to #149). The job timeout increases from 12 to 15
+  minutes to accommodate the suite's cold Move compilation. Closes #356.
+
 ## [0.5.0] - 2026-07-07
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds the Tier 2 example suite (`pnpm test:example`) as a gate to the E2E tests job in CI. The counter-example mocha tests run on every PR to main, in movelite mode. Movement-node mode stays deferred to #149 (Linux MintFunder issue).

The E2E job timeout increases from 12 to 15 minutes to accommodate the suite's cold Move compilation (~3s per package × 3 packages + mocha + fixture bootstrap).

## Test Plan

- [x] `pnpm test:example` runs locally in movelite mode (9/9 passing)
- [x] Validated in real CI via `gh workflow run ci.yml --ref ci/issue-356-example-gate` → run 29031139710: all 7 jobs green; E2E job log shows the new step succeeded with `9 passing (12s)`
- [x] Tier 1 (`pnpm check:example`) via pre-push hook: green
- Tier 2/3: N/A — no changes under `packages/movehat/src/**`, `bin/**`, or templates; CI-only change validated by the workflow_dispatch run above

## Closes #356