### PR TITLE
fix: close local-network deployment races (#341 sub-PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Concurrent deploys of the same Move package no longer race. The build
+  step writes in-place to `<packageDir>/build/` with the deployer address
+  baked into the bytecode, and the SDK publish path (movelite) reads those
+  bytes back from disk — so two overlapping deploys could publish bytecode
+  compiled for the other deploy's address, and two same-module deploys
+  could both pass the already-deployed check and double-publish. Deploys
+  now serialize per package directory through an in-process keyed lock
+  covering the idempotency check, build, publish, and deployment record —
+  in both write paths (`deployContract` and `deployCodeObject`, which
+  share the lock). The autoDeploy loop also no longer mutates the
+  process-global `MH_CLI_REDEPLOY` environment variable (interleaved
+  set/restore across concurrent fixtures could strand it as `true`);
+  `deployContract` and `deployCodeObject` instead accept an explicit
+  `redeploy` option, with the env var still honored as a fallback for the
+  CLI's `--redeploy` flag. New public option, so the next release is a
+  minor bump. Serial mocha hides these races today; they become reachable
+  with the implicit shared node planned in #341. Closes #359.
+
 - `MoveliteManager` process lifecycle is now safe for long-lived use.
   Interrupting a test run with Ctrl+C no longer leaves an orphaned movelite
   holding port 8090 (a sync kill hook now runs on process exit and on

--- a/packages/movehat/src/__tests__/deployContract.test.ts
+++ b/packages/movehat/src/__tests__/deployContract.test.ts
@@ -754,3 +754,230 @@ describe("Publisher — SDK publish path (movelite backend)", () => {
     ).rejects.toThrow(/Expected exactly one compiled package/);
   });
 });
+
+/**
+ * The build step writes in-place to <packageDir>/build/ with the deployer
+ * address baked into the bytecode, and publishViaSdk reads those bytes
+ * back from disk. Without per-package-dir serialization, two overlapping
+ * deploys publish each other's artifacts. These tests pin the lock.
+ */
+describe("Publisher — per-package-dir deploy serialization", () => {
+  const PKG = "dummy";
+  let tmpCwd: string;
+  let tmpHome: string;
+  let origCwd: string;
+  let origHome: string | undefined;
+  let origRedeploy: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "movehat-lock-home-"));
+    tmpCwd = mkdtempSync(join(tmpdir(), "movehat-lock-cwd-"));
+
+    writeFileSync(
+      join(tmpCwd, "movehat.config.js"),
+      `export default {
+  defaultNetwork: "testnet",
+  networks: { testnet: { url: "https://testnet.movementnetwork.xyz/v1", chainId: "testnet" } }
+};
+`
+    );
+
+    const moveDir = join(tmpCwd, "move");
+    mkdirSync(join(moveDir, "sources"), { recursive: true });
+    writeFileSync(
+      join(moveDir, "Move.toml"),
+      `[package]\nname = "${PKG}"\nversion = "0.0.1"\n\n[addresses]\n`
+    );
+    writeFileSync(join(moveDir, "sources", "dummy.move"), "// intentionally empty\n");
+
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    origCwd = process.cwd();
+    process.chdir(tmpCwd);
+    origRedeploy = process.env.MH_CLI_REDEPLOY;
+    delete process.env.MH_CLI_REDEPLOY;
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(origCwd);
+    } finally {
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      if (origRedeploy === undefined) delete process.env.MH_CLI_REDEPLOY;
+      else process.env.MH_CLI_REDEPLOY = origRedeploy;
+      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+      if (existsSync(tmpCwd)) rmSync(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
+  function makeMockAptos(hash: string) {
+    const publishPackageTransaction = vi.fn(async (args: unknown) => ({ __tx: true, args }));
+    const aptos = {
+      publishPackageTransaction,
+      transaction: { sign: vi.fn(() => ({})), submit: { simple: vi.fn(async () => ({ hash })) } },
+      waitForTransaction: vi.fn(async () => ({ success: true, hash })),
+    } as unknown as Aptos;
+    return { aptos, publishPackageTransaction };
+  }
+
+  /**
+   * Build adapter that actually writes marker artifacts into build/ (the
+   * way the real CLI bakes the deployer address into the bytecode), then
+   * yields long enough for a concurrent unserialized build to stomp them.
+   */
+  function makeMarkingAdapter(marker: number): ChildProcessAdapter {
+    return {
+      async run(input) {
+        if (input.args[1] !== "build") {
+          throw new Error(`SDK path must not invoke the CLI for: ${input.args.join(" ")}`);
+        }
+        const pkgDir = join(tmpCwd, "move", "build", PKG);
+        mkdirSync(join(pkgDir, "bytecode_modules"), { recursive: true });
+        writeFileSync(join(pkgDir, "package-metadata.bcs"), new Uint8Array([marker]));
+        writeFileSync(
+          join(pkgDir, "bytecode_modules", "m.mv"),
+          new Uint8Array([marker, marker])
+        );
+        await new Promise((res) => setTimeout(res, 30));
+        return { exitCode: 0, stdout: "build ok", stderr: "" };
+      },
+      spawn() {
+        throw new Error("spawn not used");
+      },
+    };
+  }
+
+  it("concurrent same-dir deploys each publish their own build artifacts", async () => {
+    const { config, account } = await initRuntime();
+    const a = makeMockAptos("0x" + "a".repeat(64));
+    const b = makeMockAptos("0x" + "b".repeat(64));
+
+    await Promise.all([
+      new Publisher({ adapter: makeMarkingAdapter(0xaa) }).deploy({
+        moduleName: "stomp_a",
+        config,
+        account,
+        packageDir: join(tmpCwd, "move"),
+        sdkPublish: true,
+        aptos: a.aptos,
+      }),
+      new Publisher({ adapter: makeMarkingAdapter(0xbb) }).deploy({
+        moduleName: "stomp_b",
+        config,
+        account,
+        packageDir: join(tmpCwd, "move"),
+        sdkPublish: true,
+        aptos: b.aptos,
+      }),
+    ]);
+
+    const publishedMetadata = (mock: ReturnType<typeof makeMockAptos>) => {
+      const args = mock.publishPackageTransaction.mock.calls[0]![0] as {
+        metadataBytes: Uint8Array;
+      };
+      return Array.from(args.metadataBytes);
+    };
+    expect(publishedMetadata(a)).toEqual([0xaa]);
+    expect(publishedMetadata(b)).toEqual([0xbb]);
+  });
+
+  it("concurrent same-module deploys publish exactly once; the loser throws ModuleAlreadyDeployedError", async () => {
+    const { config, account } = await initRuntime();
+    const a = makeMockAptos("0x" + "c".repeat(64));
+    const b = makeMockAptos("0x" + "d".repeat(64));
+
+    const results = await Promise.allSettled([
+      new Publisher({ adapter: makeMarkingAdapter(0xaa) }).deploy({
+        moduleName: "counter",
+        config,
+        account,
+        packageDir: join(tmpCwd, "move"),
+        sdkPublish: true,
+        aptos: a.aptos,
+      }),
+      new Publisher({ adapter: makeMarkingAdapter(0xbb) }).deploy({
+        moduleName: "counter",
+        config,
+        account,
+        packageDir: join(tmpCwd, "move"),
+        sdkPublish: true,
+        aptos: b.aptos,
+      }),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+      ModuleAlreadyDeployedError
+    );
+
+    const publishCount =
+      a.publishPackageTransaction.mock.calls.length +
+      b.publishPackageTransaction.mock.calls.length;
+    expect(publishCount).toBe(1);
+  });
+
+  it("redeploy: true bypasses the already-deployed check without touching the env", async () => {
+    const { config, account } = await initRuntime();
+    const { aptos } = makeMockAptos("0x" + "e".repeat(64));
+
+    mkdirSync(join(tmpCwd, "deployments", "testnet"), { recursive: true });
+    writeFileSync(
+      join(tmpCwd, "deployments", "testnet", "counter.json"),
+      JSON.stringify({
+        address: "0x1",
+        moduleName: "counter",
+        network: "testnet",
+        deployer: "0x1",
+        timestamp: 0,
+      })
+    );
+
+    const deployment = await new Publisher({ adapter: makeMarkingAdapter(0xaa) }).deploy({
+      moduleName: "counter",
+      config,
+      account,
+      packageDir: join(tmpCwd, "move"),
+      sdkPublish: true,
+      aptos,
+      redeploy: true,
+    });
+
+    expect(deployment.moduleName).toBe("counter");
+    expect(process.env.MH_CLI_REDEPLOY).toBeUndefined();
+  });
+
+  it("redeploy: false wins over MH_CLI_REDEPLOY=true", async () => {
+    const { config, account } = await initRuntime();
+    const { aptos, publishPackageTransaction } = makeMockAptos("0x" + "f".repeat(64));
+
+    mkdirSync(join(tmpCwd, "deployments", "testnet"), { recursive: true });
+    writeFileSync(
+      join(tmpCwd, "deployments", "testnet", "counter.json"),
+      JSON.stringify({
+        address: "0x1",
+        moduleName: "counter",
+        network: "testnet",
+        deployer: "0x1",
+        timestamp: 0,
+      })
+    );
+
+    process.env.MH_CLI_REDEPLOY = "true";
+    await expect(
+      new Publisher({ adapter: makeMarkingAdapter(0xaa) }).deploy({
+        moduleName: "counter",
+        config,
+        account,
+        packageDir: join(tmpCwd, "move"),
+        sdkPublish: true,
+        aptos,
+        redeploy: false,
+      })
+    ).rejects.toThrow(ModuleAlreadyDeployedError);
+    expect(publishPackageTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -1,6 +1,6 @@
 import { Account, Aptos, PrivateKey, PrivateKeyVariants } from "@aptos-labs/ts-sdk";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { MovehatConfig } from "../types/config.js";
 import { extractNamedAddresses } from "../commands/compile.js";
 import {
@@ -23,6 +23,7 @@ import {
   cleanupCallbacks,
 } from "./movementProfile.js";
 import { parseTxHash } from "../utils/parseCliOutput.js";
+import { withKeyedLock } from "../utils/keyedMutex.js";
 
 /** @internal */
 export interface PublisherDeps {
@@ -42,6 +43,12 @@ export interface PublishInput {
    */
   sdkPublish?: boolean | undefined;
   aptos?: Aptos | undefined;
+  /**
+   * Skip the already-deployed check and overwrite the deployment record.
+   * Falls back to `MH_CLI_REDEPLOY=true` (set by the CLI's --redeploy flag)
+   * when omitted.
+   */
+  redeploy?: boolean | undefined;
 }
 
 /**
@@ -57,7 +64,34 @@ export class Publisher {
 
     validateSafeName(moduleName, "module");
 
-    const forceRedeploy = process.env.MH_CLI_REDEPLOY === "true";
+    const dir = input.packageDir || config.moveDir;
+
+    // Validate (no shell escape — runCli uses spawn, which takes args
+    // verbatim and would treat the single-quote wrapping as part of the
+    // literal path, breaking Movement CLI argument parsing).
+    const safeDir = validatePathSafety(dir, "package directory");
+
+    // Serialize per package dir: the build step writes in-place to
+    // <safeDir>/build/ with the deployer address baked into the bytecode,
+    // and the SDK publish path reads those bytes back from disk — a
+    // concurrent deploy of the same package would publish bytecode
+    // compiled for the other deploy's address. Locking from the
+    // already-deployed check through saveDeployment also closes the
+    // check-then-publish TOCTOU for same-module deploys.
+    return withKeyedLock(resolve(safeDir), () =>
+      this.deployLocked(input, dir, safeDir),
+    );
+  }
+
+  private async deployLocked(
+    input: PublishInput,
+    dir: string,
+    safeDir: string,
+  ): Promise<DeploymentInfo> {
+    const { moduleName, config, account } = input;
+
+    const forceRedeploy =
+      input.redeploy ?? process.env.MH_CLI_REDEPLOY === "true";
 
     const existingDeployment = loadDeployment(config.network, moduleName);
     if (existingDeployment && !forceRedeploy) {
@@ -101,13 +135,6 @@ export class Publisher {
     if (forceRedeploy && existingDeployment) {
       logger.info(`Redeploying module "${moduleName}" on ${config.network}...`);
     }
-
-    const dir = input.packageDir || config.moveDir;
-
-    // Validate (no shell escape — runCli uses spawn, which takes args
-    // verbatim and would treat the single-quote wrapping as part of the
-    // literal path, breaking Movement CLI argument parsing).
-    const safeDir = validatePathSafety(dir, "package directory");
 
     logger.step(`Publishing module "${moduleName}" from ${dir}...`);
 

--- a/packages/movehat/src/core/Publisher.ts
+++ b/packages/movehat/src/core/Publisher.ts
@@ -60,7 +60,7 @@ export class Publisher {
   constructor(private readonly deps: PublisherDeps = {}) {}
 
   async deploy(input: PublishInput): Promise<DeploymentInfo> {
-    const { moduleName, config, account } = input;
+    const { moduleName, config } = input;
 
     validateSafeName(moduleName, "module");
 

--- a/packages/movehat/src/harness/codeObject.ts
+++ b/packages/movehat/src/harness/codeObject.ts
@@ -1,4 +1,5 @@
 import { PrivateKey, PrivateKeyVariants } from "@aptos-labs/ts-sdk";
+import { resolve } from "node:path";
 import type { MovehatRuntime } from "../types/runtime.js";
 import type {
   DeployCodeObjectOptions,
@@ -28,13 +29,14 @@ import {
   ensureSignalHandler,
   cleanupCallbacks,
 } from "../core/movementProfile.js";
+import { withKeyedLock } from "../utils/keyedMutex.js";
 
 /**
  * Deploy a Move package as a code object via `movement move deploy-object`.
  *
  * Mirrors `core/Publisher.deploy` exactly for the security-critical parts
- * (per-deploy unique profile, atomic ~/.aptos/config.yaml mutation under
- * the shared mutex, SIGINT-safe sync cleanup, stderr redaction via
+ * (per-deploy unique temp key file, per-package-dir deploy lock shared
+ * with the Publisher, SIGINT-safe sync cleanup, stderr redaction via
  * `runCli`). The only differences are:
  *
  *   1. CLI subcommand: `deploy-object` instead of `publish` + a required
@@ -60,6 +62,7 @@ export async function deployCodeObject(
     subcommand: "deploy-object",
     extraArgs: [],
     checkIdempotency: true,
+    redeploy: options.redeploy,
   });
 }
 
@@ -114,6 +117,11 @@ interface ExecuteOptions {
   /** Whether to throw `ModuleAlreadyDeployedError` if a record exists. */
   checkIdempotency: boolean;
   /**
+   * Skip the already-deployed check and overwrite the deployment record.
+   * Falls back to `MH_CLI_REDEPLOY=true` when omitted.
+   */
+  redeploy?: boolean | undefined;
+  /**
    * For upgrade-object: the object's existing address. Skips the parse-
    * from-stdout step (the address is known up front).
    */
@@ -123,15 +131,37 @@ interface ExecuteOptions {
 async function executeMovementMoveObject(
   opts: ExecuteOptions
 ): Promise<CodeObjectInfo> {
+  const { runtime, moduleName } = opts;
+  const config = runtime.config;
+
+  validateSafeName(moduleName, "module");
+
+  const dir = opts.packageDir || config.moveDir;
+  const safeDir = validatePathSafety(dir, "package directory");
+
+  // Serialize per package dir, sharing the Publisher's lock map: both
+  // write paths build in-place into <safeDir>/build/, so a concurrent
+  // deploy of the same package (through either path) could publish
+  // bytecode compiled for the other deploy's address. Upgrade builds
+  // too, so it takes the lock as well.
+  return withKeyedLock(resolve(safeDir), () =>
+    executeMovementMoveObjectLocked(opts, dir, safeDir),
+  );
+}
+
+async function executeMovementMoveObjectLocked(
+  opts: ExecuteOptions,
+  dir: string,
+  safeDir: string,
+): Promise<CodeObjectInfo> {
   const { runtime, moduleName, subcommand } = opts;
   const config = runtime.config;
   const account = runtime.account;
 
-  validateSafeName(moduleName, "module");
-
   // Idempotency: deploy-object refuses re-deploy unless MH_CLI_REDEPLOY=true.
   // Upgrade does not check this (the whole point is to overwrite).
-  const forceRedeploy = process.env.MH_CLI_REDEPLOY === "true";
+  const forceRedeploy =
+    opts.redeploy ?? process.env.MH_CLI_REDEPLOY === "true";
   if (opts.checkIdempotency) {
     const existing = loadDeployment(config.network, moduleName);
     if (existing && !forceRedeploy) {
@@ -165,9 +195,6 @@ async function executeMovementMoveObject(
       );
     }
   }
-
-  const dir = opts.packageDir || config.moveDir;
-  const safeDir = validatePathSafety(dir, "package directory");
 
   logger.step(
     `${subcommand === "deploy-object" ? "Deploying" : "Upgrading"} module "${moduleName}" from ${dir}...`

--- a/packages/movehat/src/helpers/setupLocalTesting.ts
+++ b/packages/movehat/src/helpers/setupLocalTesting.ts
@@ -252,30 +252,19 @@ async function setupWithLocalNode(
     if (options.autoDeploy && options.autoDeploy.length > 0) {
       logger.step(`Auto-deploying ${options.autoDeploy.length} module(s)...`);
 
-      const previousRedeploy = process.env.MH_CLI_REDEPLOY;
-      process.env.MH_CLI_REDEPLOY = 'true';
-
       // movelite's REST responses can't drive the Movement CLI publish flow,
       // so deploy through the TypeScript SDK when it is the spawned backend.
       const sdkPublish = isMovelite;
 
-      try {
-        for (const moduleName of options.autoDeploy) {
-          try {
-            logger.plain(`   Deploying ${moduleName}...`);
-            await runtime.deployContract(moduleName, { sdkPublish });
-            logger.success(`${moduleName} deployed`, 2);
-          } catch (error) {
-            const msg = error instanceof Error ? error.message : String(error);
-            logger.error(`Failed to deploy ${moduleName}: ${msg}`, 2);
-            throw error;
-          }
-        }
-      } finally {
-        if (previousRedeploy === undefined) {
-          delete process.env.MH_CLI_REDEPLOY;
-        } else {
-          process.env.MH_CLI_REDEPLOY = previousRedeploy;
+      for (const moduleName of options.autoDeploy) {
+        try {
+          logger.plain(`   Deploying ${moduleName}...`);
+          await runtime.deployContract(moduleName, { sdkPublish, redeploy: true });
+          logger.success(`${moduleName} deployed`, 2);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          logger.error(`Failed to deploy ${moduleName}: ${msg}`, 2);
+          throw error;
         }
       }
 

--- a/packages/movehat/src/runtime.ts
+++ b/packages/movehat/src/runtime.ts
@@ -115,6 +115,7 @@ export async function initRuntime(
       packageDir?: string;
       adapter?: ChildProcessAdapter;
       sdkPublish?: boolean;
+      redeploy?: boolean;
     }
   ): Promise<DeploymentInfo> => {
     // Thin orchestrator; the actual logic lives in core/Publisher.ts.
@@ -124,6 +125,7 @@ export async function initRuntime(
       account,
       packageDir: options?.packageDir,
       sdkPublish: options?.sdkPublish,
+      redeploy: options?.redeploy,
       aptos,
     });
   };

--- a/packages/movehat/src/templates/types/movehat.d.ts
+++ b/packages/movehat/src/templates/types/movehat.d.ts
@@ -42,6 +42,7 @@ declare module 'movehat' {
       moduleName: string,
       options?: {
         packageDir?: string;
+        redeploy?: boolean;
       }
     ) => Promise<DeploymentInfo>;
     getDeployment: (moduleName: string) => DeploymentInfo | null;

--- a/packages/movehat/src/types/harness.ts
+++ b/packages/movehat/src/types/harness.ts
@@ -64,6 +64,13 @@ export interface DeployCodeObjectOptions {
   includedArtifacts?: "none" | "sparse" | "all";
 
   /**
+   * Skip the already-deployed check and overwrite the deployment record.
+   * Falls back to the `MH_CLI_REDEPLOY=true` environment variable when
+   * omitted.
+   */
+  redeploy?: boolean;
+
+  /**
    * Test-only override for the child-process adapter. Production callers
    * leave this undefined so the default spawn-based adapter is used.
    * @internal

--- a/packages/movehat/src/types/harness.ts
+++ b/packages/movehat/src/types/harness.ts
@@ -85,7 +85,8 @@ export interface DeployCodeObjectOptions {
  * on-chain at `objectAddress` and have been deployed previously (typically
  * via `deployCodeObject`).
  */
-export interface UpgradeCodeObjectOptions extends DeployCodeObjectOptions {
+export interface UpgradeCodeObjectOptions
+  extends Omit<DeployCodeObjectOptions, "redeploy"> {
   /** Address of the existing code object to upgrade. Required. */
   objectAddress: string;
 }

--- a/packages/movehat/src/types/runtime.ts
+++ b/packages/movehat/src/types/runtime.ts
@@ -53,6 +53,12 @@ export interface MovehatRuntime {
        * is movelite, whose REST responses the Movement CLI cannot consume.
        */
       sdkPublish?: boolean;
+      /**
+       * Skip the already-deployed check and overwrite the deployment
+       * record. Falls back to the `MH_CLI_REDEPLOY=true` environment
+       * variable (set by the CLI's --redeploy flag) when omitted.
+       */
+      redeploy?: boolean;
     }
   ) => Promise<DeploymentInfo>;
   getDeployment: (moduleName: string) => DeploymentInfo | null;

--- a/packages/movehat/src/utils/__tests__/keyedMutex.test.ts
+++ b/packages/movehat/src/utils/__tests__/keyedMutex.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { withKeyedLock } from "../keyedMutex.js";
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("withKeyedLock", () => {
+  it("serializes same-key calls in FIFO order", async () => {
+    const events: string[] = [];
+    const gate = deferred();
+
+    const first = withKeyedLock("k", async () => {
+      events.push("first:start");
+      await gate.promise;
+      events.push("first:end");
+    });
+    const second = withKeyedLock("k", async () => {
+      events.push("second:start");
+      events.push("second:end");
+    });
+
+    // Give the second call every chance to start early if the lock leaked.
+    await new Promise((res) => setImmediate(res));
+    expect(events).toEqual(["first:start"]);
+
+    gate.resolve();
+    await Promise.all([first, second]);
+    expect(events).toEqual([
+      "first:start",
+      "first:end",
+      "second:start",
+      "second:end",
+    ]);
+  });
+
+  it("rejection reaches its own caller and does not block the next waiter", async () => {
+    const boom = new Error("boom");
+    const first = withKeyedLock("k", async () => {
+      throw boom;
+    });
+    const second = withKeyedLock("k", async () => "ok");
+
+    await expect(first).rejects.toBe(boom);
+    await expect(second).resolves.toBe("ok");
+  });
+
+  it("distinct keys run concurrently", async () => {
+    const gateA = deferred();
+    let aStarted = false;
+
+    const a = withKeyedLock("a", async () => {
+      aStarted = true;
+      await gateA.promise;
+    });
+    const b = withKeyedLock("b", async () => "b-done");
+
+    await expect(b).resolves.toBe("b-done");
+    expect(aStarted).toBe(true);
+
+    gateA.resolve();
+    await a;
+  });
+
+  it("releases the key once all waiters settle", async () => {
+    await withKeyedLock("k", async () => {});
+
+    // With the entry cleaned up, a fresh call must run immediately rather
+    // than chain behind a stale settled tail.
+    let ran = false;
+    await withKeyedLock("k", async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+
+  it("returns fn's resolved value", async () => {
+    await expect(withKeyedLock("k", async () => 42)).resolves.toBe(42);
+  });
+});

--- a/packages/movehat/src/utils/keyedMutex.ts
+++ b/packages/movehat/src/utils/keyedMutex.ts
@@ -1,0 +1,29 @@
+const tails = new Map<string, Promise<void>>();
+
+/**
+ * Runs `fn` under an in-process FIFO lock scoped to `key`. Calls with the
+ * same key execute one at a time in arrival order; calls with different
+ * keys run concurrently. A rejected `fn` rejects only its own caller — the
+ * next waiter on the key still runs.
+ *
+ * Non-reentrant: calling `withKeyedLock` with the same key from inside `fn`
+ * deadlocks. In-process only: it cannot serialize against other processes
+ * touching the same on-disk state.
+ *
+ * @internal
+ */
+export function withKeyedLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = tails.get(key) ?? Promise.resolve();
+  const result = prev.then(() => fn());
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  tails.set(key, tail);
+  void tail.finally(() => {
+    if (tails.get(key) === tail) {
+      tails.delete(key);
+    }
+  });
+  return result;
+}


### PR DESCRIPTION
## Summary

Closes the three in-process deploy races that become reachable once fixtures share a node implicitly (#341 sub-PR 3):

1. **build/ stomp**: `movement move build` writes in-place to `<packageDir>/build/` with the deployer address baked into the bytecode, and the SDK publish path (movelite) reads those bytes back from disk non-atomically — two overlapping same-package deploys could publish bytecode compiled for the other deploy's address.
2. **Idempotency TOCTOU**: two concurrent same-module deploys both passed the already-deployed check and double-published.
3. **MH_CLI_REDEPLOY env mutation**: the autoDeploy loop's set/restore of the process-global env var could strand it as `true` when fixtures interleave.

Fix: new internal `withKeyedLock` utility (`src/utils/keyedMutex.ts`, FIFO promise-tail chain per key); both write paths (`Publisher.deploy`, `codeObject.executeMovementMoveObject` — shared lock map, so they serialize against each other) wrap idempotency check + build + publish + record under the lock, keyed by `resolve(packageDir)`. The autoDeploy loop passes an explicit `redeploy: true` option threaded through `deployContract` → `Publisher.deploy` / `deployCodeObject`; the env var stays honored as a fallback for the CLI's `--redeploy` flag.

Documented limits (in the utility docstring): in-process only (two mocha processes can still stomp); same moduleName from two different packageDirs stays last-writer-wins on the record (user error).

## Tests

- `keyedMutex.test.ts` (new, 5 tests): FIFO per key, rejection isolation, distinct keys run concurrently, entry cleanup, return value.
- `deployContract.test.ts` (+4): build-stomp regression (concurrent same-dir deploys each publish their own marker artifacts), idempotency TOCTOU (exactly one publish, loser throws `ModuleAlreadyDeployedError`), `redeploy: true` bypass without env, `redeploy: false` wins over env.
- **Mutation-verified**: with `withKeyedLock` replaced by a pass-through, both regression tests fail; restored, 630/630 green.

## Tier 1 / Tier 2 (§6.2)

- [x] Unit suite: 630/630 passing (was 621; +9 new)
- [x] Tier 1 `pnpm check:example`: exit 0
- [x] `pnpm test:example`: 9 passing (15s)
- [x] `pnpm test:smoke`: exit 0
- [x] `MOVEHAT_EXPECT_BACKEND=movelite pnpm assert-backend`: passed (boot 5602ms)
- [x] `MOVEHAT_EXPECT_BACKEND=movement-node pnpm assert-backend`: passed (boot 24535ms)
- `pnpm test:e2e:quick`: N/A — no changes under `templates/scripts/**`
- §9 grep: 15 matches before and after (all pre-existing; zero new)

Closes #359. Tracks #341.